### PR TITLE
Argon2 Password Encoder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 		<owasp.json.sanitizer.version>[1.0,)</owasp.json.sanitizer.version>
 		<pdfbox.version>1.8.4</pdfbox.version>
 		<pf4j.version>3.10.0</pf4j.version>
+		<bouncycastle.version>1.76</bouncycastle.version>
 		<poi.version>5.2.3</poi.version>
 		<primefaces.version>13.0.5</primefaces.version>
 		<primefaces-extensions.version>13.0.5</primefaces-extensions.version>
@@ -432,12 +433,17 @@
 				<artifactId>spring-jdbc</artifactId>
 				<version>${spring.version}</version>
 			</dependency>
-		
 			<dependency>
 				<groupId>org.pf4j</groupId>
 				<artifactId>pf4j</artifactId>
 				<version>${pf4j.version}</version>
 			</dependency>
+			<dependency>
+			    <groupId>org.bouncycastle</groupId>
+			    <artifactId>bcprov-jdk18on</artifactId>
+			    <version>${bouncycastle.version}</version>
+			</dependency>
+			
 			<!-- html reports and html to pdf conversion -->
 			<dependency>
 				<groupId>org.freemarker</groupId>

--- a/skyve-ext/pom.xml
+++ b/skyve-ext/pom.xml
@@ -121,6 +121,12 @@
 			<groupId>org.pf4j</groupId>
 			<artifactId>pf4j</artifactId>
 		</dependency>
+		<dependency>
+		    <groupId>org.bouncycastle</groupId>
+		    <artifactId>bcprov-jdk18on</artifactId>
+		    <scope>compile</scope>
+		</dependency>
+		
 		<!-- html reports and html to pdf conversion -->
 		<dependency>
 			<groupId>org.freemarker</groupId>

--- a/skyve-ext/src/main/java/org/skyve/EXT.java
+++ b/skyve-ext/src/main/java/org/skyve/EXT.java
@@ -576,7 +576,7 @@ public class EXT {
 			result = "{scrypt}" + SCryptPasswordEncoder.defaultsForSpringSecurity_v5_8().encode(clearText);
 		}
 		else if ("argon2".equals(passwordHashingAlgorithm)) {
-			result = "{argon2}" + new Argon2PasswordEncoder(16, 32, 1, 19 * 1024, 2).encode(clearText);
+			result = "{argon2}" + Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8().encode(clearText);
 		}
 		else {
 			throw new DomainException(passwordHashingAlgorithm + " not supported");

--- a/skyve-ext/src/main/java/org/skyve/EXT.java
+++ b/skyve-ext/src/main/java/org/skyve/EXT.java
@@ -71,6 +71,7 @@ import org.skyve.util.JSON;
 import org.skyve.util.Mail;
 import org.skyve.util.PushMessage;
 import org.skyve.util.Util;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
@@ -573,6 +574,9 @@ public class EXT {
 		}
 		else if ("scrypt".equals(passwordHashingAlgorithm)) {
 			result = "{scrypt}" + SCryptPasswordEncoder.defaultsForSpringSecurity_v5_8().encode(clearText);
+		}
+		else if ("argon2".equals(passwordHashingAlgorithm)) {
+			result = "{argon2}" + new Argon2PasswordEncoder(16, 32, 1, 19 * 1024, 2).encode(clearText);
 		}
 		else {
 			throw new DomainException(passwordHashingAlgorithm + " not supported");

--- a/skyve-ext/src/test/java/org/skyve/EXTParameterisedTest.java
+++ b/skyve-ext/src/test/java/org/skyve/EXTParameterisedTest.java
@@ -40,8 +40,10 @@ public class EXTParameterisedTest {
 				{ "bcrypt", longPassword },
 				{ "pbkdf2", shortPassword },
 				{ "pbkdf2", longPassword },
-//				{ "scrypt", shortPassword },
-//				{ "scrypt", longPassword },
+				{ "scrypt", shortPassword },
+				{ "scrypt", longPassword },
+				{ "argon2", shortPassword },
+				{ "argon2", longPassword },
 		});
 	}
 
@@ -62,7 +64,7 @@ public class EXTParameterisedTest {
 
 		// verify the result
 		// System.out.println(String.format("%s (%d): %s (%d)", algorithm, clearText.length(), result, result.length()));
-		assertThat("Encoded length should be less than 100 chars", result.length() <= 255, is(true));
+		assertThat("Encoded length should be less than 255 chars", result.length() <= 255, is(true));
 		assertThat(result, is(not(clearText)));
 	}
 }


### PR DESCRIPTION
[Trello](https://trello.com/c/A0Ry267H)

**Changes**
- Added `bouncycastle` dependency to `skyve-ext`
- Added Argon2 option to `EXT.hashPassword`
- Updated `EXTParameterisedTest`

**Note**
- The usage of Argon2PasswordEncoder requires additional dependency `bouncycastle`
- Argon2PasswordEncoder declaration is customised to increase memory config
- Foundry new project json should default to argon2 (project root and docker files) when upgraded