### PR TITLE
[UUIDv7] Created UUIDv7, replace randomUUID() usage

### DIFF
--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -246,3 +246,7 @@ WILDCAT depends upon the following libraries:
 	* Spring Security
 		https://spring.io/projects/spring-security
 		https://github.com/spring-projects/spring-security/blob/master/license.txt (Apache v2)
+		
+	* uuid-creator
+		https://github.com/f4b6a3/uuid-creator
+		https://github.com/f4b6a3/uuid-creator/blob/master/LICENSE (MIT)

--- a/skyve-core/src/main/java/org/skyve/impl/domain/AbstractPersistentBean.java
+++ b/skyve-core/src/main/java/org/skyve/impl/domain/AbstractPersistentBean.java
@@ -1,10 +1,9 @@
 package org.skyve.impl.domain;
 
-import java.util.UUID;
-
 import org.skyve.domain.PersistentBean;
 import org.skyve.domain.types.OptimisticLock;
 import org.skyve.impl.domain.types.jaxb.OptimisticLockMapper;
+import org.skyve.impl.util.UUIDv7;
 
 import jakarta.persistence.MappedSuperclass;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -25,7 +24,7 @@ public abstract class AbstractPersistentBean extends AbstractBean implements Per
 	 */
 	private static final long serialVersionUID = -3598872446903601438L;
 
-	private String bizId = UUID.randomUUID().toString();
+	private String bizId = UUIDv7.create().toString();
 
 	private Integer bizVersion;
 

--- a/skyve-core/src/main/java/org/skyve/impl/domain/AbstractTransientBean.java
+++ b/skyve-core/src/main/java/org/skyve/impl/domain/AbstractTransientBean.java
@@ -1,8 +1,7 @@
 package org.skyve.impl.domain;
 
-import java.util.UUID;
-
 import org.skyve.domain.TransientBean;
