### PR TITLE
Self-registration - email related methods moved from SelfRegistration to User

### DIFF
--- a/skyve-ee/src/generated/modules/admin/domain/Configuration.java
+++ b/skyve-ee/src/generated/modules/admin/domain/Configuration.java
@@ -861,6 +861,26 @@ public abstract class Configuration extends AbstractPersistentBean {
 	}
 
 	/**
+	 * selfRegistrationConfiguredEmailOrGroupNotConfigured
+	 *
+	 * @return The condition
+	 */
+	@XmlTransient
+	public boolean isSelfRegistrationConfiguredEmailOrGroupNotConfigured() {
+		return (startup.getAccountAllowUserSelfRegistration().equals(Boolean.TRUE) &&
+					(!modules.admin.Configuration.ConfigurationExtension.validSMTPHost() || userSelfRegistrationGroup == null));
+	}
+
+	/**
+	 * {@link #isSelfRegistrationConfiguredEmailOrGroupNotConfigured} negation.
+	 *
+	 * @return The negated condition
+	 */
+	public boolean isNotSelfRegistrationConfiguredEmailOrGroupNotConfigured() {
+		return (! isSelfRegistrationConfiguredEmailOrGroupNotConfigured());
+	}
+
+	/**
 	 * True when this application has a default customer specified (is single tenant)
 	 *
 	 * @return The condition

--- a/skyve-ee/src/generated/modules/admin/domain/User.java
+++ b/skyve-ee/src/generated/modules/admin/domain/User.java
@@ -112,6 +112,8 @@ public abstract class User extends AbstractPersistentBean {
 	public static final String activationCodePropertyName = "activationCode";
 	/** @hidden */
 	public static final String activationCodeCreationDateTimePropertyName = "activationCodeCreationDateTime";
+	/** @hidden */
+	public static final String activateUrlPropertyName = "activateUrl";
 
 	/**
 	 * Wizard State
@@ -468,6 +470,10 @@ public abstract class User extends AbstractPersistentBean {
 	 * admin.user.activationCodeCreationDateTime.description
 	 **/
 	private DateTime activationCodeCreationDateTime;
+	/**
+	 * Activation Url
+	 **/
+	private String activateUrl;
 
 	@Override
 	@XmlTransient
@@ -1255,6 +1261,23 @@ return modules.admin.User.UserBizlet.bizKey(this);
 	}
 
 	/**
+	 * {@link #activateUrl} accessor.
+	 * @return	The value.
+	 **/
+	public String getActivateUrl() {
+		return activateUrl;
+	}
+
+	/**
+	 * {@link #activateUrl} mutator.
+	 * @param activateUrl	The new value.
+	 **/
+	@XmlElement
+	public void setActivateUrl(String activateUrl) {
+		this.activateUrl = activateUrl;
+	}
+
+	/**
 	 * Allows administrators to manually activate users when User Self-Registration is enabled.
 	 *
 	 * @return The condition
@@ -1463,6 +1486,25 @@ return modules.admin.User.UserBizlet.bizKey(this);
 	 */
 	public boolean isNotSelfRegistrationEnabled() {
 		return (! isSelfRegistrationEnabled());
+	}
+
+	/**
+	 * True when User Self-Registration is enabled and the User has not been activated.
+	 *
+	 * @return The condition
+	 */
+	@XmlTransient
+	public boolean isSelfRegistrationEnabledAndUserNotActivated() {
+		return ((org.skyve.impl.util.UtilImpl.ACCOUNT_ALLOW_SELF_REGISTRATION && (getActivated().equals(Boolean.FALSE))));
+	}
+
+	/**
+	 * {@link #isSelfRegistrationEnabledAndUserNotActivated} negation.
+	 *
+	 * @return The negated condition
+	 */
+	public boolean isNotSelfRegistrationEnabledAndUserNotActivated() {
+		return (! isSelfRegistrationEnabledAndUserNotActivated());
 	}
 
 	/**

--- a/skyve-ee/src/generatedTest/modules/admin/User/actions/ResendActivationTest.java
+++ b/skyve-ee/src/generatedTest/modules/admin/User/actions/ResendActivationTest.java
@@ -1,0 +1,26 @@
+package modules.admin.User.actions;
+
+import modules.admin.User.UserExtension;
+import modules.admin.domain.User;
+import org.skyve.util.DataBuilder;
+import org.skyve.util.test.SkyveFixture.FixtureType;
+import util.AbstractActionTest;
+
+/**
+ * Generated - local changes will be overwritten.
+ * Extend {@link AbstractActionTest} to create your own tests for this action.
+ */
+public class ResendActivationTest extends AbstractActionTest<UserExtension, ResendActivation> {
+
+	@Override
+	protected ResendActivation getAction() {
+		return new ResendActivation();
+	}
+
+	@Override
+	protected UserExtension getBean() throws Exception {
+		return new DataBuilder()
+			.fixture(FixtureType.crud)
+			.build(User.MODULE_NAME, User.DOCUMENT_NAME);
+	}
+}

