### PR TITLE
Add fluent builder classes for view user access metadata

### DIFF
--- a/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentView.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentView.java
@@ -1,6 +1,12 @@
 package org.skyve.metadata.view.fluent;
 
 import org.skyve.impl.metadata.repository.view.ViewMetaData;
+import org.skyve.impl.metadata.repository.view.access.ViewDocumentAggregateUserAccessMetaData;
+import org.skyve.impl.metadata.repository.view.access.ViewModelAggregateUserAccessMetaData;
+import org.skyve.impl.metadata.repository.view.access.ViewPreviousCompleteUserAccessMetaData;
+import org.skyve.impl.metadata.repository.view.access.ViewQueryAggregateUserAccessMetaData;
+import org.skyve.impl.metadata.repository.view.access.ViewSingularUserAccessMetaData;
+import org.skyve.impl.metadata.repository.view.access.ViewUserAccessMetaData;
 import org.skyve.impl.metadata.view.ViewImpl;
 import org.skyve.metadata.view.View;
 import org.skyve.metadata.view.View.ViewParameter;
@@ -64,6 +70,169 @@ public class FluentView extends FluentContainer<FluentView> {
 		view.setDocumentation(documentation);
 		return this;
 	}
+	
+	/**
+	 * Adds a new {@link FluentViewDocumentAggregateAccess} to this view.
+	 */
+	public FluentView addViewDocumentAggregateAccess(FluentViewDocumentAggregateAccess access) {
+		return addAccess(access);
+	}
+
+	/**
+	 * Finds the view document aggregate access in this view's list of accesses.
+	 */
+	public FluentViewDocumentAggregateAccess findViewDocumentAggregateAccess(final String documentName) {
+		ViewUserAccessMetaData result = view.getAccesses().getAccesses().stream()
+				.filter(a -> a instanceof ViewDocumentAggregateUserAccessMetaData
+						&& ((ViewDocumentAggregateUserAccessMetaData) a).getDocumentName().equals(documentName))
+				.findFirst()
+				.orElse(null);
+
+		return result != null ? new FluentViewDocumentAggregateAccess((ViewDocumentAggregateUserAccessMetaData) result)
+				: null;
+	}
+
+	/**
+	 * Removes the {@link ViewDocumentAggregateUserAccessMetaData} with the specified
+	 * document name if one is defined for this view.
+	 */
+	public FluentView removeDocumentAggregateAccess(final String documentName) {
+		view.getAccesses().getAccesses().removeIf(a -> a instanceof ViewDocumentAggregateUserAccessMetaData
+				&& ((ViewDocumentAggregateUserAccessMetaData) a).getDocumentName().equals(documentName));
+		return this;
+	}
+
+	/**
+	 * Adds a new {@link FluentViewModelAggregateAccess} to this view.
+	 */
+	public FluentView addViewModelAggregateAccess(FluentViewModelAggregateAccess access) {
+		return addAccess(access);
+	}
+
+	/**
+	 * Finds the view model aggregate access in this view's list of accesses.
+	 */
+	public FluentViewModelAggregateAccess findViewModelAggregateAccess(final String modelName) {
+		ViewUserAccessMetaData result = view.getAccesses().getAccesses().stream()
+				.filter(a -> a instanceof ViewModelAggregateUserAccessMetaData
+						&& ((ViewModelAggregateUserAccessMetaData) a).getModelName().equals(modelName))
+				.findFirst()
+				.orElse(null);
+
+		return result != null ? new FluentViewModelAggregateAccess((ViewModelAggregateUserAccessMetaData) result)
+				: null;
+	}
+
+	/**
+	 * Removes the {@link ViewModelAggregateUserAccessMetaData} with the specified
+	 * document name if one is defined for this view.
+	 */
+	public FluentView removeModelAggregateAccess(final String modelName) {
+		view.getAccesses().getAccesses().removeIf(a -> a instanceof ViewModelAggregateUserAccessMetaData
+				&& ((ViewModelAggregateUserAccessMetaData) a).getModelName().equals(modelName));
+		return this;
+	}
+
+	/**
+	 * Adds a new {@link FluentViewPreviousCompleteAccess} to this view.
+	 */
+	public FluentView addViewPreviousCompleteAccess(FluentViewPreviousCompleteAccess access) {
+		return addAccess(access);
+	}
+
+	/**
+	 * Finds the view previous complete access in this view's list of accesses.
+	 */
+	public FluentViewPreviousCompleteAccess findViewPreviousCompleteAccess(final String binding) {
+		ViewUserAccessMetaData result = view.getAccesses().getAccesses().stream()
+				.filter(a -> a instanceof ViewPreviousCompleteUserAccessMetaData
+						&& ((ViewPreviousCompleteUserAccessMetaData) a).getBinding().equals(binding))
+				.findFirst()
+				.orElse(null);
+
+		return result != null ? new FluentViewPreviousCompleteAccess((ViewPreviousCompleteUserAccessMetaData) result)
+				: null;
+	}
+
+	/**
+	 * Removes the {@link ViewPreviousCompleteUserAccessMetaData} with the specified
+	 * document name if one is defined for this view.
+	 */
+	public FluentView removePreviousCompleteAccess(final String binding) {
+		view.getAccesses().getAccesses().removeIf(a -> a instanceof ViewPreviousCompleteUserAccessMetaData
+				&& ((ViewPreviousCompleteUserAccessMetaData) a).getBinding().equals(binding));
+		return this;
+	}
+
+	/**
+	 * Adds a new {@link FluentViewQueryAggregateAccess} to this view.
+	 */
+	public FluentView addViewQueryAggregateAccess(FluentViewQueryAggregateAccess access) {
+		return addAccess(access);
+	}
+
+	/**
+	 * Finds the view query access in this view's list of accesses.
+	 */
+	public FluentViewQueryAggregateAccess findViewQueryAggregateAccess(final String queryName) {
+		ViewUserAccessMetaData result = view.getAccesses().getAccesses().stream()
+				.filter(a -> a instanceof ViewQueryAggregateUserAccessMetaData
+						&& ((ViewQueryAggregateUserAccessMetaData) a).getQueryName().equals(queryName))
+				.findFirst()
+				.orElse(null);
+
+		return result != null ? new FluentViewQueryAggregateAccess((ViewQueryAggregateUserAccessMetaData) result)
+				: null;
+	}
+
+	/**
+	 * Removes the {@link ViewQueryAggregateUserAccessMetaData} with the specified
+	 * document name if one is defined for this view.
+	 */
+	public FluentView removeQueryAggregateAccess(final String queryName) {
+		view.getAccesses().getAccesses().removeIf(a -> a instanceof ViewQueryAggregateUserAccessMetaData
+				&& ((ViewQueryAggregateUserAccessMetaData) a).getQueryName().equals(queryName));
+		return this;
+	}
+
+	/**
+	 * Adds a new {@link FluentViewSingularAccess} to this view.
+	 */
+	public FluentView addViewSingularAccess(FluentViewSingularAccess access) {
+		return addAccess(access);
+	}
+
+	/**
+	 * Finds the view singular access in this view's list of accesses.
+	 */
+	public FluentViewSingularAccess findViewSingularAccess(final String documentName) {
+		ViewUserAccessMetaData result = view.getAccesses().getAccesses().stream()
+				.filter(a -> a instanceof ViewSingularUserAccessMetaData
+						&& ((ViewSingularUserAccessMetaData) a).getDocumentName().equals(documentName))
+				.findFirst()
+				.orElse(null);
+
+		return result != null ? new FluentViewSingularAccess((ViewSingularUserAccessMetaData) result)
+				: null;
+	}
+
+	/**
+	 * Removes the {@link ViewSingularUserAccessMetaData} with the specified
+	 * document name if one is defined for this view.
+	 */
+	public FluentView removeSingularAccess(final String documentName) {
+		view.getAccesses().getAccesses().removeIf(a -> a instanceof ViewSingularUserAccessMetaData
+				&& ((ViewSingularUserAccessMetaData) a).getDocumentName().equals(documentName));
+		return this;
+	}
+
+	/**
+	 * Clears all the accesses for this module role.
+	 */
+	public FluentView clearAccesses() {
+		view.getAccesses().getAccesses().clear();
+		return this;
+	}
 
 	public FluentView helpRelativeFileName(String helpRelativeFileName) {
 		view.setHelpRelativeFileName(helpRelativeFileName);
@@ -104,14 +273,15 @@ public class FluentView extends FluentContainer<FluentView> {
 		view.getParameters().removeIf(p -> (binding.equals(p.getBoundTo()) || binding.equals(p.getFromBinding())));
 		return this;
 	}
-	
+
 	public FluentView clearParameters() {
 		view.getParameters().clear();
 		return this;
 	}
 
 	public FluentViewParameter findParameter(String binding) {
-		ViewParameter result = view.getParameters().stream().filter(p -> (binding.equals(p.getBoundTo()) || binding.equals(p.getFromBinding()))).findAny().orElse(null);
+		ViewParameter result = view.getParameters().stream()
+				.filter(p -> (binding.equals(p.getBoundTo()) || binding.equals(p.getFromBinding()))).findAny().orElse(null);
 		if (result != null) {
 			return new FluentViewParameter(result);
 		}
@@ -121,5 +291,13 @@ public class FluentView extends FluentContainer<FluentView> {
 	@Override
 	public ViewMetaData get() {
 		return view;
+	}
+
+	/**
+	 * Adds a new {@link FluentViewUserAccess} to this module role.
+	 */
+	private <T extends FluentViewUserAccess<?, ?>> FluentView addAccess(T access) {
+		view.getAccesses().getAccesses().add(access.get());
+		return this;
 	}
 }

--- a/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewDocumentAggregateAccess.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewDocumentAggregateAccess.java
@@ -1,0 +1,52 @@
+package org.skyve.metadata.view.fluent;
+
+import java.util.Set;
+
+import org.skyve.impl.metadata.repository.view.access.ViewDocumentAggregateUserAccessMetaData;
+
+/**
+ * A fluent helper builder class to construct and manipulate the {@link ViewDocumentAggregateUserAccessMetaData} metadata.
+ * 
+ * @author brandon-klar
+ */
+public class FluentViewDocumentAggregateAccess
+		extends FluentViewUserAccess<FluentViewDocumentAggregateAccess, ViewDocumentAggregateUserAccessMetaData> {
+
+	/**
+	 * Creates a new FluentViewDocumentAggregateAccess
+	 */
+	public FluentViewDocumentAggregateAccess() {
+		access = new ViewDocumentAggregateUserAccessMetaData();
+	}
+
+	/**
+	 * Creates a new FluentModuleRoleDocumentAggregateAccess from the specified ViewDocumentAggregateUserAccessMetaData.
+	 */
+	public FluentViewDocumentAggregateAccess(ViewDocumentAggregateUserAccessMetaData access) {
+		this.access = access;
+	}
+
+	/**
+	 * Returns a FluentViewDocumentAggregateAccess from a runtime metadata.
+	 */
+	protected FluentViewDocumentAggregateAccess from(Set<String> uxuis) {
+		uxuis.forEach(u -> addUxUi(u));
+		return this;
+	}
+
+	/**
+	 * Specifies the document name for this FluentViewDocumentAggregateAccess.
+	 */
+	public FluentViewDocumentAggregateAccess documentName(final String documentName) {
+		access.setDocumentName(documentName);
+		return this;
+	}
+
+	/**
+	 * Returns the underlying document aggregate user access metadata from this builder.
+	 */
+	@Override
+	public ViewDocumentAggregateUserAccessMetaData get() {
+		return access;
+	}
+}

--- a/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewModelAggregateAccess.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewModelAggregateAccess.java
@@ -1,0 +1,52 @@
+package org.skyve.metadata.view.fluent;
+
+import java.util.Set;
+
+import org.skyve.impl.metadata.repository.view.access.ViewModelAggregateUserAccessMetaData;
+
+/**
+ * A fluent helper builder class to construct and manipulate the {@link ViewModelAggregateUserAccessMetaData} metadata.
+ * 
+ * @author brandon-klar
+ */
+public class FluentViewModelAggregateAccess
+		extends FluentViewUserAccess<FluentViewModelAggregateAccess, ViewModelAggregateUserAccessMetaData> {
+	/**
+	 * Creates a new FluentViewModelAggregateAccess
+	 */
+	public FluentViewModelAggregateAccess() {
+		access = new ViewModelAggregateUserAccessMetaData();
+	}
+
+	/**
+	 * Creates a new FluentViewModelAggregateAccess from the specified ViewModelAggregateUserAccessMetaData.
+	 */
+	public FluentViewModelAggregateAccess(ViewModelAggregateUserAccessMetaData access) {
+		this.access = access;
+	}
+
+	/**
+	 * Returns a FluentViewModelAggregateAccess from a runtime metadata.
+	 */
+	protected FluentViewModelAggregateAccess from(Set<String> uxuis) {
+		uxuis.forEach(u -> addUxUi(u));
+		return this;
+	}
+
+	/**
+	 * Specifies the model name for this FluentViewModelAggregateAccess.
+	 */
+	public FluentViewModelAggregateAccess modelName(final String modelName) {
+		access.setModelName(modelName);
+		return this;
+	}
+
+	/**
+	 * Returns the underlying model aggregate user access metadata from this builder.
+	 */
+	@Override
+	public ViewModelAggregateUserAccessMetaData get() {
+		return access;
+	}
+
+}

--- a/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewPreviousCompleteAccess.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewPreviousCompleteAccess.java
@@ -1,0 +1,53 @@
+package org.skyve.metadata.view.fluent;
+
+import java.util.Set;
+
+import org.skyve.impl.metadata.repository.view.access.ViewPreviousCompleteUserAccessMetaData;
+
+/**
+ * A fluent helper builder class to construct and manipulate the {@link ViewPreviousCompleteUserAccessMetaData} metadata.
+ * 
+ * @author brandon-klar
+ */
+public class FluentViewPreviousCompleteAccess
+		extends FluentViewUserAccess<FluentViewPreviousCompleteAccess, ViewPreviousCompleteUserAccessMetaData> {
+
+	/**
+	 * Creates a new FluentViewPreviousCompleteAccess
+	 */
+	public FluentViewPreviousCompleteAccess() {
+		access = new ViewPreviousCompleteUserAccessMetaData();
+	}
+
+	/**
+	 * Creates a new FluentViewPreviousCompleteAccess from the specified ViewPreviousCompleteUserAccessMetaData.
+	 */
+	public FluentViewPreviousCompleteAccess(ViewPreviousCompleteUserAccessMetaData access) {
+		this.access = access;
+	}
+
+	/**
+	 * Returns a FluentViewPreviousCompleteAccess from a runtime metadata.
+	 */
+	protected FluentViewPreviousCompleteAccess from(Set<String> uxuis) {
+		uxuis.forEach(u -> addUxUi(u));
+		return this;
+	}
+
+	/**
+	 * 
+	 */
+	public FluentViewPreviousCompleteAccess binding(final String binding) {
+		access.setBinding(binding);
+		return this;
+	}
+
+	/**
+	 * Returns the underlying view user access metadata from this builder.
+	 */
+	@Override
+	public ViewPreviousCompleteUserAccessMetaData get() {
+		return access;
+	}
+
+}

--- a/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewQueryAggregateAccess.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewQueryAggregateAccess.java
@@ -1,0 +1,53 @@
+package org.skyve.metadata.view.fluent;
+
+import java.util.Set;
+
+import org.skyve.impl.metadata.repository.view.access.ViewQueryAggregateUserAccessMetaData;
+
+/**
+ * A fluent helper builder class to construct and manipulate the {@link ViewQueryAggregateUserAccessMetaData} metadata.
+ * 
+ * @author brandon-klar
+ */
+public class FluentViewQueryAggregateAccess
+		extends FluentViewUserAccess<FluentViewQueryAggregateAccess, ViewQueryAggregateUserAccessMetaData> {
+
+	/**
+	 * Creates a new FluentViewQueryAggregateAccess
+	 */
+	public FluentViewQueryAggregateAccess() {
+		access = new ViewQueryAggregateUserAccessMetaData();
+	}
+
+	/**
+	 * Creates a new FluentViewQueryAggregateAccess from the specified ViewQueryAggregateUserAccessMetaData.
+	 */
+	public FluentViewQueryAggregateAccess(ViewQueryAggregateUserAccessMetaData access) {
+		this.access = access;
+	}
+
+	/**
+	 * Returns a FluentViewQueryAggregateAccess from a runtime metadata.
+	 */
+	protected FluentViewQueryAggregateAccess from(Set<String> uxuis) {
+		uxuis.forEach(u -> addUxUi(u));
+		return this;
+	}
+
+	/**
+	 * Specifies the query name for this FluentViewQueryAggregateAccess.
+	 */
+	public FluentViewQueryAggregateAccess queryName(final String queryName) {
+		access.setQueryName(queryName);
+		return this;
+	}
+
+	/**
+	 * Returns the underlying view user access metadata from this builder.
+	 */
+	@Override
+	public ViewQueryAggregateUserAccessMetaData get() {
+		return access;
+	}
+
+}

--- a/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewSingularAccess.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewSingularAccess.java
@@ -1,0 +1,52 @@
+package org.skyve.metadata.view.fluent;
+
+import java.util.Set;
+
+import org.skyve.impl.metadata.repository.view.access.ViewSingularUserAccessMetaData;
+
+/**
+ * A fluent helper builder class to construct and manipulate the {@link ViewSingularUserAccessMetaData} metadata.
+ * 
+ * @author brandon-klar
+ */
+public class FluentViewSingularAccess extends FluentViewUserAccess<FluentViewSingularAccess, ViewSingularUserAccessMetaData> {
+
+	/**
+	 * Creates a new FluentViewDocumentAggregateAccess
+	 */
+	public FluentViewSingularAccess() {
+		access = new ViewSingularUserAccessMetaData();
+	}
+
+	/**
+	 * Creates a new FluentModuleRoleDocumentAggregateAccess from the specified ViewSingularUserAccessMetaData.
+	 */
+	public FluentViewSingularAccess(ViewSingularUserAccessMetaData access) {
+		this.access = access;
+	}
+
+	/**
+	 * Returns a FluentViewDocumentAggregateAccess from a runtime metadata.
+	 */
+	protected FluentViewSingularAccess from(Set<String> uxuis) {
+		uxuis.forEach(u -> addUxUi(u));
+		return this;
+	}
+
+	/**
+	 * Specifies the document name for this FluentViewSingularAccess
+	 */
+	public FluentViewSingularAccess documentName(final String documentName) {
+		access.setDocumentName(documentName);
+		return this;
+	}
+
+	/**
+	 * Returns the underlying view user access metadata from this builder.
+	 */
+	@Override
+	public ViewSingularUserAccessMetaData get() {
+		return access;
+	}
+
+}

--- a/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewUserAccess.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/fluent/FluentViewUserAccess.java
@@ -1,0 +1,65 @@
+package org.skyve.metadata.view.fluent;
+
+import org.skyve.impl.metadata.repository.view.access.ViewUserAccessMetaData;
+import org.skyve.impl.metadata.repository.view.access.ViewUserAccessUxUiMetadata;
+
+/**
+ * Abstract base fluent builder class for working with {@link FluentViewUserAccess}.
+ * 
+ * @author brandon-klar
+ *
+ * @param <T> The fluent view user access builder subtype
+ * @param <M> The view user access metadata subtype
+ */
+abstract class FluentViewUserAccess<T extends FluentViewUserAccess<T, M>, M extends ViewUserAccessMetaData> {
+
+	protected M access;
+
+	protected FluentViewUserAccess() {
+		// no implementation
+	}
+
+	/**
+	 * Returns the underlying view user access metadata from this builder.
+	 */
+	public abstract M get();
+
+	/**
+	 * Add a new ViewUserAccessUxUiMetadata to this view user access.
+	 */
+	@SuppressWarnings("unchecked")
+	public T addUxUi(ViewUserAccessUxUiMetadata uxui) {
+		access.getUxuis().add(uxui);
+		return (T) this;
+	}
+
+	/**
+	 * Add a new uxui to this view user access with the specified uxui name.
+	 */
+	@SuppressWarnings("unchecked")
+	public T addUxUi(String uxui) {
+		ViewUserAccessUxUiMetadata namedUxUi = new ViewUserAccessUxUiMetadata();
+		namedUxUi.setName(uxui);
+		access.getUxuis().add(namedUxUi);
+		return (T) this;
+	}
+
+	/**
+	 * Clears all the uxuis for this view user access.
+	 */
+	@SuppressWarnings("unchecked")
+	public T clearUxUis() {
+		access.getUxuis().clear();
+		return (T) this;
+	}
+
+	/**
+	 * Removes the specified module role access uxui with the specified name if one is defined
+	 * for this access.
+	 */
+	@SuppressWarnings("unchecked")
+	public T removeUxUi(String uxui) {
+		access.getUxuis().removeIf(u -> uxui.equals(u.getName()));
+		return (T) this;
+	}
+}

--- a/skyve-core/src/test/java/org/skyve/metadata/module/fluent/FluentViewTest.java
+++ b/skyve-core/src/test/java/org/skyve/metadata/module/fluent/FluentViewTest.java
@@ -1,0 +1,381 @@
+package org.skyve.metadata.module.fluent;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.skyve.impl.metadata.repository.view.access.ViewUserAccessesMetaData;
+import org.skyve.metadata.view.fluent.FluentView;
+import org.skyve.metadata.view.fluent.FluentViewDocumentAggregateAccess;
+import org.skyve.metadata.view.fluent.FluentViewModelAggregateAccess;
+import org.skyve.metadata.view.fluent.FluentViewPreviousCompleteAccess;
+import org.skyve.metadata.view.fluent.FluentViewQueryAggregateAccess;
+import org.skyve.metadata.view.fluent.FluentViewSingularAccess;
+
+public class FluentViewTest {
+
+	private FluentView fluent;
+
+	@Before
+	public void setup() throws Exception {
+		fluent = new FluentView();
+		fluent.get().setAccesses(new ViewUserAccessesMetaData());
+	}
+	
+	@SuppressWarnings("boxing")
+	@Test
+	public void testAddDocumentAggregateAccess() {
+		// setup the test data
+		FluentViewDocumentAggregateAccess access = new FluentViewDocumentAggregateAccess();
+		access.documentName("TestDocument1");
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(0));
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(0));
+		// call the method under test
+		fluent.addViewDocumentAggregateAccess(access);
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+	}
+	
+	@SuppressWarnings("boxing")
+	@Test
+	public void testAddQueryAggregateAccess() {
+		// setup the test data
+		FluentViewQueryAggregateAccess access = new FluentViewQueryAggregateAccess();
+		access.queryName("TestQuery1");
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(0));
+
+		// call the method under test
+		fluent.addViewQueryAggregateAccess(access);
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testAddModelAggregateAccess() {
+		// setup the test data
+		FluentViewModelAggregateAccess access = new FluentViewModelAggregateAccess();
+		access.modelName("TestModel1");
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(0));
+
+		// call the method under test
+		fluent.addViewModelAggregateAccess(access);
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testAddSingularAccess() {
+		// setup the test data
+		FluentViewSingularAccess access = new FluentViewSingularAccess();
+		access.documentName("TestDocument1");
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(0));
+
+		// call the method under test
+		fluent.addViewSingularAccess(access);
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testAddPreviousCompleteAccess() {
+		// setup the test data
+		FluentViewPreviousCompleteAccess access = new FluentViewPreviousCompleteAccess();
+		access.binding("Binding1");
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(0));
+
+		// call the method under test
+		fluent.addViewPreviousCompleteAccess(access);
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testClearAccesses() {
+		// setup the test data
+		FluentViewDocumentAggregateAccess access1 = new FluentViewDocumentAggregateAccess();
+		access1.documentName("TestDocument1");
+
+		FluentViewModelAggregateAccess access2 = new FluentViewModelAggregateAccess();
+		access2.modelName("TestModel1");
+
+		fluent.addViewDocumentAggregateAccess(access1);
+		fluent.addViewModelAggregateAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		fluent.clearAccesses();
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(0));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testFindDocumentAggregateAccess() {
+		// setup the test data
+		FluentViewDocumentAggregateAccess access1 = new FluentViewDocumentAggregateAccess();
+		access1.documentName("TestDocument1");
+
+		FluentViewDocumentAggregateAccess access2 = new FluentViewDocumentAggregateAccess();
+		access2.documentName("TestDocument2");
+		
+		fluent.addViewDocumentAggregateAccess(access1);
+		fluent.addViewDocumentAggregateAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		FluentViewDocumentAggregateAccess result = fluent.findViewDocumentAggregateAccess("TestDocument1");
+
+		// verify the result
+		assertThat(result, is(notNullValue()));
+		assertThat(result.get().getDocumentName(), is("TestDocument1"));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testFindModelAggregateAccess() {
+		// setup the test data
+		FluentViewModelAggregateAccess access1 = new FluentViewModelAggregateAccess();
+		access1.modelName("TestModel1");
+
+		FluentViewModelAggregateAccess access2 = new FluentViewModelAggregateAccess();
+		access2.modelName("TestModel2");
+
+		fluent.addViewModelAggregateAccess(access1);
+		fluent.addViewModelAggregateAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		FluentViewModelAggregateAccess result = fluent.findViewModelAggregateAccess("TestModel1");
+
+		// verify the result
+		assertThat(result, is(notNullValue()));
+		assertThat(result.get().getModelName(), is("TestModel1"));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testFindPreviousCompleteAccess() {
+		// setup the test data
+		FluentViewPreviousCompleteAccess access1 = new FluentViewPreviousCompleteAccess();
+		access1.binding("TestBinding1");
+
+		FluentViewPreviousCompleteAccess access2 = new FluentViewPreviousCompleteAccess();
+		access2.binding("TestBinding2");
+
+		fluent.addViewPreviousCompleteAccess(access1);
+		fluent.addViewPreviousCompleteAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		FluentViewPreviousCompleteAccess result = fluent.findViewPreviousCompleteAccess("TestBinding1");
+
+		// verify the result
+		assertThat(result, is(notNullValue()));
+		assertThat(result.get().getBinding(), is("TestBinding1"));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testFindQueryAggregateAccess() {
+		// setup the test data
+		FluentViewQueryAggregateAccess access1 = new FluentViewQueryAggregateAccess();
+		access1.queryName("TestQuery1");
+
+		FluentViewQueryAggregateAccess access2 = new FluentViewQueryAggregateAccess();
+		access2.queryName("TestQuery2");
+
+		fluent.addViewQueryAggregateAccess(access1);
+		fluent.addViewQueryAggregateAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		FluentViewQueryAggregateAccess result = fluent.findViewQueryAggregateAccess("TestQuery1");
+
+		// verify the result
+		assertThat(result, is(notNullValue()));
+		assertThat(result.get().getQueryName(), is("TestQuery1"));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testFindSingularAccess() {
+		// setup the test data
+		FluentViewSingularAccess access1 = new FluentViewSingularAccess();
+		access1.documentName("TestDocument1");
+
+		FluentViewSingularAccess access2 = new FluentViewSingularAccess();
+		access2.documentName("TestDocument2");
+
+		fluent.addViewSingularAccess(access1);
+		fluent.addViewSingularAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		FluentViewSingularAccess result = fluent.findViewSingularAccess("TestDocument1");
+
+		// verify the result
+		assertThat(result, is(notNullValue()));
+		assertThat(result.get().getDocumentName(), is("TestDocument1"));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testRemoveDocumentAggregateAccess() {
+		// setup the test data
+		FluentViewDocumentAggregateAccess access1 = new FluentViewDocumentAggregateAccess();
+		access1.documentName("TestDocument1");
+
+		FluentViewDocumentAggregateAccess access2 = new FluentViewDocumentAggregateAccess();
+		access2.documentName("TestDocument2");
+
+		fluent.addViewDocumentAggregateAccess(access1);
+		fluent.addViewDocumentAggregateAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		fluent.removeDocumentAggregateAccess("TestDocument1");
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+		assertThat(fluent.get().getAccesses().getAccesses(), not(hasItem(access1.get())));
+		assertThat(fluent.get().getAccesses().getAccesses(), hasItem(access2.get()));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testRemoveModelAggregateAccess() {
+		// setup the test data
+		FluentViewModelAggregateAccess access1 = new FluentViewModelAggregateAccess();
+		access1.modelName("TestModel1");
+
+		FluentViewModelAggregateAccess access2 = new FluentViewModelAggregateAccess();
+		access2.modelName("TestModel2");
+
+		fluent.addViewModelAggregateAccess(access1);
+		fluent.addViewModelAggregateAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		fluent.removeModelAggregateAccess("TestModel1");
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+		assertThat(fluent.get().getAccesses().getAccesses(), not(hasItem(access1.get())));
+		assertThat(fluent.get().getAccesses().getAccesses(), hasItem(access2.get()));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testRemovePreviousCompleteAccess() {
+		// setup the test data
+		FluentViewPreviousCompleteAccess access1 = new FluentViewPreviousCompleteAccess();
+		access1.binding("TestBinding1");
+
+		FluentViewPreviousCompleteAccess access2 = new FluentViewPreviousCompleteAccess();
+		access2.binding("TestBinding2");
+
+		fluent.addViewPreviousCompleteAccess(access1);
+		fluent.addViewPreviousCompleteAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		fluent.removePreviousCompleteAccess("TestBinding1");
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+		assertThat(fluent.get().getAccesses().getAccesses(), not(hasItem(access1.get())));
+		assertThat(fluent.get().getAccesses().getAccesses(), hasItem(access2.get()));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testRemoveQueryAggregateAccess() {
+		// setup the test data
+		FluentViewQueryAggregateAccess access1 = new FluentViewQueryAggregateAccess();
+		access1.queryName("TestQuery1");
+
+		FluentViewQueryAggregateAccess access2 = new FluentViewQueryAggregateAccess();
+		access2.queryName("TestQuery2");
+
+		fluent.addViewQueryAggregateAccess(access1);
+		fluent.addViewQueryAggregateAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		fluent.removeQueryAggregateAccess("TestQuery1");
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+		assertThat(fluent.get().getAccesses().getAccesses(), not(hasItem(access1.get())));
+		assertThat(fluent.get().getAccesses().getAccesses(), hasItem(access2.get()));
+	}
+
+	@SuppressWarnings("boxing")
+	@Test
+	public void testRemoveSingularAccess() {
+		// setup the test data
+		FluentViewSingularAccess access1 = new FluentViewSingularAccess();
+		access1.documentName("TestDocument1");
+
+		FluentViewSingularAccess access2 = new FluentViewSingularAccess();
+		access2.documentName("TestDocument2");
+
+		fluent.addViewSingularAccess(access1);
+		fluent.addViewSingularAccess(access2);
+
+		// validate the test data
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(2));
+
+		// call the method under test
+		fluent.removeSingularAccess("TestDocument1");
+
+		// verify the result
+		assertThat(fluent.get().getAccesses().getAccesses().size(), is(1));
+		assertThat(fluent.get().getAccesses().getAccesses(), not(hasItem(access1.get())));
+		assertThat(fluent.get().getAccesses().getAccesses(), hasItem(access2.get()));
+	}
+}


### PR DESCRIPTION
- update FluentView to add add, find and remove methods for the view metadata types
- add tests in FluentViewTest
- add abstract FluentViewUserAccess class
- add and implement subclasses that extend from FluentViewUserAccess