+import org.skyve.impl.util.UUIDv7;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
@@ -12,7 +11,7 @@ import jakarta.xml.bind.annotation.XmlType;
 public abstract class AbstractTransientBean extends AbstractBean implements TransientBean {
 	private static final long serialVersionUID = -6469229627937972374L;
 
-	private String bizId = UUID.randomUUID().toString();
+	private String bizId = UUIDv7.create().toString();
 
 	private String bizCustomer;
 

--- a/skyve-core/src/main/java/org/skyve/impl/metadata/model/document/DocumentImpl.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/model/document/DocumentImpl.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.logging.Level;
 
 import org.skyve.domain.Bean;
@@ -36,6 +35,7 @@ import org.skyve.impl.metadata.repository.behaviour.ActionMetaData;
 import org.skyve.impl.metadata.repository.behaviour.BizletMetaData;
 import org.skyve.impl.persistence.AbstractDocumentQuery;
 import org.skyve.impl.persistence.AbstractPersistence;
+import org.skyve.impl.util.UUIDv7;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.MetaDataException;
 import org.skyve.metadata.controller.BizExportAction;
@@ -289,7 +289,7 @@ public final class DocumentImpl extends ModelImpl implements Document {
 			final Map<String, Object> p = new TreeMap<>();
 			
 			// Bean
-			p.put(Bean.DOCUMENT_ID, UUID.randomUUID().toString());
+			p.put(Bean.DOCUMENT_ID, UUIDv7.create().toString());
 			p.put(Bean.BIZ_KEY, null);
 			p.put(Bean.CUSTOMER_NAME, null);
 			p.put(Bean.DATA_GROUP_ID, null);

--- a/skyve-core/src/main/java/org/skyve/impl/util/UUIDv7.java
+++ b/skyve-core/src/main/java/org/skyve/impl/util/UUIDv7.java
@@ -1,0 +1,81 @@
+package org.skyve.impl.util;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Adapted from: <a href="https://github.com/f4b6a3/uuid-creator">f4b6a3/uuid-creator</a>
+ * 
+ * <pre>
+ * MIT License
+ * 
+ * Copyright (c) 2018-2023 Fabio Lima
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * </pre>
+ * 
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9562.html#name-uuid-version-7">UUIDv7 RFC</a>
+ */
+public class UUIDv7 {
+
+    private static SecureRandom random = new SecureRandom();
+
+    private UUIDv7() {
+    }
+
+    /**
+     * Create a unix epoch (ms) time based UUID (Version 7, variant 0b10) using the current time.
+     * 
+     * @return a time base UUID
+     */
+    public static UUID create() {
+        return create(Instant.now());
+    }
+
+    /**
+     * Create a unix epoch (ms) time based UUID (version 7, variant 0b10) using the
+     * provided instant. Most likely only useful for testing.
+     * 
+     * @return a time base UUID
+     */
+    public static UUID create(Instant instant) {
+        final long time = instant.toEpochMilli();
+        final long msb = (time << 16) | (random.nextLong() & 0x0fffL) | 0x7000L;
+        final long lsb = (random.nextLong() & 0x3fffffffffffffffL) | 0x8000000000000000L;
+        return new UUID(msb, lsb);
+    }
+
+    /**
+     * Extract the timestamp component from the provided UUID. No version or variant
+     * checking is performed (eg: providing a UUIDv4 will produce nonsense times).
+     * 
+     * @param uuid The UUID to convert
+     * @return the instant the provided UUID was created.
+     */
+    public static Instant toInstant(UUID uuid) {
+
+        long msb = uuid.getMostSignificantBits();
+
+        // Get the 48 bits of the timestamp, masking out any extra bits
+        long time = (msb >> 16) & 0x0000ffffffffffffl;
+
+        return Instant.ofEpochMilli(time);
+    }
+}

--- a/skyve-core/src/main/java/org/skyve/impl/util/UtilImpl.java
+++ b/skyve-core/src/main/java/org/skyve/impl/util/UtilImpl.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.UUID;
 import java.util.logging.Logger;
 
 import org.hibernate.internal.util.SerializationHelper;
@@ -563,7 +562,7 @@ public class UtilImpl {
 		}
 		else if (object instanceof AbstractPersistentBean) {
 			AbstractPersistentBean bean = (AbstractPersistentBean) object;
-			bean.setBizId(UUID.randomUUID().toString());
+			bean.setBizId(UUIDv7.create().toString());
 			bean.setBizLock(null);
 			bean.setBizVersion(null);
 

--- a/skyve-core/src/main/java/org/skyve/metadata/view/model/list/RelationTreeModelFilter.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/model/list/RelationTreeModelFilter.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.UUID;
 
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.skyve.CORE;
@@ -16,6 +15,7 @@ import org.skyve.domain.HierarchicalBean;
 import org.skyve.domain.PersistentBean;
 import org.skyve.domain.app.AppConstants;
 import org.skyve.domain.types.OptimisticLock;
+import org.skyve.impl.util.UUIDv7;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.Attribute;
 import org.skyve.metadata.model.Attribute.AttributeType;
@@ -153,7 +153,7 @@ public class RelationTreeModelFilter<T extends Bean> extends InMemoryFilter {
 		
 		Map<String, Object> properties = new TreeMap<>();
 		// concat a random ID to handle cyclic object graphs
-		properties.put(Bean.DOCUMENT_ID, bean.getBizId() + UUID.randomUUID().toString());
+		properties.put(Bean.DOCUMENT_ID, bean.getBizId() + UUIDv7.create().toString());
 		properties.put(PersistentBean.LOCK_NAME, new OptimisticLock(u.getName(), new Date()));
 		properties.put(PersistentBean.TAGGED_NAME, null);
 		properties.put(PersistentBean.FLAG_COMMENT_NAME, null);

--- a/skyve-core/src/main/java/org/skyve/util/DataBuilder.java
+++ b/skyve-core/src/main/java/org/skyve/util/DataBuilder.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.UUID;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -19,6 +18,7 @@ import org.skyve.impl.bind.BindUtil;
 import org.skyve.impl.metadata.customer.CustomerImpl;
 import org.skyve.impl.metadata.model.document.AssociationImpl;
 import org.skyve.impl.metadata.model.document.DocumentImpl;
+import org.skyve.impl.util.UUIDv7;
 import org.skyve.metadata.MetaDataException;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.Attribute;
@@ -580,7 +580,7 @@ public class DataBuilder {
 						BindUtil.set(result, name, new GeometryFactory().createPoint(new Coordinate(RANDOM.nextInt(180) - RANDOM.nextInt(180), RANDOM.nextInt(90) - RANDOM.nextInt(90))));
 						break;
 					case id:
-						BindUtil.set(result, name, UUID.randomUUID().toString());
+						BindUtil.set(result, name, UUIDv7.create().toString());
 						break;
 					case markup:
 					case memo:

--- a/skyve-core/src/main/java/org/skyve/util/test/TestUtil.java
+++ b/skyve-core/src/main/java/org/skyve/util/test/TestUtil.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -39,6 +38,7 @@ import org.skyve.impl.metadata.model.document.field.validator.LongValidator;
 import org.skyve.impl.metadata.model.document.field.validator.TextValidator.ValidatorType;
 import org.skyve.impl.persistence.AbstractDocumentQuery;
 import org.skyve.impl.util.TimeUtil;
+import org.skyve.impl.util.UUIDv7;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.Attribute;
 import org.skyve.metadata.model.Attribute.AttributeType;
@@ -183,7 +183,7 @@ public class TestUtil {
 						new Coordinate(RANDOM.nextInt(10), RANDOM.nextInt(10))));
 				break;
 			case id:
-				BindUtil.set(bean, name, UUID.randomUUID().toString());
+				BindUtil.set(bean, name, UUIDv7.create().toString());
 				break;
 			case markup:
 			case memo:
@@ -321,7 +321,7 @@ public class TestUtil {
 					BindUtil.set(result, name, new GeometryFactory().createPoint(new Coordinate(0, 0)));
 					break;
 				case id:
-					BindUtil.set(result, name, UUID.randomUUID().toString());
+					BindUtil.set(result, name, UUIDv7.create().toString());
 					break;
 				case markup:
 				case memo:

--- a/skyve-core/src/test/java/org/skyve/util/UUIDv7Test.java
+++ b/skyve-core/src/test/java/org/skyve/util/UUIDv7Test.java
@@ -1,0 +1,72 @@
+package org.skyve.util;
+
+import static java.util.stream.Collectors.toSet;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.skyve.impl.util.UUIDv7;
+
+public class UUIDv7Test {
+
+    private final int iterationCount = 100_000;
+
+    @Test
+    public void duplicateTest() {
+
+        Set<String> generated = new TreeSet<>();
+
+        for (int i = iterationCount; i > 0; --i) {
+            generated.add(UUIDv7.create()
+                                .toString());
+        }
+
+        assertThat(generated.size(), is(iterationCount));
+    }
+
+    @Test
+    public void sameTimeTest() {
+
+        Instant now = Instant.now();
+
+        Set<String> generated = new TreeSet<>();
+
+        for (int i = iterationCount; i > 0; --i) {
+            generated.add(UUIDv7.create(now)
+                                .toString());
+        }
+
+        // Even generating UUIDs in the same millisecond leaves
+        // 72 bits of randomness; duplicates are very unlikely
+        assertThat(generated.size(), is(iterationCount));
+
+        // The first 48 bits (13 characters in the string representation)
+        // should be identical between all of these UUIDs as they were created
+        // using the same millisecond
+        Set<String> timePrefix = generated.stream()
+                                          .map(s -> s.substring(0, 13))
+                                          .limit(2000)
+                                          .collect(toSet());
+
+        assertThat(timePrefix.size(), is(1));
+    }
+
+    @Test
+    public void testToInstant() {
+
+        Instant now = Instant.now();
+
+        UUID uuid = UUIDv7.create(now);
+
+        Instant result = UUIDv7.toInstant(uuid);
+
+        assertThat(result, is(now.truncatedTo(ChronoUnit.MILLIS)));
+    }
+
+}


### PR DESCRIPTION
[Implementation of UUIDv7](https://trello.com/c/1b00WS3p)

Since this is standalone from the Audit archiving I presume we can drop this straight onto master.

I've replaced the various `UUID.randomUUID()` calls in _skyve-core_ with `UUIDv7.create()`. There's still a handful of `UUID.randomUUID()` calls in the other projects, but they appear to either be test code, or generating random tokens (where I presume we want to leave the token entirely random).

Also: is the included MIT license in the javadoc for UUIDv7 sufficient?