--- a/skyve-ee/src/skyve/modules/admin/Configuration/Configuration.xml
+++ b/skyve-ee/src/skyve/modules/admin/Configuration/Configuration.xml
@@ -145,6 +145,14 @@
 				]]>
 			</expression>
 		</condition>	
+		<condition name="selfRegistrationConfiguredEmailOrGroupNotConfigured">
+			<expression>
+				<![CDATA[
+					startup.getAccountAllowUserSelfRegistration().equals(Boolean.TRUE) &&
+					(!modules.admin.Configuration.ConfigurationExtension.validSMTPHost() || userSelfRegistrationGroup == null)
+				]]>
+			</expression>
+		</condition>
 		<condition name="backupsConfigured">
 			<expression>
 				<![CDATA[

--- a/skyve-ee/src/skyve/modules/admin/Configuration/views/_selfRegistrationNotConfiguredBanner.xml
+++ b/skyve-ee/src/skyve/modules/admin/Configuration/views/_selfRegistrationNotConfiguredBanner.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<view name="_selfRegistrationNotConfiguredBanner" title="Configuration" xmlns="http://www.skyve.org/xml/view" 
+	xsi:schemaLocation="http://www.skyve.org/xml/view ../../../../schemas/view.xsd"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<vbox visible="selfRegistrationConfiguredEmailOrGroupNotConfigured" shrinkWrap="height">
+		<form>
+			<column />
+			<row>
+				<item align="centre">
+					<blurb>
+						<![CDATA[
+							<div style="margin-bottom: 0;" class="ui-messages ui-widget" aria-live="polite">
+								<div style="margin: 0;" class="ui-messages-info ui-corner-all">
+									<span class="ui-messages-warn-icon"></span>
+									<ul>
+										<li role="alert" aria-atomic="true">
+											<span class="ui-messages-warn-detail">
+												Self-registration has been enabled - please ensure that email is configured and a self-registration group is chosen
+											</span>
+										</li>
+									</ul>
+								</div>
+							</div>				
+						]]>
+					</blurb>
+				</item>
+			</row>
+		</form>		
+	</vbox>
+</view>

--- a/skyve-ee/src/skyve/modules/admin/Configuration/views/_tabGeneral.xml
+++ b/skyve-ee/src/skyve/modules/admin/Configuration/views/_tabGeneral.xml
@@ -5,6 +5,7 @@
 	
 	<component name="_emailNotConfiguredBanner" />
 	<component name="_backupsNotConfiguredBanner" />
+	<component name="_selfRegistrationNotConfiguredBanner" />
 	
 	<form border="true" borderTitle="admin.configuration.tabGeneral.passwordComplexity.borderTitle">
 		<column responsiveWidth="3" />

--- a/skyve-ee/src/skyve/modules/admin/SelfRegistration/SelfRegistrationExtension.java
+++ b/skyve-ee/src/skyve/modules/admin/SelfRegistration/SelfRegistrationExtension.java
@@ -1,88 +1,22 @@
 package modules.admin.SelfRegistration;
 
-import java.util.UUID;
-
 import org.apache.commons.lang3.StringUtils;
-import org.skyve.domain.Bean;
 import org.skyve.domain.messages.Message;
 import org.skyve.domain.messages.ValidationException;
-import org.skyve.domain.types.DateTime;
-import org.skyve.metadata.customer.Customer;
-import org.skyve.metadata.model.document.Document;
-import org.skyve.metadata.model.document.Relation;
-import org.skyve.metadata.module.Module;
-import org.skyve.persistence.Persistence;
-import org.skyve.util.BeanVisitor;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
 
-import modules.admin.Communication.CommunicationUtil;
-import modules.admin.Communication.CommunicationUtil.ResponseMode;
 import modules.admin.Configuration.ConfigurationExtension;
-import modules.admin.User.UserExtension;
 import modules.admin.domain.Configuration;
-import modules.admin.domain.Contact;
 import modules.admin.domain.SelfRegistration;
-import modules.admin.domain.SelfRegistrationActivation;
 import modules.admin.domain.User;
 
 public class SelfRegistrationExtension extends SelfRegistration {
 
 	private static final long serialVersionUID = 4437526012340020305L;
 
-	public static final String SELF_REGISTRATION_COMMUNICATION = "SYSTEM Self Registration";
-	public static final String SELF_REGISTRATION_SUBJECT = "Activate your account";
-	public static final String SELF_REGISTRATION_HEADING = "Welcome!";
-	public static final String SELF_REGISTRATION_BODY = String.format("<p>Hi <b>{%1$s}</b>,</p><br/>"
-			+ "<p>Thank you for registering.</p>"
-			+ "<p>To complete your account setup, please click the activation link below.</p>"
-			+ "<p><a href=\"{%2$s}\">{%2$s}</a></p>"
-			+ "<p>If you have any questions about your new account, contact us at <a href=\"mailto:%3$s\">%3$s</a>.</p>",
-			Binder.createCompoundBinding(SelfRegistration.userPropertyName, User.contactPropertyName, Contact.namePropertyName),
-			SelfRegistration.activateUrlPropertyName,
-			Util.getSupportEmailAddress());
-
 	static final String CONFIRM_PASSWORD_REQUIRED = "Confirm Password is required.";
 	static final String PASSWORD_MISMATCH = "You did not type the same password.  Please re-enter the password again.";
 	static final String PASSWORD_REQUIRED = "Password is required.";
-
-	/**
-	 * Generates the activation link for the email to send to the new user with the activation code.
-	 */
-	public void generateActivationLink() {
-		StringBuilder urlBuilder = new StringBuilder();
-		urlBuilder.append(Util.getDocumentUrl(SelfRegistrationActivation.MODULE_NAME, SelfRegistrationActivation.DOCUMENT_NAME))
-				.append("&code=")
-				.append(this.getUser().getActivationCode());
-		setActivateUrl(urlBuilder.toString());
-	}
-
-	@Override
-	public String getLoginUrl() {
-		return Util.getSkyveContextUrl() + "/login";
-	}
-
-	@Override
-	public String getLoginMessage() {
-		return String.format("If you are an existing user, please <a href=\"%s\">Log in</a>", getLoginUrl());
-	}
-
-	/**
-	 * Sends the activation email to the user who registered.
-	 * 
-	 * @throws Exception
-	 */
-	public void sendUserRegistrationEmail() throws Exception {
-		Util.LOGGER.info("Sending registration email to " + this.getUser().getContact().getEmail1());
-		CommunicationUtil.sendFailSafeSystemCommunication(SELF_REGISTRATION_COMMUNICATION,
-				this.getUser().getContact().getEmail1(),
-				null,
-				SELF_REGISTRATION_SUBJECT,
-				SELF_REGISTRATION_BODY,
-				ResponseMode.EXPLICIT,
-				null,
-				this);
-	}
 
 	/**
 	 * Validates that the password and confirmPassword entered during a SelfRegistration
@@ -134,72 +68,4 @@ public class SelfRegistrationExtension extends SelfRegistration {
 		}
 	}
 
-	/**
-	 * Generates the activation code and link for this new user and upserts them
-	 * into the datastore.
-	 */
-	public void generateActivationDetailsAndSave(final Persistence persistence) {
-		// Set activation details
-		getUser().setActivated(Boolean.FALSE);
-		getUser().setActivationCode(UUID.randomUUID().toString());
-		getUser().setActivationCodeCreationDateTime(new DateTime());
-
-		getUser().setBizUserId(getBizId());
-
-		// Save and set the user
-		setUser(upsertUser(persistence, getUser()));
-
-		// Generate link used for activation
-		generateActivationLink();
-	}
-
-	/**
-	 * Upsert the user into the database.
-	 * <br />
-	 * NOTE: We upsert the user rather than regularly calling {@link Persistence#save(org.skyve.domain.PersistentBean)} because
-	 * calling save will automatically set the bizUserId to be the current logged in user.
-	 * <br />
-	 * When registering, we want the User we are just about to create to own the documents.
-	 * 
-	 * @param persistence skyve persistence to save the bean
-	 * @param bean the user bean to register
-	 * @return the saved user bean
-	 */
-	private UserExtension upsertUser(Persistence persistence, UserExtension bean) {
-		persistence.begin();
-
-		// update bizuser id on User and related objects
-		org.skyve.metadata.user.User u = persistence.getUser();
-		Customer c = u.getCustomer();
-		Module am = c.getModule(bean.getBizModule());
-		Document ad = am.getDocument(c, bean.getBizDocument());
-		new UpdateBizUserVisitor(bean.getBizId()).visit(ad, bean, c);
-
-		// upsert Contact, User and Roles
-		persistence.upsertBeanTuple(bean.getContact());
-		persistence.upsertBeanTuple(bean);
-		persistence.upsertCollectionTuples(bean, User.groupsPropertyName);
-
-		persistence.commit(false);
-		return bean;
-	}
-
-	/**
-	 * Visitor to update all beans related to a document to have a given owning bizUserId
-	 */
-	private class UpdateBizUserVisitor extends BeanVisitor {
-
-		private String bizUserId;
-
-		public UpdateBizUserVisitor(String bizUserId) {
-			super(false, false, false);
-			this.bizUserId = bizUserId;
-		}
-
-		@Override
-		protected boolean accept(String binding, Document document, Document owningDocument, Relation owningRelation, Bean bean) {
-			bean.setBizUserId(bizUserId);
-			return true;
-		}
-	}
 }

--- a/skyve-ee/src/skyve/modules/admin/SelfRegistration/actions/Register.java
+++ b/skyve-ee/src/skyve/modules/admin/SelfRegistration/actions/Register.java
@@ -72,8 +72,8 @@ public class Register implements ServerSideAction<SelfRegistrationExtension> {
 					throw e;
 				}
 
-				// geneate the activation code and save the new user
-				bean.generateActivationDetailsAndSave(persistence);
+				// generate the activation code and save the new user
+				bean.getUser().generateActivationDetailsAndSave(persistence);
 
 				// Send registration email to the new user
 				sendRegistrationEmail(bean);
@@ -97,7 +97,7 @@ public class Register implements ServerSideAction<SelfRegistrationExtension> {
 		try {
 			// Send the registration email
 			CORE.getPersistence().begin();
-			bean.sendUserRegistrationEmail();
+			bean.getUser().sendUserRegistrationEmail();
 			CORE.getPersistence().commit(false);
 		} catch (Exception e) {
 			LOGGER.warn("Self Registration successful but email failed to send.", e);

--- a/skyve-ee/src/skyve/modules/admin/SelfRegistration/actions/ResendActivation.java
+++ b/skyve-ee/src/skyve/modules/admin/SelfRegistration/actions/ResendActivation.java
@@ -33,9 +33,9 @@ public class ResendActivation implements ServerSideAction<SelfRegistrationExtens
 			}
 
 			// Set activation details
-			bean.generateActivationDetailsAndSave(CORE.getPersistence());
+			bean.getUser().generateActivationDetailsAndSave(CORE.getPersistence());
 
-			bean.sendUserRegistrationEmail();
+			bean.getUser().sendUserRegistrationEmail();
 		}
 
 		return new ServerSideActionResult<>(bean);

--- a/skyve-ee/src/skyve/modules/admin/User/User.xml
+++ b/skyve-ee/src/skyve/modules/admin/User/User.xml
@@ -216,6 +216,11 @@
 			<displayName>admin.user.activationCodeCreationDateTime.displayName</displayName>
 			<description>admin.user.activationCodeCreationDateTime.description</description>
 		</dateTime>
+		<!-- needs i18n properties -->
+		<text name="activateUrl" persistent="false" audited="false" trackChanges="false">
+            <displayName>Activation Url</displayName>
+            <length>2083</length>
+        </text>
 		
 	</attributes>
 	<conditions>
@@ -294,6 +299,12 @@
 			<description>True when User Self-Registration is enabled.</description>
 			<expression>
 				<![CDATA[org.skyve.impl.util.UtilImpl.ACCOUNT_ALLOW_SELF_REGISTRATION]]>
+			</expression>
+		</condition>
+		<condition name="selfRegistrationEnabledAndUserNotActivated" usage="view">
+			<description>True when User Self-Registration is enabled and the User has not been activated.</description>
+			<expression>
+				<![CDATA[(org.skyve.impl.util.UtilImpl.ACCOUNT_ALLOW_SELF_REGISTRATION && (getActivated().equals(Boolean.FALSE)))]]>
 			</expression>
 		</condition>
 		<condition name="canActivateUser" usage="view">

--- a/skyve-ee/src/skyve/modules/admin/User/UserExtension.java
+++ b/skyve-ee/src/skyve/modules/admin/User/UserExtension.java
@@ -1,17 +1,31 @@
 package modules.admin.User;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.skyve.CORE;
+import org.skyve.domain.Bean;
+import org.skyve.domain.types.DateTime;
 import org.skyve.impl.metadata.repository.AbstractRepository;
 import org.skyve.impl.metadata.user.UserImpl;
 import org.skyve.impl.persistence.hibernate.AbstractHibernatePersistence;
 import org.skyve.impl.util.SQLMetaDataUtil;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.customer.Customer;
+import org.skyve.metadata.model.document.Document;
+import org.skyve.metadata.model.document.Relation;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.Role;
+import org.skyve.persistence.Persistence;
+import org.skyve.util.BeanVisitor;
+import org.skyve.util.Binder;
+import org.skyve.util.Util;
 
+import modules.admin.Communication.CommunicationUtil;
+import modules.admin.Communication.CommunicationUtil.ResponseMode;
+import modules.admin.domain.Contact;
+import modules.admin.domain.SelfRegistration;
+import modules.admin.domain.SelfRegistrationActivation;
 import modules.admin.domain.User;
 import modules.admin.domain.UserRole;
 
@@ -20,6 +34,19 @@ public class UserExtension extends User {
 
 	private boolean determinedRoles = false;
 
+	public static final String SELF_REGISTRATION_COMMUNICATION = "SYSTEM Self Registration";
+	public static final String SELF_REGISTRATION_SUBJECT = "Activate your account";
+	public static final String SELF_REGISTRATION_HEADING = "Welcome!";
+	public static final String SELF_REGISTRATION_BODY = String.format("<p>Hi <b>{%1$s}</b>,</p><br/>"
+			+ "<p>Thank you for registering.</p>"
+			+ "<p>To complete your account setup, please click the activation link below.</p>"
+			+ "<p><a href=\"{%2$s}\">{%2$s}</a></p>"
+			+ "<p>If you have any questions about your new account, contact us at <a href=\"mailto:%3$s\">%3$s</a>.</p>",
+			Binder.createCompoundBinding(User.contactPropertyName, Contact.namePropertyName),
+			activateUrlPropertyName,
+			Util.getSupportEmailAddress());
+
+	
 	@Override
 	public List<UserRole> getAssignedRoles() {
 		List<UserRole> assignedRoles = super.getAssignedRoles();
@@ -75,5 +102,102 @@ public class UserExtension extends User {
 		
 		return metaDataUser;
 	}
+	
+	/**
+	 * Generates the activation code and link for this new user and upserts them
+	 * into the datastore.
+	 */
+	public void generateActivationDetailsAndSave(final Persistence persistence) {
+		// Set activation details
+		this.setActivated(Boolean.FALSE);
+		this.setActivationCode(UUID.randomUUID().toString());
+		this.setActivationCodeCreationDateTime(new DateTime());
 
+		this.setBizUserId(getBizId());
+		
+		// Save and set the user
+		this.upsertUser(persistence, this);
+		
+		// Generate link used for activation
+		generateActivationLink();
+	}
+	
+	/**
+	 * Generates the activation link for the email to send to the new user with the activation code.
+	 */
+	public void generateActivationLink() {
+		StringBuilder urlBuilder = new StringBuilder();
+		urlBuilder.append(Util.getDocumentUrl(SelfRegistrationActivation.MODULE_NAME, SelfRegistrationActivation.DOCUMENT_NAME))
+				.append("&code=")
+				.append(this.getActivationCode());
+		this.setActivateUrl(urlBuilder.toString());
+	}
+	
+	/**
+	 * Sends the activation email to the user who registered.
+	 * 
+	 * @throws Exception
+	 */
+	public void sendUserRegistrationEmail() throws Exception {
+		Util.LOGGER.info("Sending registration email to " + this.getContact().getEmail1());
+		CommunicationUtil.sendFailSafeSystemCommunication(SELF_REGISTRATION_COMMUNICATION,
+				this.getContact().getEmail1(),
+				null,
+				SELF_REGISTRATION_SUBJECT,
+				SELF_REGISTRATION_BODY,
+				ResponseMode.EXPLICIT,
+				null,
+				this);
+	}
+
+	/**
+	 * Upsert the user into the database.
+	 * <br />
+	 * NOTE: We upsert the user rather than regularly calling {@link Persistence#save(org.skyve.domain.PersistentBean)} because
+	 * calling save will automatically set the bizUserId to be the current logged in user.
+	 * <br />
+	 * When registering, we want the User we are just about to create to own the documents.
+	 * 
+	 * @param persistence skyve persistence to save the bean
+	 * @param bean the user bean to register
+	 * @return the saved user bean
+	 */
+	private UserExtension upsertUser(Persistence persistence, UserExtension bean) {
+		persistence.begin();
+
+		// update bizuser id on User and related objects
+		org.skyve.metadata.user.User u = persistence.getUser();
+		Customer c = u.getCustomer();
+		Module am = c.getModule(bean.getBizModule());
+		Document ad = am.getDocument(c, bean.getBizDocument());
+		new UpdateBizUserVisitor(bean.getBizId()).visit(ad, bean, c);
+
+		// upsert Contact, User and Roles
+		persistence.upsertBeanTuple(bean.getContact());
+		persistence.upsertBeanTuple(bean);
+		persistence.upsertCollectionTuples(bean, User.groupsPropertyName);
+
+		persistence.commit(false);
+		return bean;
+	}
+	
+	/**
+	 * Visitor to update all beans related to a document to have a given owning bizUserId
+	 */
+	private class UpdateBizUserVisitor extends BeanVisitor {
+
+		private String bizUserId;
+
+		public UpdateBizUserVisitor(String bizUserId) {
+			super(false, false, false);
+			this.bizUserId = bizUserId;
+		}
+
+		@Override
+		protected boolean accept(String binding, Document document, Document owningDocument, Relation owningRelation, Bean bean) {
+			bean.setBizUserId(bizUserId);
+			return true;
+		}
+	}
+	
 }

--- a/skyve-ee/src/skyve/modules/admin/User/actions/ResendActivation.java
+++ b/skyve-ee/src/skyve/modules/admin/User/actions/ResendActivation.java
@@ -1,0 +1,42 @@
+package modules.admin.User.actions;
+
+import org.skyve.CORE;
+import org.skyve.metadata.controller.ServerSideAction;
+import org.skyve.metadata.controller.ServerSideActionResult;
+import org.skyve.web.WebContext;
+
+import modules.admin.User.UserExtension;
+import modules.admin.domain.User;
+
+/**
+ * Resends the registration email with the activation code to the user. Used when a user
+ * attempts to register an account which already exists but has not been activated.
+ */
+public class ResendActivation implements ServerSideAction<UserExtension> {
+
+	private static final long serialVersionUID = -1947122266718966646L;
+
+	@Override
+	public ServerSideActionResult<UserExtension> execute(UserExtension bean, WebContext webContext) throws Exception {
+
+		if (bean != null) {
+			if (bean.getContact() == null || bean.getContact().getName() == null) {
+//				 this came from a public page, retrieve the user
+				UserExtension user = CORE.getPersistence().retrieve(User.MODULE_NAME, User.DOCUMENT_NAME,
+						bean.getBizId());
+				
+//				if (user != null) {
+//					bean.setUser(user);
+//				}
+			}
+			
+			// Set activation details
+			bean.generateActivationDetailsAndSave(CORE.getPersistence());
+			
+			bean.sendUserRegistrationEmail();
+		}
+
+		return new ServerSideActionResult<>(bean);
+	}
+
+}

--- a/skyve-ee/src/skyve/modules/admin/User/views/edit.xml
+++ b/skyve-ee/src/skyve/modules/admin/User/views/edit.xml
@@ -36,7 +36,17 @@
 				</row>
 				<row>
 					<item>
-						<checkBox binding="activated" triState="false" enabled="canActivateUser" visible="selfRegistrationEnabled"/>
+						<checkBox binding="activated" triState="false" enabled="canActivateUser" visible="selfRegistrationEnabled">
+							<onChangedHandlers><rerender/></onChangedHandlers>
+						</checkBox>
+					</item>
+				</row>
+				<row>
+					<item>
+						<spacer/>
+					</item>
+					<item>
+						<button action="ResendActivation"/>
 					</item>
 				</row>
 			</form>
@@ -95,5 +105,6 @@
 		relativeIconFileName="shared/icons/Job.gif"/>
 		<action className="GeneratePassword" displayName="admin.user.actions.generatePassword.actionName" invisible="notSecurityAdministrator" 
 		relativeIconFileName="shared/icons/Job.gif"/>
+		<action className="ResendActivation" inActionPanel="false" visible="selfRegistrationEnabledAndUserNotActivated" displayName="Resend Activation"/>
 	</actions>
 </view>

--- a/skyve-ee/src/skyve/modules/admin/admin.xml
+++ b/skyve-ee/src/skyve/modules/admin/admin.xml
@@ -332,6 +332,7 @@
 					<action name="New" />
 					<action name="Next" />
 					<action name="Back" />
+					<action name="ResendActivation"/>
 				</document>
 				<document name="UserCandidateContact" permission="_____" />
 				<document name="UserList" permission="_____">


### PR DESCRIPTION
 - Security Admins can now resend activation emails from User
 - moved email related methods from SelfRegistrationExtension to
UserExtension
 - added warning banner to Configuration.edit view for when
self-registration is enabled but either emails are not configured or the
self-registration group is not set
 - added ActivationURL field to User
 - added 'Resend Activation' button to User.edit view with conditional
visibility on whether the account is activated or not