### PR TITLE
Include/exclude content and/or audit log from backup

### DIFF
--- a/skyve-core/src/main/java/org/skyve/domain/app/AppConstants.java
+++ b/skyve-core/src/main/java/org/skyve/domain/app/AppConstants.java
@@ -44,6 +44,8 @@ public final class AppConstants {
 	public static final String END_TIME_ATTRIBUTE_NAME = "endTime";
 	public static final String FROM_EMAIL_ATTRIBUTE_NAME = "fromEmail";
 	public static final String GROUPS_ATTRIBUTE_NAME = "groups";
+	public static final String INCLUDE_CONTENT_ATTRIBUTE_NAME = "includeContent";
+	public static final String INCLUDE_AUDITS_ATTRIBUTE_NAME = "includeAuditLog";
 	public static final String LOG_ATTRIBUTE_NAME = "log";
 	public static final String MEMO_1_ATTRIBUTE_NAME = "memo1";
 	public static final String MODULE_NAME_ATTRIBUTE_NAME = "moduleName";
@@ -74,6 +76,8 @@ public final class AppConstants {
 	public static final String USER_ATTRIBUTE_NAME = "user";
 	public static final String USER_NAME_ATTRIBUTE_NAME = "userName";
 	
+	// Persistent Identifiers
+	public static final String ADMIN_AUDIT_PERSISTENT_IDENTIFIER = "ADM_Audit";
 	
 	// Actions
 	public static final String MAKE_PASSWORD_CHANGE_ACTION_NAME = "MakePasswordChange";

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/BackupUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/BackupUtil.java
@@ -389,6 +389,34 @@ final class BackupUtil {
 	}
 	
 	/**
+	 * Fetch 'include content' value selected in UI.
+	 * 
+	 * @param bean DataMaintenance bean
+	 */
+	static boolean getIncludeContent(Bean bean) {
+		if (bean != null) {
+			Boolean includeContent = (Boolean) BindUtil.get(bean, AppConstants.INCLUDE_CONTENT_ATTRIBUTE_NAME);
+			return Boolean.TRUE.equals(includeContent) ? true : false;
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * Fetch 'include audits' value selected in UI.
+	 * 
+	 * @param bean DataMaintenance bean
+	 */
+	static boolean getIncludeAuditLog(Bean bean) {
+		if (bean != null) {
+			Boolean includeAudits = (Boolean) BindUtil.get(bean, AppConstants.INCLUDE_AUDITS_ATTRIBUTE_NAME);
+			return Boolean.TRUE.equals(includeAudits) ? true : false;
+		}
+		
+		return false;
+	}
+	
+	/**
 	 * Constructs and returns a set of attributes (table.column) to redact.
 	 * 
 	 * @param sensitivityIndex Sensitivity benchmark. If any attribute has a greater than or equal to sensitivity score, it is redacted.

--- a/skyve-war/src/generated/java/modules/admin/domain/Audit.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Audit.java
@@ -31,7 +31,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Audit extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -85,7 +85,7 @@ public class Audit extends AbstractPersistentBean {
 	 * Operation
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Operation implements Enumeration {
 		insert("I", "Insert"),
 		update("U", "Update"),

--- a/skyve-war/src/generated/java/modules/admin/domain/ChangePassword.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ChangePassword.java
@@ -16,7 +16,7 @@ import org.skyve.impl.domain.AbstractTransientBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class ChangePassword extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/Communication.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Communication.java
@@ -26,7 +26,7 @@ import org.skyve.impl.domain.types.jaxb.DateTimeMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class Communication extends AbstractPersistentBean implements org.skyve.domain.app.admin.Communication {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/CommunicationTemplate.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/CommunicationTemplate.java
@@ -16,7 +16,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class CommunicationTemplate extends AbstractPersistentBean implements org.skyve.domain.app.admin.CommunicationTemplate {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/Configuration.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Configuration.java
@@ -33,7 +33,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class Configuration extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -148,7 +148,7 @@ public abstract class Configuration extends AbstractPersistentBean {
 				in a future version of Skyve. Here for backwards compatibility during Restore.
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum PasswordComplexityModel implements Enumeration {
 		minimumMin6Chars("MINIMUM", "Minimum - min 6 chars"),
 		mediumMin6CharsUpperLowerAndNumeric("MEDIUM", "Medium - min 6 chars, upper, lower and numeric"),
@@ -222,7 +222,7 @@ public abstract class Configuration extends AbstractPersistentBean {
 	 * The type of two factor authentication to be used for all users.
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum TwoFactorType implements Enumeration {
 		off("OFF", "Off"),
 		email("EMAIL", "Email");

--- a/skyve-war/src/generated/java/modules/admin/domain/Contact.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Contact.java
@@ -24,7 +24,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Contact extends AbstractPersistentBean implements org.skyve.domain.app.admin.Contact {
 	/**
 	 * For Serialization
@@ -59,7 +59,7 @@ public class Contact extends AbstractPersistentBean implements org.skyve.domain.
 	 * Whether this contact is a person or an organisation.
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum ContactType implements Enumeration {
 		person("Person", "Person"),
 		organisation("Organisation", "Organisation");

--- a/skyve-war/src/generated/java/modules/admin/domain/Content.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Content.java
@@ -20,7 +20,7 @@ import org.skyve.impl.domain.types.jaxb.TimestampMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Content extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/ControlPanel.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ControlPanel.java
@@ -34,7 +34,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class ControlPanel extends AbstractTransientBean {
 	/**
 	 * For Serialization
@@ -160,7 +160,7 @@ public abstract class ControlPanel extends AbstractTransientBean {
 	 * User Agent Type
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum SailUserAgentType implements Enumeration {
 		desktop("desktop", "Desktop"),
 		tablet("tablet", "Tablet"),
@@ -234,7 +234,7 @@ public abstract class ControlPanel extends AbstractTransientBean {
 	 * Assert (stop if they fail), Verify (test but don't stop), or None (don't conduct the tests at all)
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum SailTestStrategy implements Enumeration {
 		Assert("Assert", "Assert"),
 		Verify("Verify", "Verify"),
@@ -305,7 +305,7 @@ public abstract class ControlPanel extends AbstractTransientBean {
 	 * Executor
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum SailExecutor implements Enumeration {
 		primeFacesInlineSelenese("org.skyve.impl.sail.execution.PrimeFacesInlineSeleneseExecutor", "PrimeFaces Inline Selenese"),
 		primeFacesInlineWebDriver("org.skyve.impl.sail.execution.PrimeFacesInlineWebDriverExecutor", "PrimeFaces Inline Web Driver");

--- a/skyve-war/src/generated/java/modules/admin/domain/DataGroup.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/DataGroup.java
@@ -16,7 +16,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class DataGroup extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/DataMaintenance.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/DataMaintenance.java
@@ -40,7 +40,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class DataMaintenance extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -150,11 +150,17 @@ public abstract class DataMaintenance extends AbstractPersistentBean {
 	/** @hidden */
 	public static final String dataSensitivityPropertyName = "dataSensitivity";
 
+	/** @hidden */
+	public static final String includeContentPropertyName = "includeContent";
+
+	/** @hidden */
+	public static final String includeAuditLogPropertyName = "includeAuditLog";
+
 	/**
 	 * Pre-Process
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum RestorePreProcess implements Enumeration {
 		noProcessing("noProcessing", "No Processing"),
 		dropTablesUsingMetadataRecreateTablesFromBackupCreatesql("dropUsingMetadataAndCreateUsingBackup", "Drop tables using metadata & recreate tables from backup create.sql"),
@@ -230,7 +236,7 @@ public abstract class DataMaintenance extends AbstractPersistentBean {
 	 * Content Option
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum ContentRestoreOption implements Enumeration {
 		clearOrphanedContentIDs("clearOrphanedContentIds", "Clear Orphaned Content IDs"),
 		saveOrphanedContentIDs("saveOrphanedContentIds", "Save Orphaned Content IDs"),
@@ -301,7 +307,7 @@ public abstract class DataMaintenance extends AbstractPersistentBean {
 	 * Indexing Option
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum RestoreIndexingOption implements Enumeration {
 		data("data", "Data"),
 		content("content", "Content"),
@@ -373,7 +379,7 @@ public abstract class DataMaintenance extends AbstractPersistentBean {
 	 * Option
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum RefreshOption implements Enumeration {
 		upsert("Upsert", "Upsert"),
 		save("Save", "Save");
@@ -446,7 +452,7 @@ public abstract class DataMaintenance extends AbstractPersistentBean {
 <p>Evicting beans will free memory for large data jobs, however there may be impacts if the action (processing) selected affects items that other beans may reference.</p>
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum EvictOption implements Enumeration {
 		bean("Bean", "Bean"),
 		none("None", "None"),
@@ -521,7 +527,7 @@ public abstract class DataMaintenance extends AbstractPersistentBean {
 	 * Determines which attributes are redacted in backup job.
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum DataSensitivity implements Enumeration {
 		none("none", "None"),
 		internal("internal", "Internal"),
@@ -759,6 +765,24 @@ public abstract class DataMaintenance extends AbstractPersistentBean {
 	 * Determines which attributes are redacted in backup job.
 	 **/
 	private DataSensitivity dataSensitivity;
+
+	/**
+	 * Content
+	 * <br/>
+	 * Determines if content is included in the backup file.
+	 * <br/>
+	 * Determines if content is to be included in the generated backup.
+	 **/
+	private Boolean includeContent = Boolean.valueOf(true);
+
+	/**
+	 * Audits
+	 * <br/>
+	 * Determines if the audit log is to be included in the backup file.
+	 * <br/>
+	 * Determines if the audit log is to be included in the generated backup.
+	 **/
+	private Boolean includeAuditLog = Boolean.valueOf(true);
 
 	@Override
 	@XmlTransient
@@ -1410,6 +1434,42 @@ public abstract class DataMaintenance extends AbstractPersistentBean {
 	public void setDataSensitivity(DataSensitivity dataSensitivity) {
 		preset(dataSensitivityPropertyName, dataSensitivity);
 		this.dataSensitivity = dataSensitivity;
+	}
+
+	/**
+	 * {@link #includeContent} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getIncludeContent() {
+		return includeContent;
+	}
+
+	/**
+	 * {@link #includeContent} mutator.
+	 * @param includeContent	The new value.
+	 **/
+	@XmlElement
+	public void setIncludeContent(Boolean includeContent) {
+		preset(includeContentPropertyName, includeContent);
+		this.includeContent = includeContent;
+	}
+
+	/**
+	 * {@link #includeAuditLog} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getIncludeAuditLog() {
+		return includeAuditLog;
+	}
+
+	/**
+	 * {@link #includeAuditLog} mutator.
+	 * @param includeAuditLog	The new value.
+	 **/
+	@XmlElement
+	public void setIncludeAuditLog(Boolean includeAuditLog) {
+		preset(includeAuditLogPropertyName, includeAuditLog);
+		this.includeAuditLog = includeAuditLog;
 	}
 
 	/**

--- a/skyve-war/src/generated/java/modules/admin/domain/DocumentCreator.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/DocumentCreator.java
@@ -16,7 +16,7 @@ import org.skyve.impl.domain.AbstractTransientBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class DocumentCreator extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/DocumentNumber.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/DocumentNumber.java
@@ -16,7 +16,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class DocumentNumber extends AbstractPersistentBean implements org.skyve.domain.app.admin.DocumentNumber {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/DownloadFolder.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/DownloadFolder.java
@@ -16,7 +16,7 @@ import org.skyve.impl.domain.AbstractTransientBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class DownloadFolder extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/DynamicEntity.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/DynamicEntity.java
@@ -23,7 +23,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class DynamicEntity extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/DynamicRelation.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/DynamicRelation.java
@@ -23,7 +23,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class DynamicRelation extends AbstractPersistentBean implements ChildBean<DynamicEntity> {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/Generic.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Generic.java
@@ -43,7 +43,7 @@ import org.skyve.persistence.Persistence;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Generic extends AbstractTransientBean implements HierarchicalBean<Generic> {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/Group.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Group.java
@@ -22,7 +22,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class Group extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/GroupRole.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/GroupRole.java
@@ -19,7 +19,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class GroupRole extends AbstractPersistentBean implements ChildBean<GroupExtension> {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/ImportExport.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ImportExport.java
@@ -29,7 +29,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class ImportExport extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -91,7 +91,7 @@ public abstract class ImportExport extends AbstractPersistentBean {
 	 * Mode
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Mode implements Enumeration {
 		importData("importData", "Import Data"),
 		exportData("exportData", "Export Data");
@@ -161,7 +161,7 @@ public abstract class ImportExport extends AbstractPersistentBean {
 	 * Error handling
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum RollbackErrors implements Enumeration {
 		rollbackErrors("rollbackErrors", "admin.importExport.rollbackErrors.rollbackErrors.description"),
 		noRollbackErrors("noRollbackErrors", "admin.importExport.rollbackErrors.noRollbackErrors.description");
@@ -239,7 +239,7 @@ public abstract class ImportExport extends AbstractPersistentBean {
 <i>With this option, new records will always be created</i></p>
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum LoadType implements Enumeration {
 		createFind("createFind", "admin.importExport.loadType.createFind.description"),
 		createAll("createAll", "admin.importExport.loadType.createAll.description");

--- a/skyve-war/src/generated/java/modules/admin/domain/ImportExportColumn.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ImportExportColumn.java
@@ -27,7 +27,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class ImportExportColumn extends AbstractPersistentBean implements ChildBean<ImportExportExtension> {
 	/**
 	 * For Serialization
@@ -57,7 +57,7 @@ public class ImportExportColumn extends AbstractPersistentBean implements ChildB
 	 * Action
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum LoadAction implements Enumeration {
 		setValue("set", "admin.importExportColumn.loadAction.set.description"),
 		lookupEquals("equals", "admin.importExportColumn.loadAction.equals.description"),

--- a/skyve-war/src/generated/java/modules/admin/domain/Job.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Job.java
@@ -21,7 +21,7 @@ import org.skyve.impl.domain.types.jaxb.TimestampMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class Job extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/JobSchedule.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/JobSchedule.java
@@ -23,7 +23,7 @@ import org.skyve.impl.domain.types.jaxb.DateTimeMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class JobSchedule extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/Jobs.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Jobs.java
@@ -20,7 +20,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Jobs extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/ModuleDocument.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ModuleDocument.java
@@ -20,7 +20,7 @@ import org.skyve.impl.domain.AbstractTransientBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class ModuleDocument extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/ReportDataset.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ReportDataset.java
@@ -24,7 +24,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class ReportDataset extends AbstractPersistentBean implements ChildBean<ReportTemplateExtension>, org.skyve.domain.app.admin.ReportDataset {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/ReportDesign.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ReportDesign.java
@@ -33,7 +33,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class ReportDesign extends AbstractTransientBean {
 	/**
 	 * For Serialization
@@ -222,7 +222,7 @@ public class ReportDesign extends AbstractTransientBean {
 	 * Mode
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Mode implements Enumeration {
 		sql("sql", "sql"),
 		bean("bean", "bean");
@@ -292,7 +292,7 @@ public class ReportDesign extends AbstractTransientBean {
 	 * Definition Source
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum DefinitionSource implements Enumeration {
 		document("document", "document"),
 		view("view", "view"),
@@ -364,7 +364,7 @@ public class ReportDesign extends AbstractTransientBean {
 	 * Type
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum ReportType implements Enumeration {
 		report("Report", "Report"),
 		subreport("Subreport", "Subreport");
@@ -434,7 +434,7 @@ public class ReportDesign extends AbstractTransientBean {
 	 * Orientation
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Orientation implements Enumeration {
 		portrait("Portrait", "Portrait"),
 		landscape("Landscape", "Landscape");
@@ -504,7 +504,7 @@ public class ReportDesign extends AbstractTransientBean {
 	 * Collection Type
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum CollectionType implements Enumeration {
 		child("child", "child"),
 		aggregation("aggregation", "aggregation"),

--- a/skyve-war/src/generated/java/modules/admin/domain/ReportManager.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ReportManager.java
@@ -30,7 +30,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class ReportManager extends AbstractTransientBean {
 	/**
 	 * For Serialization
@@ -57,7 +57,7 @@ public abstract class ReportManager extends AbstractTransientBean {
 	 * Import action
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum ImportActionType implements Enumeration {
 		validateOnlyReportConfigurationsAndTemplates("validate", "Validate only report configurations and templates"),
 		validateThenImportReportConfigurationsAndTemplates("import", "Validate then import report configurations and templates");

--- a/skyve-war/src/generated/java/modules/admin/domain/ReportParameter.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ReportParameter.java
@@ -31,7 +31,7 @@ import org.skyve.impl.domain.types.jaxb.DateOnlyMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class ReportParameter extends AbstractPersistentBean implements ChildBean<ReportTemplateExtension>, org.skyve.domain.app.admin.ReportParameter {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/ReportTemplate.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/ReportTemplate.java
@@ -46,7 +46,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class ReportTemplate extends AbstractPersistentBean implements org.skyve.domain.app.admin.ReportTemplate {
 	/**
 	 * For Serialization
@@ -384,7 +384,7 @@ public abstract class ReportTemplate extends AbstractPersistentBean implements o
 	 * Which template engine is being used to create this report?
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum ReportType implements Enumeration {
 		jasper("Jasper", "Jasper"),
 		freemarker("Freemarker", "Freemarker");
@@ -456,7 +456,7 @@ public abstract class ReportTemplate extends AbstractPersistentBean implements o
 	 * What is the output format for this report?
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum OutputFormat implements Enumeration {
 		CSV("CSV", "CSV"),
 		PDF("PDF", "PDF");
@@ -528,7 +528,7 @@ public abstract class ReportTemplate extends AbstractPersistentBean implements o
 	 * The query mode of the Jasper report
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Mode implements Enumeration {
 		SQL("sql", "SQL"),
 		bean("bean", "Bean");
@@ -604,7 +604,7 @@ public abstract class ReportTemplate extends AbstractPersistentBean implements o
 					</ul>
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum WizardState implements Enumeration {
 		enterDetails("enterDetails", "enterDetails"),
 		enterMarkup("enterMarkup", "enterMarkup");
@@ -677,7 +677,7 @@ public abstract class ReportTemplate extends AbstractPersistentBean implements o
 				markup to enter directly?
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum GenerateExisting implements Enumeration {
 		generate("Generate", "Generate"),
 		existing("Existing", "Existing");

--- a/skyve-war/src/generated/java/modules/admin/domain/SelfRegistration.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/SelfRegistration.java
@@ -23,7 +23,7 @@ import org.skyve.impl.domain.types.jaxb.DateTimeMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class SelfRegistration extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/SelfRegistrationActivation.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/SelfRegistrationActivation.java
@@ -27,7 +27,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class SelfRegistrationActivation extends AbstractTransientBean {
 	/**
 	 * For Serialization
@@ -69,7 +69,7 @@ public abstract class SelfRegistrationActivation extends AbstractTransientBean {
 	 * Activation Result
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Result implements Enumeration {
 		SUCCESS("SUCCESS", "SUCCESS"),
 		ALREADYACTIVATED("ALREADY_ACTIVATED", "ALREADY_ACTIVATED"),

--- a/skyve-war/src/generated/java/modules/admin/domain/Snapshot.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Snapshot.java
@@ -18,7 +18,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Snapshot extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/Snapshots.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Snapshots.java
@@ -19,7 +19,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Snapshots extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/Startup.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Startup.java
@@ -32,7 +32,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class Startup extends AbstractTransientBean {
 	/**
 	 * For Serialization
@@ -121,7 +121,7 @@ public abstract class Startup extends AbstractTransientBean {
 	 * Which map technology would you like to use for this Skyve application? Note: Google Maps requires an API key.
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum MapType implements Enumeration {
 		gmap("gmap", "Google Maps"),
 		leaflet("leaflet", "Open Street Map");
@@ -193,7 +193,7 @@ public abstract class Startup extends AbstractTransientBean {
 	 * Which external backup provider should be used this Skyve application? Note: additional charges may apply.
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum BackupType implements Enumeration {
 		none("none", "None (Internal Backups)"),
 		azure("org.skyve.impl.backup.AzureBlobStorageBackup", "Azure Blob Storage");

--- a/skyve-war/src/generated/java/modules/admin/domain/Subscription.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Subscription.java
@@ -30,7 +30,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Subscription extends AbstractPersistentBean implements org.skyve.domain.app.admin.Subscription {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/SystemDashboard.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/SystemDashboard.java
@@ -19,7 +19,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class SystemDashboard extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/Tag.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Tag.java
@@ -32,7 +32,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class Tag extends AbstractPersistentBean implements org.skyve.domain.app.admin.Tag {
 	/**
 	 * For Serialization
@@ -131,7 +131,7 @@ public abstract class Tag extends AbstractPersistentBean implements org.skyve.do
 	 * Operator
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum CombinationsOperator implements Enumeration {
 		union("Union", "Union"),
 		except("Except", "Except"),
@@ -202,7 +202,7 @@ public abstract class Tag extends AbstractPersistentBean implements org.skyve.do
 	 * Filter Operator
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum FilterOperator implements Enumeration {
 		equals("equals", "Equals"),
 		like("like", "Like"),
@@ -273,7 +273,7 @@ public abstract class Tag extends AbstractPersistentBean implements org.skyve.do
 	 * Filter Action
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum FilterAction implements Enumeration {
 		tagRecordsThatMatch("tag", "Tag records that match"),
 		unTagRecordsThatMatch("unTag", "UnTag records that match");

--- a/skyve-war/src/generated/java/modules/admin/domain/Tagged.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Tagged.java
@@ -18,7 +18,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Tagged extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/User.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/User.java
@@ -42,7 +42,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class User extends AbstractPersistentBean implements org.skyve.domain.app.admin.User {
 	/**
 	 * For Serialization
@@ -172,7 +172,7 @@ public abstract class User extends AbstractPersistentBean implements org.skyve.d
 			to confirm the new user name and password and membership of groups.
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum WizardState implements Enumeration {
 		confirmContact("confirmContact", "confirmContact"),
 		createContact("createContact", "createContact"),
@@ -244,7 +244,7 @@ public abstract class User extends AbstractPersistentBean implements org.skyve.d
 	 * Groups
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum GroupSelection implements Enumeration {
 		existingGroups("existingGroups", "Existing groups"),
 		newGroup("newGroup", "New group");

--- a/skyve-war/src/generated/java/modules/admin/domain/UserCandidateContact.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/UserCandidateContact.java
@@ -29,7 +29,7 @@ import org.skyve.impl.domain.AbstractTransientBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class UserCandidateContact extends AbstractTransientBean implements ChildBean<UserExtension> {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/UserDashboard.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/UserDashboard.java
@@ -22,7 +22,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class UserDashboard extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/UserList.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/UserList.java
@@ -20,7 +20,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class UserList extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/UserLoginRecord.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/UserLoginRecord.java
@@ -21,7 +21,7 @@ import org.skyve.impl.domain.types.jaxb.DateTimeMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class UserLoginRecord extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/UserMonthlyHits.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/UserMonthlyHits.java
@@ -24,7 +24,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class UserMonthlyHits extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -60,7 +60,7 @@ public class UserMonthlyHits extends AbstractPersistentBean {
 	 * Device
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Device implements Enumeration {
 		phone("P", "Phone"),
 		tablet("T", "Tablet"),

--- a/skyve-war/src/generated/java/modules/admin/domain/UserProxy.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/UserProxy.java
@@ -24,7 +24,7 @@ import org.skyve.impl.domain.types.jaxb.DateTimeMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class UserProxy extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/UserRole.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/UserRole.java
@@ -19,7 +19,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class UserRole extends AbstractPersistentBean implements ChildBean<UserExtension> {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/UserToken.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/UserToken.java
@@ -20,7 +20,7 @@ import org.skyve.impl.domain.types.jaxb.TimestampMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class UserToken extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/admin/domain/admin_orm.hbm.xml
+++ b/skyve-war/src/generated/java/modules/admin/domain/admin_orm.hbm.xml
@@ -234,6 +234,8 @@
 				<param name="enumClass">modules.admin.domain.DataMaintenance$DataSensitivity</param>
 			</type>
 		</property>
+		<property name="includeContent" />
+		<property name="includeAuditLog" />
 		<filter name="adminDataMaintenanceNoneFilter" condition="1=0"/>
 		<filter name="adminDataMaintenanceCustomerFilter" condition="bizCustomer=:customerParam"/>
 		<filter name="adminDataMaintenanceDataGroupIdFilter" condition="bizDataGroupId=:dataGroupIdParam"/>

--- a/skyve-war/src/generated/java/modules/kitchensink/domain/ContainerGrid.java
+++ b/skyve-war/src/generated/java/modules/kitchensink/domain/ContainerGrid.java
@@ -18,7 +18,7 @@ import org.skyve.impl.domain.AbstractTransientBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class ContainerGrid extends AbstractTransientBean implements ChildBean<KitchenSink> {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/kitchensink/domain/DataRepeater.java
+++ b/skyve-war/src/generated/java/modules/kitchensink/domain/DataRepeater.java
@@ -18,7 +18,7 @@ import org.skyve.impl.domain.AbstractTransientBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class DataRepeater extends AbstractTransientBean implements ChildBean<KitchenSink> {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/kitchensink/domain/InlineGrid.java
+++ b/skyve-war/src/generated/java/modules/kitchensink/domain/InlineGrid.java
@@ -34,7 +34,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class InlineGrid extends AbstractTransientBean implements ChildBean<KitchenSink> {
 	/**
 	 * For Serialization
@@ -76,7 +76,7 @@ public class InlineGrid extends AbstractTransientBean implements ChildBean<Kitch
 	 * ConstantEnum
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum ConstantEnum implements Enumeration {
 		one1("one", "One (1)!"),
 		two2("two", "Two (2)!"),

--- a/skyve-war/src/generated/java/modules/kitchensink/domain/KitchenSink.java
+++ b/skyve-war/src/generated/java/modules/kitchensink/domain/KitchenSink.java
@@ -49,7 +49,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class KitchenSink extends AbstractTransientBean {
 	/**
 	 * For Serialization
@@ -154,7 +154,7 @@ public class KitchenSink extends AbstractTransientBean {
 	 * Combo
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Combo implements Enumeration {
 		one("one", "one"),
 		two("two", "two"),
@@ -225,7 +225,7 @@ public class KitchenSink extends AbstractTransientBean {
 	 * Radio
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Radio implements Enumeration {
 		one("one", "one"),
 		two("two", "two"),

--- a/skyve-war/src/generated/java/modules/kitchensink/domain/ListAttributes.java
+++ b/skyve-war/src/generated/java/modules/kitchensink/domain/ListAttributes.java
@@ -42,7 +42,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class ListAttributes extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -117,7 +117,7 @@ public class ListAttributes extends AbstractPersistentBean {
 	 * ConstantEnum
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum ConstantEnum implements Enumeration {
 		one1("one", "One (1)!"),
 		two2("two", "Two (2)!"),

--- a/skyve-war/src/generated/java/modules/kitchensink/domain/LookupDescription.java
+++ b/skyve-war/src/generated/java/modules/kitchensink/domain/LookupDescription.java
@@ -16,7 +16,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class LookupDescription extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/kitchensink/domain/OrderedGrid.java
+++ b/skyve-war/src/generated/java/modules/kitchensink/domain/OrderedGrid.java
@@ -30,7 +30,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class OrderedGrid extends AbstractTransientBean implements ChildBean<KitchenSink> {
 	/**
 	 * For Serialization
@@ -60,7 +60,7 @@ public class OrderedGrid extends AbstractTransientBean implements ChildBean<Kitc
 	 * Enum 3
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Enum3 implements Enumeration {
 		one("one", "one"),
 		two("two", "two"),

--- a/skyve-war/src/generated/java/modules/test/domain/AllAttributesEmbedded.java
+++ b/skyve-war/src/generated/java/modules/test/domain/AllAttributesEmbedded.java
@@ -50,7 +50,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class AllAttributesEmbedded extends AbstractPersistentBean implements ChildBean<AllAttributesPersistent> {
 	/**
 	 * For Serialization
@@ -128,7 +128,7 @@ public class AllAttributesEmbedded extends AbstractPersistentBean implements Chi
 	 * Enum 3
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Enum3 implements Enumeration {
 		one("one", "one"),
 		two("two", "two"),

--- a/skyve-war/src/generated/java/modules/test/domain/AllAttributesPersistent.java
+++ b/skyve-war/src/generated/java/modules/test/domain/AllAttributesPersistent.java
@@ -53,7 +53,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class AllAttributesPersistent extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -140,7 +140,7 @@ public class AllAttributesPersistent extends AbstractPersistentBean {
 	 * Enum 3
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Enum3 implements Enumeration {
 		one("one", "one"),
 		two("two", "two"),

--- a/skyve-war/src/generated/java/modules/test/domain/AllAttributesRequiredPersistent.java
+++ b/skyve-war/src/generated/java/modules/test/domain/AllAttributesRequiredPersistent.java
@@ -48,7 +48,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class AllAttributesRequiredPersistent extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -126,7 +126,7 @@ public class AllAttributesRequiredPersistent extends AbstractPersistentBean {
 	 * Enum 3
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Enum3 implements Enumeration {
 		one("one", "one"),
 		two("two", "two"),

--- a/skyve-war/src/generated/java/modules/test/domain/AllDynamicAttributesPersistent.java
+++ b/skyve-war/src/generated/java/modules/test/domain/AllDynamicAttributesPersistent.java
@@ -31,7 +31,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class AllDynamicAttributesPersistent extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/AnyBase.java
+++ b/skyve-war/src/generated/java/modules/test/domain/AnyBase.java
@@ -18,7 +18,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class AnyBase extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/AnyDerived1.java
+++ b/skyve-war/src/generated/java/modules/test/domain/AnyDerived1.java
@@ -17,7 +17,7 @@ import org.skyve.domain.messages.DomainException;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class AnyDerived1 extends AnyBase {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/AnyDerived2.java
+++ b/skyve-war/src/generated/java/modules/test/domain/AnyDerived2.java
@@ -17,7 +17,7 @@ import org.skyve.domain.messages.DomainException;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class AnyDerived2 extends AnyBase {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/ArcOneToMany.java
+++ b/skyve-war/src/generated/java/modules/test/domain/ArcOneToMany.java
@@ -21,7 +21,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class ArcOneToMany extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/ArcOneToOne.java
+++ b/skyve-war/src/generated/java/modules/test/domain/ArcOneToOne.java
@@ -19,7 +19,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class ArcOneToOne extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/DeleteDuringPostDelete.java
+++ b/skyve-war/src/generated/java/modules/test/domain/DeleteDuringPostDelete.java
@@ -19,7 +19,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class DeleteDuringPostDelete extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/Hierarchical.java
+++ b/skyve-war/src/generated/java/modules/test/domain/Hierarchical.java
@@ -23,7 +23,7 @@ import org.skyve.persistence.Persistence;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Hierarchical extends AbstractPersistentBean implements HierarchicalBean<Hierarchical> {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/InjectedDocument.java
+++ b/skyve-war/src/generated/java/modules/test/domain/InjectedDocument.java
@@ -19,7 +19,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public abstract class InjectedDocument extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/InverseManyToManyPersistent.java
+++ b/skyve-war/src/generated/java/modules/test/domain/InverseManyToManyPersistent.java
@@ -22,7 +22,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class InverseManyToManyPersistent extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/InverseOneToManyPersistent.java
+++ b/skyve-war/src/generated/java/modules/test/domain/InverseOneToManyPersistent.java
@@ -21,7 +21,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class InverseOneToManyPersistent extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/InverseOneToOnePersistent.java
+++ b/skyve-war/src/generated/java/modules/test/domain/InverseOneToOnePersistent.java
@@ -19,7 +19,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class InverseOneToOnePersistent extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/MappedBase.java
+++ b/skyve-war/src/generated/java/modules/test/domain/MappedBase.java
@@ -46,7 +46,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class MappedBase extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -121,7 +121,7 @@ public class MappedBase extends AbstractPersistentBean {
 	 * Enum 3
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Enum3 implements Enumeration {
 		one("one", "one"),
 		two("two", "two"),

--- a/skyve-war/src/generated/java/modules/test/domain/MappedExtensionJoinedStrategy.java
+++ b/skyve-war/src/generated/java/modules/test/domain/MappedExtensionJoinedStrategy.java
@@ -25,7 +25,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 @PolymorphicPersistentBean
 public abstract class MappedExtensionJoinedStrategy extends MappedBase {
 	/**

--- a/skyve-war/src/generated/java/modules/test/domain/MappedExtensionSingleStrategy.java
+++ b/skyve-war/src/generated/java/modules/test/domain/MappedExtensionSingleStrategy.java
@@ -25,7 +25,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 @PolymorphicPersistentBean
 public abstract class MappedExtensionSingleStrategy extends MappedBase {
 	/**

--- a/skyve-war/src/generated/java/modules/test/domain/MappedSubclassedJoinedStrategy.java
+++ b/skyve-war/src/generated/java/modules/test/domain/MappedSubclassedJoinedStrategy.java
@@ -19,7 +19,7 @@ import org.skyve.domain.messages.DomainException;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class MappedSubclassedJoinedStrategy extends MappedExtensionJoinedStrategyExtension {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/MappedSubclassedSingleStrategy.java
+++ b/skyve-war/src/generated/java/modules/test/domain/MappedSubclassedSingleStrategy.java
@@ -19,7 +19,7 @@ import org.skyve.domain.messages.DomainException;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class MappedSubclassedSingleStrategy extends MappedExtensionSingleStrategyExtension {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/Reachability.java
+++ b/skyve-war/src/generated/java/modules/test/domain/Reachability.java
@@ -28,7 +28,7 @@ import org.skyve.impl.domain.ChangeTrackingArrayList;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Reachability extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/test/domain/UniqueConstraintNonNullable.java
+++ b/skyve-war/src/generated/java/modules/test/domain/UniqueConstraintNonNullable.java
@@ -26,7 +26,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class UniqueConstraintNonNullable extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -53,7 +53,7 @@ public class UniqueConstraintNonNullable extends AbstractPersistentBean {
 	 * Enum 3
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Enum3 implements Enumeration {
 		one("one", "one"),
 		two("two", "two"),

--- a/skyve-war/src/generated/java/modules/test/domain/UniqueConstraintNullable.java
+++ b/skyve-war/src/generated/java/modules/test/domain/UniqueConstraintNullable.java
@@ -26,7 +26,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class UniqueConstraintNullable extends AbstractPersistentBean {
 	/**
 	 * For Serialization
@@ -53,7 +53,7 @@ public class UniqueConstraintNullable extends AbstractPersistentBean {
 	 * Enum 3
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Enum3 implements Enumeration {
 		one("one", "one"),
 		two("two", "two"),

--- a/skyve-war/src/generated/java/modules/test/domain/UniqueConstraintOptimisation.java
+++ b/skyve-war/src/generated/java/modules/test/domain/UniqueConstraintOptimisation.java
@@ -20,7 +20,7 @@ import org.skyve.impl.domain.AbstractPersistentBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class UniqueConstraintOptimisation extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/whosin/domain/MyStatus.java
+++ b/skyve-war/src/generated/java/modules/whosin/domain/MyStatus.java
@@ -17,7 +17,7 @@ import org.skyve.impl.domain.AbstractTransientBean;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class MyStatus extends AbstractTransientBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/whosin/domain/Office.java
+++ b/skyve-war/src/generated/java/modules/whosin/domain/Office.java
@@ -21,7 +21,7 @@ import org.skyve.impl.domain.types.jaxb.GeometryMapper;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Office extends AbstractPersistentBean {
 	/**
 	 * For Serialization

--- a/skyve-war/src/generated/java/modules/whosin/domain/Staff.java
+++ b/skyve-war/src/generated/java/modules/whosin/domain/Staff.java
@@ -50,7 +50,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class Staff extends AbstractPersistentBean implements HierarchicalBean<Staff> {
 	/**
 	 * For Serialization
@@ -101,7 +101,7 @@ public class Staff extends AbstractPersistentBean implements HierarchicalBean<St
 	 * Status
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Status implements Enumeration {
 		inTheOffice("inOffice", "In the Office"),
 		outOfTheOffice("outOffice", "Out of the Office"),

--- a/skyve-war/src/generated/java/modules/whosin/domain/StaffQualification.java
+++ b/skyve-war/src/generated/java/modules/whosin/domain/StaffQualification.java
@@ -32,7 +32,7 @@ import org.skyve.util.Util;
  */
 @XmlType
 @XmlRootElement
-@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 public class StaffQualification extends AbstractPersistentBean implements ChildBean<Staff> {
 	/**
 	 * For Serialization
@@ -68,7 +68,7 @@ public class StaffQualification extends AbstractPersistentBean implements ChildB
 	 * Type
 	 **/
 	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator", date = "2024-03-25T06:44:58.000Z")
 	public static enum Type implements Enumeration {
 		skill("Skill", "Skill"),
 		experience("Experience", "Experience"),

--- a/skyve-war/src/main/java/modules/admin/DataMaintenance/DataMaintenance.xml
+++ b/skyve-war/src/main/java/modules/admin/DataMaintenance/DataMaintenance.xml
@@ -186,6 +186,18 @@
 				<value code="secret" name="secret" description="Secret" />
 			</values>
 		</enum>
+		<boolean name="includeContent">
+			<documentation><![CDATA[Determines if content is to be included in the generated backup.]]></documentation>
+			<displayName>Content</displayName>
+			<description>Determines if content is included in the backup file.</description>
+			<defaultValue>true</defaultValue>
+		</boolean>
+		<boolean name="includeAuditLog">
+			<documentation><![CDATA[Determines if the audit log is to be included in the generated backup.]]></documentation>
+			<displayName>Audit Log</displayName>
+			<description>Determines if the audit log is to be included in the backup file.</description>
+			<defaultValue>true</defaultValue>
+		</boolean>
 	</attributes>
 	<conditions>
 		<condition name="backupSelected">

--- a/skyve-war/src/main/java/modules/admin/DataMaintenance/views/desktop/edit.xml
+++ b/skyve-war/src/main/java/modules/admin/DataMaintenance/views/desktop/edit.xml
@@ -106,11 +106,25 @@
 					</form>
 					<vbox pixelMemberPadding="5">
 						<form pixelWidth="225">
-							<column pixelWidth="75" />
-							<column pixelWidth="150" />
+							<column responsiveWidth="2"  />
+							<column responsiveWidth="4"  />
 							<row>
 								<item>
 									<combo binding="dataSensitivity" />
+								</item>
+							</row>
+						</form>
+						<form pixelWidth="225">
+							<column responsiveWidth="1"  />
+							<column responsiveWidth="1"  />
+							<column responsiveWidth="1"  />
+							<column responsiveWidth="1"  />
+							<row>
+								<item>
+									<checkBox binding="includeContent" triState="false" />
+								</item>
+								<item>
+									<checkBox binding="includeAuditLog" triState="false" />
 								</item>
 							</row>
 						</form>

--- a/skyve-war/src/main/java/modules/admin/DataMaintenance/views/edit.xml
+++ b/skyve-war/src/main/java/modules/admin/DataMaintenance/views/edit.xml
@@ -43,8 +43,6 @@
 				<form>
 					<column responsiveWidth="2" />
 					<column responsiveWidth="2" />
-					<column pixelWidth="250" />
-					<column responsiveWidth="2"  />
 					<row>
 						<item>
 							<button action="RefreshBackupList">
@@ -54,21 +52,21 @@
 							</button> 
 						</item>
 						<item>
-							<button action="DeleteBackup"  >
+							<button action="DeleteBackup">
 								<properties>
 									<c:property key="update">backups</c:property>
 								</properties>							
 							</button>
 						</item>
 						<item>
-							<button action="DownloadBackup" pixelWidth="400" >
+							<button action="DownloadBackup" pixelWidth="250">
 								<properties>
 									<c:property key="update">backups</c:property>
 								</properties>							
 							</button>
 						</item>
 						<item>
-							<button action="UploadBackup" >
+							<button action="UploadBackup" pixelWidth="250">
 								<properties>
 									<c:property key="update">backups</c:property>
 								</properties>							
@@ -77,9 +75,20 @@
 					</row>
 				</form>
 				<form>
+					<column responsiveWidth="1" />
+					<column responsiveWidth="1" />
+					<column responsiveWidth="1" />
+					<column responsiveWidth="1" />
+					<column responsiveWidth="1" />
 					<column responsiveWidth="2" />
 					<column responsiveWidth="2" />
 					<row>
+						<item>
+							<checkBox binding="includeContent" triState="false" />
+						</item>
+						<item>
+							<checkBox binding="includeAuditLog" triState="false" />
+						</item>
 						<item>
 							<combo binding="dataSensitivity" />
 						</item>


### PR DESCRIPTION
**Changes**
- Added `includeContent` & `includeAuditLog` attributes to `DataMaintenance`
- Added checkBoxes to view
- Nullify content if `includeContent` = null or attribute marked redacted
- Remove audits table from tables to save if `includeAudit` = false