### PR TITLE
Add the ability to re-run a job from a completed job

### DIFF
--- a/skyve-ejb/src/generated/java/modules/admin/domain/Job.java
+++ b/skyve-ejb/src/generated/java/modules/admin/domain/Job.java
@@ -359,4 +359,23 @@ public class Job extends AbstractPersistentBean {
 	public boolean isNotCancellable() {
 		return (! isCancellable());
 	}
+
+	/**
+	 * rerunnabble
+	 *
+	 * @return The condition
+	 */
+	@XmlTransient
+	public boolean isRerunnabble() {
+		return (getStatus() != null);
+	}
+
+	/**
+	 * {@link #isRerunnabble} negation.
+	 *
+	 * @return The negated condition
+	 */
+	public boolean isNotRerunnabble() {
+		return (! isRerunnabble());
+	}
 }

--- a/skyve-ejb/src/generatedTest/java/modules/admin/Job/actions/RerunJobTest.java
+++ b/skyve-ejb/src/generatedTest/java/modules/admin/Job/actions/RerunJobTest.java
@@ -1,0 +1,25 @@
+package modules.admin.Job.actions;
+
+import modules.admin.domain.Job;
+import org.skyve.util.DataBuilder;
+import org.skyve.util.test.SkyveFixture.FixtureType;
+import util.AbstractActionTest;
+
+/**
+ * Generated - local changes will be overwritten.
+ * Extend {@link AbstractActionTest} to create your own tests for this action.
+ */
+public class RerunJobTest extends AbstractActionTest<Job, RerunJob> {
+
+	@Override
+	protected RerunJob getAction() {
+		return new RerunJob();
+	}
+
+	@Override
+	protected Job getBean() throws Exception {
+		return new DataBuilder()
+			.fixture(FixtureType.crud)
+			.build(Job.MODULE_NAME, Job.DOCUMENT_NAME);
+	}
+}

--- a/skyve-ejb/src/main/java/modules/admin/Job/Job.xml
+++ b/skyve-ejb/src/main/java/modules/admin/Job/Job.xml
@@ -55,5 +55,8 @@
 		<condition name="cancellable">
 			<expression>getStatus() == null</expression>
 		</condition>
+		<condition name="rerunnabble">
+			<expression>getStatus() != null</expression>
+		</condition>
 	</conditions>
 </document>

--- a/skyve-ejb/src/main/java/modules/admin/Job/actions/RerunJob.java
+++ b/skyve-ejb/src/main/java/modules/admin/Job/actions/RerunJob.java
@@ -1,0 +1,76 @@
+package modules.admin.Job.actions;
+
+import java.util.List;
+
+import org.skyve.CORE;
+import org.skyve.EXT;
+import org.skyve.domain.messages.MessageSeverity;
+import org.skyve.job.JobDescription;
+import org.skyve.metadata.controller.ServerSideAction;
+import org.skyve.metadata.controller.ServerSideActionResult;
+import org.skyve.metadata.customer.Customer;
+import org.skyve.metadata.module.JobMetaData;
+import org.skyve.util.Util;
+import org.skyve.web.WebContext;
+
+import modules.admin.domain.Job;
+
+public class RerunJob implements ServerSideAction<Job> {
+
+	@Override
+	public ServerSideActionResult<Job> execute(Job bean, WebContext webContext) {
+		// try to find the job to re-run, based on unique display name
+		JobMetaData jobToRerun = null;
+		Customer c = CORE.getCustomer();
+		List<org.skyve.metadata.module.Module> modules = c.getModules();
+		for (org.skyve.metadata.module.Module m : modules) {
+			List<JobMetaData> jobs = m.getJobs();
+			for (JobMetaData j : jobs) {
+				if (j.getDisplayName().equals(bean.getDisplayName())) {
+					jobToRerun = j;
+					break;
+				}
+			}
+
+			if (jobToRerun != null) {
+				break;
+			}
+		}
+
+		if (jobToRerun != null) {
+			if (isJobAlreadyActive(jobToRerun)) {
+				webContext.growl(MessageSeverity.warn, "This job is already running");
+			} else {
+				// start the job immediately as the current user
+				EXT.getJobScheduler().runOneShotJob(jobToRerun, bean, CORE.getUser());
+				webContext.growl(MessageSeverity.info, "Started " + jobToRerun.getDisplayName());
+			}
+		} else {
+			webContext.growl(MessageSeverity.warn, "Unable to find this job to re-run");
+		}
+
+		return new ServerSideActionResult<>(bean);
+	}
+
+	/**
+	 * Checks if the current job is currently running.
+	 *
+	 * @return True if the job is running, false otherwise
+	 * @throws Exception
+	 */
+	private static boolean isJobAlreadyActive(final JobMetaData job) {
+		try {
+			List<JobDescription> runningJobs = EXT.getJobScheduler().getCustomerRunningJobs();
+			for (JobDescription jd : runningJobs) {
+				if (job.getDisplayName().equals(jd.getName())) {
+					return true;
+				}
+			}
+		} catch (Exception e) {
+			Util.LOGGER.warning("Error getting running jobs");
+			e.printStackTrace();
+		}
+
+		return false;
+	}
+}

--- a/skyve-ejb/src/main/java/modules/admin/Job/views/desktop/edit.xml
+++ b/skyve-ejb/src/main/java/modules/admin/Job/views/desktop/edit.xml
@@ -50,5 +50,6 @@
 		<cancel />
 		<zoomOut />
 		<action className="CancelJob" displayName="Cancel Job" iconStyleClass="fa fa-ban" confirm="Are you sure you want to cancel this job?" visible="cancellable"/>
+		<action className="RerunJob" displayName="Re-run Job" iconStyleClass="fa fa-refresh " confirm="Are you sure you want to re-run this job?" visible="rerunnabble"/>
 	</actions>
 </view>

--- a/skyve-ejb/src/main/java/modules/admin/Job/views/edit.xml
+++ b/skyve-ejb/src/main/java/modules/admin/Job/views/edit.xml
@@ -56,5 +56,6 @@
 		<cancel />
 		<zoomOut />
 		<action className="CancelJob" displayName="Cancel Job" iconStyleClass="fa fa-ban" confirm="Are you sure you want to cancel this job?" visible="cancellable"/>
+		<action className="RerunJob" displayName="Re-run Job" iconStyleClass="fa fa-refresh " confirm="Are you sure you want to re-run this job?" visible="rerunnabble"/>
 	</actions>
 </view>

--- a/skyve-ejb/src/main/java/modules/admin/admin.xml
+++ b/skyve-ejb/src/main/java/modules/admin/admin.xml
@@ -320,6 +320,7 @@
 				<document name="Generic" permission="CRUDG"/>
 				<document name="Job" permission="CRUDC">
 					<action name="CancelJob" />
+					<action name="RerunJob" />
 				</document>
 				<document name="Jobs" permission="_____">
 					<action name="DeleteCompletedJobs" />


### PR DESCRIPTION
If a job fails, and you push a change to the job, it is fiddly to go and run it again, especially if it is not a scheduled job. This adds an action to Job so you can go to a completed job and Rerun the job.

This has a caveat that Job only stores the display name of the job at the time it was run. It is not currently possible to uniquely identify the job and re-run it, so it needs to check the available JobMetaData for a matching display name, which is not guaranteed to be unique. This is the primary driver for this pull request.