### PR TITLE
Change password add customer

### DIFF
--- a/skyve-core/src/main/java/org/skyve/util/Util.java
+++ b/skyve-core/src/main/java/org/skyve/util/Util.java
@@ -14,6 +14,7 @@ import org.skyve.CORE;
 import org.skyve.domain.Bean;
 import org.skyve.impl.persistence.AbstractPersistence;
 import org.skyve.impl.util.UtilImpl;
+import org.skyve.impl.web.AbstractWebContext;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
@@ -376,6 +377,16 @@ public class Util {
 
 	public static String getResourceUrl(String resourceFileName) {
 		return getResourceUrl(null, null, resourceFileName);
+	}
+	
+	public static String getResetPasswordUrl() {
+		StringBuilder result = new StringBuilder(128);
+		result.append(Util.getSkyveContextUrl())
+			  .append("/pages/resetPassword.jsp").append("?")
+			  .append("t={passwordResetToken}").append("&")
+			  .append(AbstractWebContext.CUSTOMER_COOKIE_NAME).append("={bizCustomer}");
+		
+		return result.toString();
 	}
 	
     /**

--- a/skyve-ejb/src/main/java/modules/admin/Configuration/ConfigurationBizlet.java
+++ b/skyve-ejb/src/main/java/modules/admin/Configuration/ConfigurationBizlet.java
@@ -3,6 +3,7 @@ package modules.admin.Configuration;
 import org.skyve.CORE;
 import org.skyve.domain.Bean;
 import org.skyve.impl.util.UtilImpl;
+import org.skyve.impl.web.AbstractWebContext;
 import org.skyve.metadata.controller.ImplicitActionName;
 import org.skyve.metadata.model.document.SingletonCachedBizlet;
 import org.skyve.metadata.user.DocumentPermissionScope;
@@ -50,10 +51,10 @@ public class ConfigurationBizlet extends SingletonCachedBizlet<ConfigurationExte
 		if (result.getPasswordResetEmailBody() == null) {
 			String body = String.format("<html><head/><body>Hi {%s},<p/>" +
 					"Please click below to reset your password.<p/>" +
-					"<a href=\"{url}/pages/resetPassword.jsp?t={%s}\">" +
+					"<a href=\"{#resetPasswordUrl}\">" +
 					"Reset Password</a></body></html>",
-					Binder.createCompoundBinding(User.contactPropertyName, Contact.namePropertyName),
-					User.passwordResetTokenPropertyName);
+					Binder.createCompoundBinding(User.contactPropertyName, Contact.namePropertyName)
+				);
 			result.setPasswordResetEmailBody(body);
 		}
 

--- a/skyve-ejb/src/main/java/modules/admin/UserList/UserListUtil.java
+++ b/skyve-ejb/src/main/java/modules/admin/UserList/UserListUtil.java
@@ -1,7 +1,6 @@
 package modules.admin.UserList;
 
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
 
 import modules.admin.domain.Contact;
 import modules.admin.domain.User;
@@ -12,10 +11,9 @@ public class UserListUtil {
 	public static final String SYSTEM_USER_INVITATION_DEFAULT_SUBJECT = "Invitation to join";
 	public static final String SYSTEM_USER_INVITATION_DEFAULT_BODY = String.format("Hi {%s}, a user account has been created for you.<br /><br />" +
 			"Please click below to reset your password.<br />" +
-			"<a href=\"%s/pages/resetPassword.jsp?t={%s}\">Reset Password</a>",
-			Binder.createCompoundBinding(User.contactPropertyName, Contact.namePropertyName),
-			Util.getSkyveContextUrl(),
-			User.passwordResetTokenPropertyName);
+			"<a href=\"{#resetPasswordUrl}\">Reset Password</a>",
+			Binder.createCompoundBinding(User.contactPropertyName, Contact.namePropertyName)
+		);
 	
 	
 

--- a/skyve-ext/src/main/java/org/skyve/util/CommunicationUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/util/CommunicationUtil.java
@@ -38,6 +38,7 @@ public class CommunicationUtil {
 	private static final String INVALID_RESOLVED_EMAIL_ADDRESS = "The sendTo address could not be resolved to a valid email address";
 	public static final String SPECIAL_BEAN_URL = "{#url}";
 	public static final String SPECIAL_CONTEXT = "{#context}";
+	public static final String SPECIAL_LOGOUT_URL = "{#resetPasswordUrl}";
 	public static final String SENT_SUCCESSFULLY_MESSAGE = "Communication sent";
 
 	/**
@@ -166,7 +167,7 @@ public class CommunicationUtil {
 
 		// process email body
 		String emailBodyMain = communication.getBody();
-
+		
 		emailBodyMain = formatCommunicationMessage(customer, emailBodyMain, beans);
 
 		if (communication.getTemplate() != null) {
@@ -757,12 +758,17 @@ public class CommunicationUtil {
 	 */
 	public static String formatCommunicationMessage(Customer customer, String expression, Bean... beans) throws Exception {
 		String result = expression;
-
+		
+		if (result != null) {
+			result = result.replace(SPECIAL_LOGOUT_URL, Util.getResetPasswordUrl());
+		}
+		
+		
 		// default url binding to first bean
-		if (beans != null && beans.length > 0 && expression != null) {
+		if (beans != null && beans.length > 0 && result != null) {
 			Bean bean = beans[0];
 			if (bean != null) {
-				result = expression.replace(SPECIAL_BEAN_URL, Util.getDocumentUrl(beans[0]));
+				result = result.replace(SPECIAL_BEAN_URL, Util.getDocumentUrl(beans[0]));
 				result = result.replace(SPECIAL_CONTEXT, Util.getHomeUrl());
 			}
 			result = Binder.formatMessage(result, beans);

--- a/skyve-war/src/main/webapp/pages/resetPassword.jsp
+++ b/skyve-war/src/main/webapp/pages/resetPassword.jsp
@@ -6,11 +6,13 @@
 <%@ page import="org.skyve.impl.util.UtilImpl"%>
 <%@ page import="org.skyve.impl.web.UserAgent"%>
 <%@ page import="org.skyve.impl.web.WebUtil"%>
+<%@ page import="org.skyve.impl.web.AbstractWebContext"%>
 <%@ page import="org.skyve.metadata.user.User"%>
 <%@ page import="org.skyve.metadata.view.TextOutput.Sanitisation"%>
 <%@ page import="org.skyve.util.OWASP"%>
 <%@ page import="org.skyve.util.Util"%>
 <%@ page import="org.skyve.web.WebContext"%>
+
 <%
 	final String newPasswordFieldName = "newPassword";
 	final String confirmPasswordFieldName = "confirmPassword";
@@ -31,7 +33,15 @@
 	else if ((newPasswordValue != null) && (confirmPasswordValue != null)) {
 		passwordChangeErrorMessage = WebUtil.resetPassword(passwordResetToken, newPasswordValue, confirmPasswordValue);
 		if (passwordChangeErrorMessage == null) {
-			response.sendRedirect(response.encodeRedirectURL(Util.getHomeUrl() + "home.jsp"));
+			
+			String redirectURL = response.encodeRedirectURL(Util.getHomeUrl() + "home.jsp");
+
+			String customerName = request.getParameter(AbstractWebContext.CUSTOMER_COOKIE_NAME);
+			if (customerName != null && !customerName.isBlank()) {
+				redirectURL = redirectURL + "?" + AbstractWebContext.CUSTOMER_COOKIE_NAME + "=" + customerName;
+			}
+			
+			response.sendRedirect(redirectURL);
 			return;
 		}
 	}

--- a/skyve-web/src/main/java/org/skyve/impl/web/WebUtil.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/WebUtil.java
@@ -284,7 +284,11 @@ public class WebUtil {
 				String subject = (String) Binder.get(configuration, SQLMetaDataUtil.PASSWORD_RESET_EMAIL_SUBJECT_PROPERTY_NAME);
 				subject = Binder.formatMessage(subject, firstUser);
 				String body = (String) Binder.get(configuration, SQLMetaDataUtil.PASSWORD_RESET_EMAIL_BODY_PROPERTY_NAME); 
+				
+				body = body.replace("{#resetPasswordUrl}", Util.getResetPasswordUrl());
+				// keeping this for backwards compatibility
 				body = body.replace("{url}", Util.getSkyveContextUrl());
+				
 				body = Binder.formatMessage(body, firstUser);
 				String fromEmail = (String) Binder.get(configuration, SQLMetaDataUtil.FROM_EMAIL_PROPERTY_NAME);
 				EXT.sendMail(new Mail().addTo(email).from(fromEmail).subject(subject).body(body));


### PR DESCRIPTION
Configures the reset password URL in Util class.
Create a key {#resetPassowrdUrl} to use in emails which Skyve will replace with the "reset password url".
Works for "invite users" as well as "reset password" on the front page of skyve
Updates the default configuration to use this new key.
Old functionality of using {url} will continue working.
 
This change also keeps the customer reference after the user has reset the password. It adds "customer=xx" to the URL on the page redirect after resetting password.

The configuration of the email will be:
href="{#resetPassowrdUrl}"

Trello card
https://trello.com/c/PByo2FSJ/1623-change-password-button-on-the-resetpasswordjsp-does-not-respect-the-customer