### PR TITLE
Update Flying Saucer dependency to use the latest openpdf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
 		<spring-security.version>6.2.1</spring-security.version>
 		<spring.version>6.1.3</spring.version>
 		<!-- freemarker report versions -->
-		<flying-saucer.version>9.1.22</flying-saucer.version>
-		<freemarker.version>2.3.29</freemarker.version>
+		<flying-saucer.version>9.6.1</flying-saucer.version>
+		<freemarker.version>2.3.32</freemarker.version>
 		<cronutils.version>9.2.1</cronutils.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -440,7 +440,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.xhtmlrenderer</groupId>
-				<artifactId>flying-saucer-pdf-openpdf</artifactId>
+				<artifactId>flying-saucer-pdf</artifactId>
 				<version>${flying-saucer.version}</version>
 				<exclusions>
 					<exclusion>

--- a/skyve-ext/pom.xml
+++ b/skyve-ext/pom.xml
@@ -123,7 +123,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.xhtmlrenderer</groupId>
-			<artifactId>flying-saucer-pdf-openpdf</artifactId>
+			<artifactId>flying-saucer-pdf</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/skyve-ext/src/main/java/org/skyve/impl/report/freemarker/FreemarkerReportUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/report/freemarker/FreemarkerReportUtil.java
@@ -17,6 +17,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import org.apache.commons.beanutils.DynaBean;
 import org.skyve.CORE;
 import org.skyve.content.MimeType;
@@ -301,17 +303,15 @@ public final class FreemarkerReportUtil {
 	public static void generatePDFFromHTML(InputStream in, OutputStream outputStream)
 	throws Exception {
 		ITextRenderer renderer = new ITextRenderer();
-		ResourceLoaderUserAgent callback = new ResourceLoaderUserAgent(renderer.getOutputDevice());
-		callback.setSharedContext(renderer.getSharedContext());
+		ResourceLoaderUserAgent callback = new ResourceLoaderUserAgent(renderer.getOutputDevice(),
+				renderer.getSharedContext().getDotsPerPixel());
 		renderer.getSharedContext().setUserAgentCallback(callback);
 
 		loadFonts(renderer);
 
 		org.w3c.dom.Document doc = XMLResource.load(in).getDocument();
 
-		renderer.setDocument(doc, "/");
-		renderer.layout();
-		renderer.createPDF(outputStream);
+		renderer.createPDF(doc, outputStream);
 	}
 
 	/**
@@ -325,17 +325,15 @@ public final class FreemarkerReportUtil {
 	throws Exception {
 		try (OutputStream os = new FileOutputStream(outputFile)) {
 			ITextRenderer renderer = new ITextRenderer();
-			ResourceLoaderUserAgent callback = new ResourceLoaderUserAgent(renderer.getOutputDevice());
-			callback.setSharedContext(renderer.getSharedContext());
+			ResourceLoaderUserAgent callback = new ResourceLoaderUserAgent(renderer.getOutputDevice(),
+					renderer.getSharedContext().getDotsPerPixel());
 			renderer.getSharedContext().setUserAgentCallback(callback);
 
 			loadFonts(renderer);
 
 			org.w3c.dom.Document doc = XMLResource.load(new InputSource(url)).getDocument();
 
-			renderer.setDocument(doc, url);
-			renderer.layout();
-			renderer.createPDF(os);
+			renderer.createPDF(doc, os);
 		}
 	}
 
@@ -556,9 +554,10 @@ public final class FreemarkerReportUtil {
 		return template;
 	}
 
+	@ParametersAreNonnullByDefault
 	private static class ResourceLoaderUserAgent extends ITextUserAgent {
-		public ResourceLoaderUserAgent(ITextOutputDevice outputDevice) {
-			super(outputDevice);
+		private ResourceLoaderUserAgent(ITextOutputDevice outputDevice, int dotsPerPixel) {
+			super(outputDevice, dotsPerPixel);
 		}
 
 		@Override

--- a/skyve-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/skyve-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,11 @@
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
+	<deployment>
+		<dependencies>
+			<system export="true">
+				<paths>
+					<path name="org/w3c/dom/css" />
+				</paths>
+			</system>
+		</dependencies>
+	</deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
- update FreemarkerReportUtil to be compatible with the latest Flying Saucer API
- update Freemarker dependency version

The addition of `jboss-deployment-structure.xml` is all that was required to fix Freemarker reports. As far as I could tell, this fixed it on the old version. The dependency bump is not required.