### PR TITLE
Wip/logging overhaul

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,20 +510,13 @@
 	    		<version>${weld.version}</version>
 				<scope>test</scope>
 			</dependency>
-
-			<!-- Runtime dependencies -->
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
 				<version>${slf4j-api.version}</version>
-				<scope>runtime</scope>
 			</dependency>
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-jdk14</artifactId>
-				<version>${slf4j-api.version}</version>
-				<scope>runtime</scope>
-			</dependency>
+
+			<!-- Runtime dependencies -->
 			<dependency>
 				<groupId>net.sf.supercsv</groupId>
 				<artifactId>super-csv</artifactId>

--- a/skyve-content/pom.xml
+++ b/skyve-content/pom.xml
@@ -106,6 +106,8 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+			<!-- Actually excluded in zip.xml for the maven-assembly-plugin -->
 		</dependency>
 
 		<!-- test dependencies -->

--- a/skyve-content/pom.xml
+++ b/skyve-content/pom.xml
@@ -103,16 +103,9 @@
 			<version>${lucene.version}</version>
 			<scope>runtime</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<scope>runtime</scope>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/skyve-content/pom.xml
+++ b/skyve-content/pom.xml
@@ -106,6 +106,11 @@
 
 		<dependency>
 			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>
 			<scope>runtime</scope>
 		</dependency>

--- a/skyve-content/src/main/java/org/skyve/impl/content/TikaTextExtractor.java
+++ b/skyve-content/src/main/java/org/skyve/impl/content/TikaTextExtractor.java
@@ -2,7 +2,6 @@ package org.skyve.impl.content;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.logging.Level;
 
 import org.apache.tika.Tika;
 import org.apache.tika.language.detect.LanguageDetector;
@@ -15,9 +14,14 @@ import org.skyve.content.AttachmentContent;
 import org.skyve.content.TextExtractor;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Extension(points = {TextExtractor.class})
 public class TikaTextExtractor implements TextExtractor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TikaTextExtractor.class);
+
 	private static final Tika TIKA = new Tika();
 	
 	@Override
@@ -29,9 +33,7 @@ public class TikaTextExtractor implements TextExtractor {
 				result = UtilImpl.processStringValue(TIKA.parseToString(new ByteArrayInputStream(processedMarkup.getBytes())));
 			}
 			catch (Throwable t) { // include Errors like NoClassDefFound
-				UtilImpl.LOGGER.log(Level.SEVERE, 
-										"TextExtractorImpl.extractTextFromMarkup(): Markup could not be extracted by TIKA",
-										t);
+				LOGGER.error("TextExtractorImpl.extractTextFromMarkup(): Markup could not be extracted by TIKA", t);
 			}
 		}
 		return result;
@@ -93,9 +95,7 @@ public class TikaTextExtractor implements TextExtractor {
 			}
 		}
 		catch (Throwable t) { // include Errors like NoClassDefFound
-			UtilImpl.LOGGER.log(Level.SEVERE, 
-									"TextExtractorImpl.extractTextFromContent(): Attachment could not be extracted by TIKA",
-									t);
+			LOGGER.error("TextExtractorImpl.extractTextFromContent(): Attachment could not be extracted by TIKA", t);
 		}
 		
 		return (result.length() == 0) ? null : result.toString();
@@ -120,9 +120,7 @@ public class TikaTextExtractor implements TextExtractor {
 				}
 			}
 			catch (Throwable t) { // include Errors like NoClassDefFound
-				UtilImpl.LOGGER.log(Level.SEVERE, 
-										"TextExtractorImpl.sniffContentType(): Attachment could not be sniffed by TIKA",
-										t);
+				LOGGER.error("TextExtractorImpl.sniffContentType(): Attachment could not be sniffed by TIKA", t);
 			}
 		}
 	}

--- a/skyve-content/src/main/java/org/skyve/impl/content/jdbc/JDBCRemoteContentManagerServer.java
+++ b/skyve-content/src/main/java/org/skyve/impl/content/jdbc/JDBCRemoteContentManagerServer.java
@@ -11,7 +11,8 @@ import org.skyve.content.BeanContent;
 import org.skyve.content.ContentManager;
 import org.skyve.impl.cache.StateUtil;
 import org.skyve.impl.util.UtilImpl;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is used to expose the content server via JDBC to another skyve server.
@@ -60,6 +61,8 @@ public class JDBCRemoteContentManagerServer {
 	static final String REMOVE_ATTACHMENT_FUNCTION_NAME = "REMOVE_ATTACHMENT";
 	static final String GOOGLE_SEARCH_FUNCTION_NAME = "GOOGLE_SEARCH";
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(JDBCRemoteContentManagerServer.class);
+
 	private static Server server = null;
 
 	// Disallow instantiation
@@ -77,7 +80,7 @@ public class JDBCRemoteContentManagerServer {
 			server = Server.createTcpServer(UtilImpl.CONTENT_JDBC_SERVER_ARGS.split("\\s+")).start();
 			
 			// register the database functions
-			Util.LOGGER.info("REGISTER DATABASE FUNCTIONS FOR REMOTE CONTENT CALLS");
+			LOGGER.info("REGISTER DATABASE FUNCTIONS FOR REMOTE CONTENT CALLS");
 			try (Connection c = EXT.getDataStoreConnection(UtilImpl.DATA_STORES.get(CONTENT_DATA_STORE_NAME))) {
 				try (CallableStatement s = c.prepareCall(String.format("DROP ALIAS IF EXISTS %s",
 																		PUT_BEAN_FUNCTION_NAME))) {
@@ -143,7 +146,7 @@ public class JDBCRemoteContentManagerServer {
 					s.execute();
 				}
 			}
-			Util.LOGGER.info("REGISTERED DATABASE FUNCTIONS FOR REMOTE CONTENT CALLS");
+			LOGGER.info("REGISTERED DATABASE FUNCTIONS FOR REMOTE CONTENT CALLS");
 		}
 		catch (SQLException e) {
 			throw new IllegalStateException("Could not startup JDBCRemoteContentManagerServer", e);

--- a/skyve-content/src/main/java/org/skyve/impl/content/lucene/LuceneContentManager.java
+++ b/skyve-content/src/main/java/org/skyve/impl/content/lucene/LuceneContentManager.java
@@ -55,6 +55,8 @@ import org.skyve.impl.content.FileSystemContentManager;
 import org.skyve.impl.content.TikaTextExtractor;
 import org.skyve.impl.util.TimeUtil;
 import org.skyve.impl.util.UtilImpl;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 // If we want to use multiple indices for beans and attachments like elastic we will need 
 // 2 dirs underneath CONTENT/SKYVE_CONTENT/ and 2 writer instances
@@ -64,6 +66,8 @@ import org.skyve.impl.util.UtilImpl;
 public class LuceneContentManager extends FileSystemContentManager {
 	static final char BEAN_CONTENT_SUFFIX = '~';
 	
+    private static final Logger CONTENT_LOGGER = Category.CONTENT.logger();
+
 	private static Directory directory;
 	private static Analyzer analyzer;
 	private static IndexWriter writer;
@@ -168,7 +172,7 @@ public class LuceneContentManager extends FileSystemContentManager {
 		// Last modified
 		document.add(new StoredField(LAST_MODIFIED, TimeUtil.formatISODate(new Date(), true)));
 			
-		if (UtilImpl.CONTENT_TRACE) UtilImpl.LOGGER.info("LuceneContentManager.put(): " + bizContentId);
+		if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.info("LuceneContentManager.put(): " + bizContentId);
 		writer.updateDocument(new Term(Bean.DOCUMENT_ID, bizContentId), document);
 	}
 	
@@ -276,7 +280,7 @@ public class LuceneContentManager extends FileSystemContentManager {
 		}
 		document.add(new StoredField(LAST_MODIFIED, TimeUtil.formatISODate(attachment.getLastModified(), true)));
 
-		if (UtilImpl.CONTENT_TRACE) UtilImpl.LOGGER.info("LuceneContentManager.put(): " + bizId);
+		if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.info("LuceneContentManager.put(): " + bizId);
 		String contentId = attachment.getContentId();
 		// Even if existing, add the content ID to the document as it could be a re-index
 		document.add(new TextField(CONTENT_ID, contentId, Store.YES));
@@ -342,7 +346,7 @@ public class LuceneContentManager extends FileSystemContentManager {
 			result.setLastModified(lastModified);
 			result.setContentType(contentType);
 			result.setContentId(contentId);
-			if (UtilImpl.CONTENT_TRACE) UtilImpl.LOGGER.info("LuceneContentManager.get(" + contentId + "): exists");
+			if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.info("LuceneContentManager.get(" + contentId + "): exists");
 			return result;
 		}
 	}

--- a/skyve-content/zip.xml
+++ b/skyve-content/zip.xml
@@ -21,6 +21,7 @@
 			<outputDirectory>lib</outputDirectory>
 			<excludes>
 				<exclude>${project.groupId}:${project.artifactId}:jar:*</exclude>
+				<exclude>org.slf4j:slf4j-api</exclude>
 			</excludes>
 		</dependencySet>
 	</dependencySets>

--- a/skyve-core/src/main/java/org/skyve/impl/bind/BindUtil.java
+++ b/skyve-core/src/main/java/org/skyve/impl/bind/BindUtil.java
@@ -50,7 +50,6 @@ import org.skyve.impl.metadata.model.document.field.ConvertibleField;
 import org.skyve.impl.metadata.model.document.field.Field;
 import org.skyve.impl.metadata.repository.ProvidedRepositoryFactory;
 import org.skyve.impl.util.NullTolerantBeanComparator;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.MetaDataException;
 import org.skyve.metadata.SortDirection;
 import org.skyve.metadata.customer.Customer;
@@ -72,6 +71,8 @@ import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
 import org.skyve.util.Binder.TargetMetaData;
 import org.skyve.util.ExpressionEvaluator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -82,6 +83,8 @@ import jakarta.annotation.Nullable;
 public final class BindUtil {
 	private static final String DEFAULT_DISPLAY_DATE_FORMAT = "dd/MM/yyyy";
 	private static final DeproxyingPropertyUtilsBean PROPERTY_UTILS = new DeproxyingPropertyUtilsBean();
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(BindUtil.class); 
 	
 	public static @Nonnull String formatMessage(@Nonnull String message, @Nonnull Bean... beans) {
 		return formatMessage(message, null, beans);
@@ -1504,13 +1507,13 @@ public final class BindUtil {
 				}
 			}
 			catch (Exception e) {
-				UtilImpl.LOGGER.severe("Could not BindUtil.get(" + bean + ", " + binding + ")!");
-				UtilImpl.LOGGER.severe("The subsequent stack trace relates to obtaining bean property " + simpleBinding + " from " + currentBean);
-				UtilImpl.LOGGER.severe("If the stack trace contains something like \"Unknown property '" + simpleBinding + 
+				LOGGER.error("Could not BindUtil.get(" + bean + ", " + binding + ")!");
+				LOGGER.error("The subsequent stack trace relates to obtaining bean property " + simpleBinding + " from " + currentBean);
+				LOGGER.error("If the stack trace contains something like \"Unknown property '" + simpleBinding + 
 										"' on class 'class <blahblah>$$EnhancerByCGLIB$$$<blahblah>'\"" + 
 										" then you'll need to use Util.deproxy() before trying to bind to properties in the hibernate proxy.");
-				UtilImpl.LOGGER.severe("See https://github.com/skyvers/skyve-cookbook/blob/master/README.md#deproxy for details");
-				UtilImpl.LOGGER.severe("Exception message = " + e.getMessage());
+				LOGGER.error("See https://github.com/skyvers/skyve-cookbook/blob/master/README.md#deproxy for details");
+				LOGGER.error("Exception message = " + e.getMessage());
 				throw new MetaDataException(e);
 			}
 

--- a/skyve-core/src/main/java/org/skyve/impl/bind/ELExpressionEvaluator.java
+++ b/skyve-core/src/main/java/org/skyve/impl/bind/ELExpressionEvaluator.java
@@ -22,12 +22,13 @@ import org.skyve.domain.types.Decimal2;
 import org.skyve.domain.types.Decimal5;
 import org.skyve.impl.metadata.model.document.DocumentImpl;
 import org.skyve.impl.metadata.user.UserImpl;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.util.ExpressionEvaluator;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -37,7 +38,9 @@ import jakarta.el.ELProcessor;
 public class ELExpressionEvaluator extends ExpressionEvaluator {
 	public static final String EL_PREFIX = "el";
 	public static final String RTEL_PREFIX = "rtel";
-	
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ELExpressionEvaluator.class); 
+
 	// Regex expressions to find the start of an EL expression
 	private static final String[] COMMENCING_REGEX_TOKENS = new String[] {"bean\\s*\\.",
 																		"user\\s*\\.",
@@ -321,7 +324,7 @@ public class ELExpressionEvaluator extends ExpressionEvaluator {
 					}
 				}
 				catch (Exception e) {
-					UtilImpl.LOGGER.warning(input + "is malformed and caused exception " + e.getClass() + ":-" + e.getMessage());
+				    LOGGER.warn("{} is malformed and caused exception {} :- {}", input, e.getClass(), e.getMessage());
 				}
 			}
 			else { // ending an expression chain

--- a/skyve-core/src/main/java/org/skyve/impl/domain/AbstractBean.java
+++ b/skyve-core/src/main/java/org/skyve/impl/domain/AbstractBean.java
@@ -8,6 +8,7 @@ import java.util.TreeMap;
 
 import org.apache.commons.beanutils.LazyDynaMap;
 import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.deltaspike.core.api.provider.BeanProvider;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.skyve.CORE;
 import org.skyve.domain.Bean;
@@ -21,9 +22,15 @@ import org.skyve.metadata.model.Attribute;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.util.Binder.TargetMetaData;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractBean implements Bean {
 	private static final long serialVersionUID = -5241897716950549433L;
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+    private static final Logger DIRTY_LOGGER = Category.DIRTY.logger();
 
 	// Holds the old (replaced) values when a setter is called.
 	private Map<String, Object> originalValues = new TreeMap<>();
@@ -45,13 +52,17 @@ public abstract class AbstractBean implements Bean {
 				if (oldValue == null) {
 					if (propertyValue != null) {
 						originalValues.put(propertyName, oldValue);
-						if (UtilImpl.DIRTY_TRACE) UtilImpl.LOGGER.info("AbstractBean.preset(): Bean " + toString() + " is DIRTY : property " + propertyName + " is now " + propertyValue + " from " + oldValue);
+                        if (UtilImpl.DIRTY_TRACE)
+                            DIRTY_LOGGER.info("AbstractBean.preset(): Bean {} is DIRTY : property {} is now {} from {}", 
+                                    toString(), propertyName, propertyValue, oldValue);
 					}
 				}
 				else {
 					if ((propertyValue == null) || (! oldValue.equals(propertyValue))) {
 						originalValues.put(propertyName, oldValue);
-						if (UtilImpl.DIRTY_TRACE) UtilImpl.LOGGER.info("AbstractBean.preset(): Bean " + toString() + " is DIRTY : property " + propertyName + " is now " + propertyValue + " from " + oldValue);
+						if (UtilImpl.DIRTY_TRACE) 
+                            DIRTY_LOGGER.info("AbstractBean.preset(): Bean {} is DIRTY : property {} is now {} from {}",
+                                    toString(), propertyName, propertyValue, oldValue);
 					}
 				}
 			}
@@ -137,7 +148,10 @@ public abstract class AbstractBean implements Bean {
 							Object collection = BindUtil.get(this, propertyName);
 							if (collection instanceof PersistentCollection) { // persistent
 								if (((PersistentCollection) collection).isDirty()) {
-									if (UtilImpl.DIRTY_TRACE) UtilImpl.LOGGER.info("AbstractBean.isChanged(): Bean " + toString() + " is DIRTY : persistent collection " + propertyName + " is dirty ");
+									if (UtilImpl.DIRTY_TRACE) 
+                                        DIRTY_LOGGER.info(
+                                                "AbstractBean.isChanged(): Bean {} is DIRTY : persistent collection {} is dirty",
+                                                toString(), propertyName);
 									return true;
 								}
 							}
@@ -150,10 +164,12 @@ public abstract class AbstractBean implements Bean {
 			}
 		}
 		else {
-			if (UtilImpl.DIRTY_TRACE) UtilImpl.LOGGER.info("AbstractBean.isChanged(): Bean " + toString() + " is DIRTY : originalValues is not empty " + originalValues);
+            if (UtilImpl.DIRTY_TRACE)
+                DIRTY_LOGGER.info("AbstractBean.isChanged(): Bean {} is DIRTY : originalValues is not empty",
+                        toString(), originalValues);
 			return true;
 		}
-		
+
 		return false;
 	}
 	

--- a/skyve-core/src/main/java/org/skyve/impl/generate/DomainGenerator.java
+++ b/skyve-core/src/main/java/org/skyve/impl/generate/DomainGenerator.java
@@ -22,8 +22,13 @@ import org.skyve.metadata.module.Module.DocumentRef;
 import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.metadata.view.View;
 import org.skyve.metadata.view.View.ViewType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class DomainGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DomainGenerator.class);
+
 	protected static final String DECIMAL2 = "Decimal2";
 	protected static final String DECIMAL5 = "Decimal5";
 	protected static final String DECIMAL10 = "Decimal10";
@@ -297,9 +302,9 @@ public abstract class DomainGenerator {
 		catch (Exception e) {
 			throw new MetaDataException("Validation problem encountered: " + e.getLocalizedMessage(), e);
 		}
-		finally {
-			UtilImpl.LOGGER.info("Customer " + customerName + " validated in " + (System.currentTimeMillis() - millis) + " millis");
-		}
+        finally {
+            LOGGER.info("Customer {} validated in {} millis", customerName, (System.currentTimeMillis() - millis));
+        }
 	}
 	
 	/**

--- a/skyve-core/src/main/java/org/skyve/impl/generate/JPADomainGenerator.java
+++ b/skyve-core/src/main/java/org/skyve/impl/generate/JPADomainGenerator.java
@@ -10,7 +10,6 @@ import java.util.TreeSet;
 
 import org.skyve.domain.Bean;
 import org.skyve.impl.metadata.model.document.DocumentImpl;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.MetaDataException;
 import org.skyve.metadata.SortDirection;
 import org.skyve.metadata.customer.Customer;
@@ -27,8 +26,13 @@ import org.skyve.metadata.model.document.Reference;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.module.Module.DocumentRef;
 import org.skyve.metadata.repository.ProvidedRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class JPADomainGenerator extends DomainGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JPADomainGenerator.class);
+
 	JPADomainGenerator(boolean debug,
 						boolean multiTenant,
 						ProvidedRepository repository,
@@ -97,7 +101,7 @@ public final class JPADomainGenerator extends DomainGenerator {
 									String packagePath,
 									String documentName) 
 	throws IOException {
-		if (debug) UtilImpl.LOGGER.info(packagePath + '.' + documentName);
+		if (debug) LOGGER.info(packagePath + '.' + documentName);
 		Persistent persistent = document.getPersistent();
 		fw.append("package ").append(packagePath).append(";\n\n");
 

--- a/skyve-core/src/main/java/org/skyve/impl/generate/OverridableDomainGenerator.java
+++ b/skyve-core/src/main/java/org/skyve/impl/generate/OverridableDomainGenerator.java
@@ -45,7 +45,6 @@ import org.skyve.impl.metadata.model.document.field.Enumeration.EnumeratedValue;
 import org.skyve.impl.metadata.model.document.field.Field;
 import org.skyve.impl.metadata.model.document.field.Field.IndexType;
 import org.skyve.impl.metadata.model.document.field.LengthField;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.MetaDataException;
 import org.skyve.metadata.SortDirection;
 import org.skyve.metadata.controller.ServerSideAction;
@@ -72,6 +71,8 @@ import org.skyve.metadata.module.Module;
 import org.skyve.metadata.module.Module.DocumentRef;
 import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.util.test.SkyveFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Run through all vanilla modules and create the base class data structure and the extensions (if required).
@@ -80,6 +81,9 @@ import org.skyve.util.test.SkyveFactory;
  * Generate base classes.
  */
 public final class OverridableDomainGenerator extends DomainGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OverridableDomainGenerator.class);
+
 	private static class DomainClass {
 		private boolean isAbstract = false;
 		// attribute name -> attribute type
@@ -361,9 +365,7 @@ public final class OverridableDomainGenerator extends DomainGenerator {
 
 		// Make a orm.hbm.xml file
 		Path mappingFilePath = Paths.get(generatedSrcPath, packagePath, moduleName + "_orm.hbm.xml");
-		if (debug) {
-			UtilImpl.LOGGER.fine("Mapping file is " + mappingFilePath);
-		}
+	    LOGGER.debug("Mapping file is {}", mappingFilePath);
 
 		final StringBuilder filterDefinitions = new StringBuilder(1024);
 		StringBuilder mappingFileContents = new StringBuilder(4096);
@@ -500,7 +502,7 @@ public final class OverridableDomainGenerator extends DomainGenerator {
 			String className = factoryFile.getPath().replaceAll("\\\\|\\/", ".")
 													.replace(srcPath.replaceAll("\\\\|\\/", "."), "");
 
-			if (debug) UtilImpl.LOGGER.fine("Found factory " + className);
+			LOGGER.debug("Found factory " + className);
 			className = className.replaceFirst("[.][^.]+$", "");
 
 			// scan the classpath for the class
@@ -3945,12 +3947,7 @@ public final class OverridableDomainGenerator extends DomainGenerator {
 
 				if (document.getPersistent() == null || attribute.isPersistent() == false) {
 					// return, attribute is transient
-					if (debug) {
-						UtilImpl.LOGGER.fine(new StringBuilder(128).append("Ignoring transient attribute ")
-																	.append(attribute.getName())
-																	.append(" for document ")
-																	.append(document.getName()).toString());
-					}
+					LOGGER.debug("Ignoring transient attribute {} for document {}", attribute.getName(), document.getName());
 					continue;
 				}
 

--- a/skyve-core/src/main/java/org/skyve/impl/generate/QueryGenerator.java
+++ b/skyve-core/src/main/java/org/skyve/impl/generate/QueryGenerator.java
@@ -6,8 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.skyve.impl.metadata.repository.ProvidedRepositoryFactory;
 import org.skyve.impl.metadata.repository.LocalDesignRepository;
+import org.skyve.impl.metadata.repository.ProvidedRepositoryFactory;
 import org.skyve.impl.metadata.repository.module.BizQLMetaData;
 import org.skyve.impl.metadata.repository.module.MetaDataQueryColumnMetaData;
 import org.skyve.impl.metadata.repository.module.MetaDataQueryContentColumnMetaData;
@@ -16,7 +16,6 @@ import org.skyve.impl.metadata.repository.module.MetaDataQueryProjectedColumnMet
 import org.skyve.impl.metadata.repository.module.ModuleMetaData;
 import org.skyve.impl.metadata.repository.module.QueryMetaData;
 import org.skyve.impl.metadata.repository.module.SQLMetaData;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.util.XMLMetaData;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.document.Document;
@@ -28,8 +27,13 @@ import org.skyve.metadata.module.query.MetaDataQueryDefinition;
 import org.skyve.metadata.module.query.QueryDefinition;
 import org.skyve.metadata.module.query.SQLDefinition;
 import org.skyve.metadata.repository.ProvidedRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class QueryGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(QueryGenerator.class);
+
 	private QueryGenerator() {
 		// do nothing
 	}
@@ -146,7 +150,7 @@ public class QueryGenerator {
 		Customer customer = repository.getCustomer(customerName);
 		Module module = repository.getModule(customer, moduleName);
 		File file = new File("./generatedQueries.xml");
-		UtilImpl.LOGGER.info("Output is written to " + file.getCanonicalPath());
+		LOGGER.info("Output is written to {}", file.getCanonicalPath());
 		try (PrintWriter out = new PrintWriter(file)) {
 			out.println(generateQueryXML(customer, module, includeAssociationBizKeys));
 			out.flush();

--- a/skyve-core/src/main/java/org/skyve/impl/generate/ViewGenerator.java
+++ b/skyve-core/src/main/java/org/skyve/impl/generate/ViewGenerator.java
@@ -62,8 +62,13 @@ import org.skyve.metadata.view.Action;
 import org.skyve.metadata.view.View.ViewType;
 import org.skyve.util.Binder;
 import org.skyve.util.Binder.TargetMetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ViewGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ViewGenerator.class);
+
 // Revert the responsive gutter centred layout
 //	private static final Integer ONE = Integer.valueOf(1);
 //	private static final Integer TWO = Integer.valueOf(2);
@@ -579,12 +584,12 @@ public class ViewGenerator {
 		file.mkdirs();
 		filePath.append("generatedEdit.xml");
 		file = new File(filePath.toString());
-		UtilImpl.LOGGER.info("Output is written to " + file.getCanonicalPath());
+		LOGGER.info("Output is written to {}", file.getCanonicalPath());
 		try (PrintWriter out = new PrintWriter(file)) {
 			out.println(generateEditViewXML(customer, document, customerOverridden, uxui != null));
 			out.flush();
 		}
-		UtilImpl.LOGGER.info("Remember to rename this to 'edit.xml' to make this view active.");
+		LOGGER.info("Remember to rename this to 'edit.xml' to make this view active.");
 	}
 
 	public static void main(String[] args) throws Exception {
@@ -634,8 +639,8 @@ public class ViewGenerator {
 							new ViewGenerator(repository).writeEditView(srcPath, module, document, customer, customerOverridden, uxui);
 						}
 						catch (Exception e) {
-							UtilImpl.LOGGER.warning(String.format("Failed to generate edit view for %s.%s, %s.",
-									module.getName(), document.getName(), e.getMessage()));
+							LOGGER.warn("Failed to generate edit view for {}.{}, {}.",
+									module.getName(), document.getName(), e.getMessage());
 						}
 					}
 				}

--- a/skyve-core/src/main/java/org/skyve/impl/metadata/customer/CustomerImpl.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/customer/CustomerImpl.java
@@ -9,7 +9,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.logging.Level;
 
 import org.skyve.bizport.BizPortWorkbook;
 import org.skyve.domain.Bean;
@@ -54,7 +53,9 @@ import org.skyve.metadata.module.Module.DocumentRef;
 import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.Action;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 import com.google.common.base.MoreObjects;
 
@@ -62,6 +63,7 @@ import jakarta.servlet.http.HttpSession;
 
 public class CustomerImpl implements Customer {
 	private static final long serialVersionUID = 2926460705821800439L;
+	private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
 
 	/*
 	 * Change derived field groups to "relations". 
@@ -500,9 +502,9 @@ public class CustomerImpl implements Customer {
 			result = domainValueCache.get(key);
 			if (result == null) {
 				if ((bizlet != null) && DomainType.constant.equals(attribute.getDomainType())) {
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "getConstantDomainValues", "Entering " + bizlet.getClass().getName() + ".getConstantDomainValues: " + attributeName);
+                    if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering {}.getConstantDomainValues: {}", bizlet.getClass().getName(), attributeName);
 					result = bizlet.getConstantDomainValues(attributeName);
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "getConstantDomainValues", "Exiting " + bizlet.getClass().getName() + ".getConstantDomainValues: " + result);
+                    if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting {}.getConstantDomainValues: {}", bizlet.getClass().getName(), result);
 					domainValueCache.put(key, result);
 				}
 				if ((result == null) && (attribute instanceof Enumeration)) {

--- a/skyve-core/src/main/java/org/skyve/impl/metadata/model/document/DocumentImpl.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/model/document/DocumentImpl.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.logging.Level;
 
 import org.skyve.domain.Bean;
 import org.skyve.domain.ChildBean;
@@ -69,11 +68,14 @@ import org.skyve.metadata.view.model.comparison.ComparisonModel;
 import org.skyve.metadata.view.model.list.ListModel;
 import org.skyve.metadata.view.model.map.MapModel;
 import org.skyve.util.ExpressionEvaluator;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.annotation.Nonnull;
 
 public final class DocumentImpl extends ModelImpl implements Document {
-	private static final long serialVersionUID = 9091172268741052691L;
+    private static final long serialVersionUID = 9091172268741052691L;
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
 
 	private long lastModifiedMillis = Long.MAX_VALUE;
 	
@@ -163,12 +165,12 @@ public final class DocumentImpl extends ModelImpl implements Document {
 			// Run bizlet newInstance()
 			Bizlet<T> bizlet = getBizlet(customer);
 			if (bizlet != null) {
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "newInstance", "Entering " + bizlet.getClass().getName() + ".newInstance: " + result);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering {}.newInstance: {}", bizlet.getClass().getName(), result);
 				result = bizlet.newInstance(result);
 				if (result == null) {
 					throw new IllegalStateException(bizlet.getClass().getName() + ".newInstance() returned null");
 				}
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "newInstance", "Exiting " + bizlet.getClass().getName() + ".newInstance: " + result);
+                if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting {}.newInstance: {}", bizlet.getClass().getName(), result);
 			}
 
 			internalCustomer.interceptAfterNewInstance(result);
@@ -689,9 +691,11 @@ public final class DocumentImpl extends ModelImpl implements Document {
 						boolean vetoed = customer.interceptBeforeGetVariantDomainValues(attributeName);
 						if (! vetoed) {
 							if (bizlet != null) {
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "getVariantDomainValues", "Entering " + bizlet.getClass().getName() + ".getVariantDomainValues: " + attributeName);
+                                if (UtilImpl.BIZLET_TRACE)
+                                    BIZLET_LOGGER.info("getVariantDomainValues", "Entering {}.getVariantDomainValues: {}", bizlet.getClass().getName(), attributeName);
 								result = bizlet.getVariantDomainValues(attributeName);
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "getVariantDomainValues", "Exiting " + bizlet.getClass().getName() + ".getVariantDomainValues: " + result);
+								if (UtilImpl.BIZLET_TRACE) 
+								    BIZLET_LOGGER.info("getVariantDomainValues", "Exiting {}.getVariantDomainValues: {}", bizlet.getClass().getName(), result);
 							}
 							customer.interceptAfterGetVariantDomainValues(attributeName, result);
 						}
@@ -700,9 +704,9 @@ public final class DocumentImpl extends ModelImpl implements Document {
 						boolean vetoed = customer.interceptBeforeGetDynamicDomainValues(attributeName, owningBean);
 						if (! vetoed) {
 							if (bizlet != null) {
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "getDynamicDomainValues", "Entering " + bizlet.getClass().getName() + ".getDynamicDomainValues: " + attributeName + ", " + owningBean);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("getDynamicDomainValues", "Entering " + bizlet.getClass().getName() + ".getDynamicDomainValues: " + attributeName + ", " + owningBean);
 								result = bizlet.getDynamicDomainValues(attributeName, owningBean);
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "getDynamicDomainValues", "Exiting " + bizlet.getClass().getName() + ".getDynamicDomainValues: " + result);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("getDynamicDomainValues", "Exiting " + bizlet.getClass().getName() + ".getDynamicDomainValues: " + result);
 							}
 							customer.interceptAfterGetDynamicDomainValues(attributeName, owningBean, result);
 						}

--- a/skyve-core/src/main/java/org/skyve/impl/metadata/model/document/DocumentImpl.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/model/document/DocumentImpl.java
@@ -691,11 +691,9 @@ public final class DocumentImpl extends ModelImpl implements Document {
 						boolean vetoed = customer.interceptBeforeGetVariantDomainValues(attributeName);
 						if (! vetoed) {
 							if (bizlet != null) {
-                                if (UtilImpl.BIZLET_TRACE)
-                                    BIZLET_LOGGER.info("getVariantDomainValues", "Entering {}.getVariantDomainValues: {}", bizlet.getClass().getName(), attributeName);
+                                if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering {}.getVariantDomainValues: {}", bizlet.getClass().getName(), attributeName);
 								result = bizlet.getVariantDomainValues(attributeName);
-								if (UtilImpl.BIZLET_TRACE) 
-								    BIZLET_LOGGER.info("getVariantDomainValues", "Exiting {}.getVariantDomainValues: {}", bizlet.getClass().getName(), result);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting {}.getVariantDomainValues: {}", bizlet.getClass().getName(), result);
 							}
 							customer.interceptAfterGetVariantDomainValues(attributeName, result);
 						}
@@ -704,9 +702,9 @@ public final class DocumentImpl extends ModelImpl implements Document {
 						boolean vetoed = customer.interceptBeforeGetDynamicDomainValues(attributeName, owningBean);
 						if (! vetoed) {
 							if (bizlet != null) {
-								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("getDynamicDomainValues", "Entering " + bizlet.getClass().getName() + ".getDynamicDomainValues: " + attributeName + ", " + owningBean);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".getDynamicDomainValues: " + attributeName + ", " + owningBean);
 								result = bizlet.getDynamicDomainValues(attributeName, owningBean);
-								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("getDynamicDomainValues", "Exiting " + bizlet.getClass().getName() + ".getDynamicDomainValues: " + result);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".getDynamicDomainValues: " + result);
 							}
 							customer.interceptAfterGetDynamicDomainValues(attributeName, owningBean, result);
 						}

--- a/skyve-core/src/main/java/org/skyve/impl/metadata/repository/FileSystemRepository.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/repository/FileSystemRepository.java
@@ -43,11 +43,16 @@ import org.skyve.metadata.view.model.chart.ChartModel;
 import org.skyve.metadata.view.model.comparison.ComparisonModel;
 import org.skyve.metadata.view.model.list.ListModel;
 import org.skyve.metadata.view.model.map.MapModel;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 public abstract class FileSystemRepository extends MutableCachedRepository {
+
+    private static final Logger XML_LOGGER = Category.XML.logger();
+
 	protected String absolutePath;
 	// used to stop resources paths breaking out of the web root (eg ../../../../)
 	private String canonicalBasePath;
@@ -115,7 +120,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 				sb.append(CUSTOMERS_NAMESPACE).append(customerName).append('/');
 				sb.append(MODULES_NAMESPACE).append(moduleName).append('/');
 				String key = sb.toString();
-				if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info("module location = " + key);
+				if (UtilImpl.XML_TRACE) XML_LOGGER.info("module location = " + key);
 				populateDocumentLocations(key);
 			}
 		}
@@ -128,7 +133,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 			sb.setLength(0);
 			sb.append(MODULES_NAMESPACE).append(moduleName).append('/');
 			String key = sb.toString();
-			if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info("module location = " + key);
+			if (UtilImpl.XML_TRACE) XML_LOGGER.info("module location = " + key);
 			populateDocumentLocations(key);
 		}
 	}
@@ -141,7 +146,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 			sb.append(absolutePath).append(key).append('/').append(moduleName).append(".xml");
 			File moduleFile = new File(sb.toString());
 			if (moduleFile.exists()) {
-				if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(moduleName + " -> " + key);
+				if (UtilImpl.XML_TRACE) XML_LOGGER.info(moduleName + " -> " + key);
 				addKey(key);
 			}
 		}
@@ -153,7 +158,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 			sb.append(absolutePath).append(key).append('/').append(moduleName).append(".xml");
 			File moduleFile = new File(sb.toString());
 			if (moduleFile.exists()) {
-				if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(moduleName + " -> " + key);
+				if (UtilImpl.XML_TRACE) XML_LOGGER.info(moduleName + " -> " + key);
 				addKey(key);
 			}
 		}
@@ -168,7 +173,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 			if (moduleFiles != null) {
 				for (File moduleFile : moduleFiles) {
 					String moduleFileName = moduleFile.getName();
-					if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info("module file name = " + moduleFileName);
+					if (UtilImpl.XML_TRACE) XML_LOGGER.info("module file name = " + moduleFileName);
 	
 					// we have found some modules
 					if (moduleFile.isDirectory()) {
@@ -192,7 +197,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 													sb.append(META_DATA_SUFFIX);
 												}
 												String actionLocation = sb.toString();
-												if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("Action ").append(actionName).append(" -> ").append(actionLocation).toString());
+												if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("Action ").append(actionName).append(" -> ").append(actionLocation).toString());
 												addKey(actionLocation);
 											}
 										}
@@ -210,7 +215,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 												sb.append(key).append(moduleFileName).append('/');
 												sb.append(IMAGES_NAMESPACE).append(imageName);
 												String imageLocation = sb.toString();
-												if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("Dynamic Image ").append(imageName).append(" -> ").append(imageLocation).toString());
+												if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("Dynamic Image ").append(imageName).append(" -> ").append(imageLocation).toString());
 												addKey(imageLocation);
 											}
 										}
@@ -228,7 +233,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 												sb.append(key).append(moduleFileName).append('/');
 												sb.append(MODELS_NAMESPACE).append(modelName);
 												String modelLocation = sb.toString();
-												if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("Model ").append(modelName).append(" -> ").append(modelLocation).toString());
+												if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("Model ").append(modelName).append(" -> ").append(modelLocation).toString());
 												addKey(modelLocation);
 											}
 										}
@@ -246,7 +251,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 												sb.append(key).append(moduleFileName).append('/');
 												sb.append(REPORTS_NAMESPACE).append(reportName).append(JASPER_SUFFIX);
 												String reportLocation = sb.toString();
-												if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("Jasper Report ").append(reportName).append(" -> ").append(reportLocation).toString());
+												if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("Jasper Report ").append(reportName).append(" -> ").append(reportLocation).toString());
 												addKey(reportLocation);
 											}
 											else if (reportFileName.endsWith(".ftlh")) {
@@ -255,7 +260,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 												sb.append(key).append(moduleFileName).append('/');
 												sb.append(REPORTS_NAMESPACE).append(reportName).append(FREEMARKER_SUFFIX);
 												String reportLocation = sb.toString();
-												if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("Freemarker Report ").append(reportName).append(" -> ").append(reportLocation).toString());
+												if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("Freemarker Report ").append(reportName).append(" -> ").append(reportLocation).toString());
 												addKey(reportLocation);
 											}
 										}
@@ -273,7 +278,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 												sb.append(key).append(moduleFileName).append('/');
 												sb.append(VIEWS_NAMESPACE).append(viewType);
 												String viewLocation = sb.toString();
-												if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("View ").append(viewType).append(" -> ").append(viewLocation).toString());
+												if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("View ").append(viewType).append(" -> ").append(viewLocation).toString());
 												addKey(viewLocation);
 											}
 											else if (viewFile.isDirectory()) {
@@ -287,7 +292,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 															sb.append(key).append(moduleFileName).append('/');
 															sb.append(VIEWS_NAMESPACE).append(viewFileName).append('/').append(viewType);
 															String viewLocation = sb.toString();
-															if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("View ").append(viewType).append(" -> ").append(viewLocation).toString());
+															if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("View ").append(viewType).append(" -> ").append(viewLocation).toString());
 															addKey(viewLocation);
 														}
 													}
@@ -302,7 +307,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 									sb.append(key).append(moduleFileName).append('/');
 									sb.append(moduleFileName).append(BIZLET_SUFFIX);
 									String bizletLocation = sb.toString();
-									if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("Bizlet ").append(moduleFileName).append(" -> ").append(bizletLocation).toString());
+									if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("Bizlet ").append(moduleFileName).append(" -> ").append(bizletLocation).toString());
 									addKey(bizletLocation);
 								}
 								// found the bizlet metadata file
@@ -311,7 +316,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 									sb.append(key).append(moduleFileName).append('/');
 									sb.append(moduleFileName).append(BIZLET_SUFFIX).append(META_DATA_SUFFIX);
 									String bizletLocation = sb.toString();
-									if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("BizletMetaData ").append(moduleFileName).append(" -> ").append(bizletLocation).toString());
+									if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("BizletMetaData ").append(moduleFileName).append(" -> ").append(bizletLocation).toString());
 									addKey(bizletLocation);
 								}
 								// found the extension class file
@@ -320,7 +325,7 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 									sb.append(key).append(moduleFileName).append('/');
 									sb.append(moduleFileName).append("Extension");
 									String extensionLocation = sb.toString();
-									if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("Extension ").append(moduleFileName).append(" -> ").append(extensionLocation).toString());
+									if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("Extension ").append(moduleFileName).append(" -> ").append(extensionLocation).toString());
 									addKey(extensionLocation);
 								}
 								// found the factory class file
@@ -329,13 +334,13 @@ public abstract class FileSystemRepository extends MutableCachedRepository {
 									sb.append(key).append(moduleFileName).append('/');
 									sb.append(moduleFileName).append("Factory");
 									String factoryLocation = sb.toString();
-									if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("Factory ").append(moduleFileName).append(" -> ").append(factoryLocation).toString());
+									if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("Factory ").append(moduleFileName).append(" -> ").append(factoryLocation).toString());
 									addKey(factoryLocation);
 								}
 								// found the document definition file
 								else if (documentFileName.equals(moduleFileName + ".xml")) {
 									String documentLocation = key + moduleFileName;
-									if (UtilImpl.XML_TRACE) UtilImpl.LOGGER.info(new StringBuilder(128).append("Document ").append(moduleFileName).append(" -> ").append(documentLocation).toString());
+									if (UtilImpl.XML_TRACE) XML_LOGGER.info(new StringBuilder(128).append("Document ").append(moduleFileName).append(" -> ").append(documentLocation).toString());
 									addKey(documentLocation);
 								}
 							} // for (all document files)

--- a/skyve-core/src/main/java/org/skyve/impl/metadata/user/UserImpl.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/user/UserImpl.java
@@ -28,6 +28,8 @@ import org.skyve.metadata.user.DocumentPermissionScope;
 import org.skyve.metadata.user.User;
 import org.skyve.metadata.user.UserAccess;
 import org.skyve.persistence.Persistence;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.annotation.Nonnull;
 
@@ -35,6 +37,8 @@ public class UserImpl implements User {
 	private static final long serialVersionUID = -8485741818564437957L;
 
 	private static final String SECURITY_ADMINISTRATOR_ROLE = "admin.SecurityAdministrator";
+
+    private static final Logger SECURITY_LOGGER = Category.SECURITY.logger();
 
 	/**
 	 * Represents a user that does not belong to a data group.
@@ -494,23 +498,13 @@ public class UserImpl implements User {
 					}
 				}
 				if ((! result) && UtilImpl.SECURITY_TRACE) {
-					StringBuilder trace = new StringBuilder(256);
-					trace.append("Security - ");
-					trace.append(beanBizModule).append('.');
-					trace.append(beanBizDocument).append('.');
-					trace.append(beanBizId).append(" denied - not in scope");
-					UtilImpl.LOGGER.info(trace.toString());
+                    SECURITY_LOGGER.info("Security - {}.{}.{} denied - not in scope", beanBizModule, beanBizDocument, beanBizId);
 				}
 			}
 			else {
 				result = false;
 				if (UtilImpl.SECURITY_TRACE) {
-					StringBuilder trace = new StringBuilder(256);
-					trace.append("Security - ");
-					trace.append(beanBizModule).append('.');
-					trace.append(beanBizDocument).append('.');
-					trace.append(beanBizId).append(" denied - no read permission");
-					UtilImpl.LOGGER.info(trace.toString());
+					SECURITY_LOGGER.info("Security - {}.{}.{} denied - no read permission", beanBizModule, beanBizDocument, beanBizId);
 				}
 			}
 		}
@@ -523,14 +517,9 @@ public class UserImpl implements User {
 			Document parentDocument = document.getParentDocument(customer);
 			if (parentDocument == null) { // document has no parent
 				result = false;
-				if (UtilImpl.SECURITY_TRACE) {
-					StringBuilder trace = new StringBuilder(256);
-					trace.append("Security - ");
-					trace.append(beanBizModule).append('.');
-					trace.append(beanBizDocument).append('.');
-					trace.append(beanBizId).append(" denied - no permission");
-					UtilImpl.LOGGER.info(trace.toString());
-				}
+                if (UtilImpl.SECURITY_TRACE) {
+                    SECURITY_LOGGER.info("Security - {}.{}.{} denied - no permission", beanBizModule, beanBizDocument, beanBizId);
+                }
 			}
 			else { // found a parent document
 				if (! beanBizDocument.equals(parentDocument.getName())) { // exclude hierarchical documents
@@ -566,12 +555,7 @@ public class UserImpl implements User {
 													(String) values[2], 
 													(String) values[3]);
 							if ((! result) && (UtilImpl.SECURITY_TRACE)) {
-								StringBuilder trace = new StringBuilder(256);
-								trace.append("Security - ");
-								trace.append(beanBizModule).append('.');
-								trace.append(beanBizDocument).append('.');
-								trace.append(beanBizId).append(" denied - no read on parent");
-								UtilImpl.LOGGER.info(trace.toString());
+			                    SECURITY_LOGGER.info("Security - {}.{}.{} denied - no read on parent", beanBizModule, beanBizDocument, beanBizId);
 							}
 						}
 					}
@@ -603,23 +587,15 @@ public class UserImpl implements User {
 				// deny if user can't read owning document
 				result = canReadBean(bizId, bizModule, bizDocument, bizCustomer, bizDataGroupId, bizUserId);
 				if ((! result) && (UtilImpl.SECURITY_TRACE)) {
-					StringBuilder trace = new StringBuilder(256);
-					trace.append("Security - ");
-					trace.append(bizModule).append('.');
-					trace.append(bizDocument).append('.');
-					trace.append(bizId).append(" denied - no read. Content permission can be explicitly granted for non-persistent document attribtues");
-					UtilImpl.LOGGER.info(trace.toString());
+                    SECURITY_LOGGER.info(
+                            "Security - {}.{}.{} denied - no read. Content permission can be explicitly granted for non-persistent document attribtues",
+                            bizModule, bizDocument, bizId);
 				}
 			}
 		}
 		else {
 			if (UtilImpl.SECURITY_TRACE) {
-				StringBuilder trace = new StringBuilder(256);
-				trace.append("Security - ");
-				trace.append(bizModule).append('.');
-				trace.append(bizDocument).append('.');
-				trace.append(attributeName).append(" denied - restricted content");
-				UtilImpl.LOGGER.info(trace.toString());
+                SECURITY_LOGGER.info( "Security - {}.{}.{} denied - restricted content", bizModule, bizDocument, attributeName);
 			}
 		}
 

--- a/skyve-core/src/main/java/org/skyve/impl/metadata/view/ViewVisitor.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/view/ViewVisitor.java
@@ -82,8 +82,13 @@ import org.skyve.metadata.view.Disableable;
 import org.skyve.metadata.view.Invisible;
 import org.skyve.metadata.view.widget.bound.Bound;
 import org.skyve.util.Binder.TargetMetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class ViewVisitor extends ActionVisitor {
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
 	protected CustomerImpl customer;
 	protected ModuleImpl module;
 	protected DocumentImpl document;

--- a/skyve-core/src/main/java/org/skyve/impl/persistence/AbstractBizQL.java
+++ b/skyve-core/src/main/java/org/skyve/impl/persistence/AbstractBizQL.java
@@ -7,10 +7,14 @@ import org.skyve.domain.messages.DomainException;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.persistence.AutoClosingIterable;
 import org.skyve.persistence.BizQL;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public class AbstractBizQL extends AbstractQuery implements BizQL {
 	private String query;
 	private String resolvedQuery;
+	
+	private static final Logger QUERY_LOGGER = Category.QUERY.logger();
 
 	public AbstractBizQL(String query) {
 		this.query = query;
@@ -26,7 +30,7 @@ public class AbstractBizQL extends AbstractQuery implements BizQL {
 	public AbstractBizQL putParameter(String name, Object value) {
 		parameters.put(name, value);
 		if (UtilImpl.QUERY_TRACE) {
-			UtilImpl.LOGGER.info("    SET PARAM " + name + " = " + value);
+		    QUERY_LOGGER.info("    SET PARAM {} = {}", name, value);
 		}
 		return this;
 	}

--- a/skyve-core/src/main/java/org/skyve/impl/persistence/AbstractDocumentQuery.java
+++ b/skyve-core/src/main/java/org/skyve/impl/persistence/AbstractDocumentQuery.java
@@ -16,8 +16,13 @@ import org.skyve.metadata.module.Module;
 import org.skyve.persistence.DocumentFilter;
 import org.skyve.persistence.DocumentQuery;
 import org.skyve.util.Binder;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public abstract class AbstractDocumentQuery extends AbstractQuery implements DocumentQuery {
+
+    private static final Logger QUERY_LOGGER = Category.QUERY.logger();
+
 	/**
 	 * Used to get metadata about the query's driving document
 	 */
@@ -105,7 +110,7 @@ public abstract class AbstractDocumentQuery extends AbstractQuery implements Doc
 	public AbstractDocumentQuery putParameter(String name, Object value) {
 		parameters.put(name, value);
 		if (UtilImpl.QUERY_TRACE) {
-			UtilImpl.LOGGER.info("    SET PARAM " + name + " = " + value);
+		    QUERY_LOGGER.info("    SET PARAM " + name + " = " + value);
 		}
 		return this;
 	}

--- a/skyve-core/src/main/java/org/skyve/impl/persistence/AbstractSQL.java
+++ b/skyve-core/src/main/java/org/skyve/impl/persistence/AbstractSQL.java
@@ -32,9 +32,14 @@ import org.skyve.metadata.model.Attribute.AttributeType;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.persistence.DataStore;
 import org.skyve.persistence.SQL;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public abstract class AbstractSQL extends AbstractQuery implements SQL {
-	private String query = null;
+
+    private static final Logger QUERY_LOGGER = Category.QUERY.logger();
+
+    private String query = null;
 	private String moduleName;
 	private String documentName;
 
@@ -130,7 +135,7 @@ public abstract class AbstractSQL extends AbstractQuery implements SQL {
 		parameters.put(name, value);
 		parametersTypes.put(name, type);
 		if (UtilImpl.QUERY_TRACE) {
-			UtilImpl.LOGGER.info("    SET PARAM " + name + " = " + value);
+		    QUERY_LOGGER.info("    SET PARAM " + name + " = " + value);
 		}
 		return this;
 	}

--- a/skyve-core/src/main/java/org/skyve/impl/sail/execution/ScriptExecutor.java
+++ b/skyve-core/src/main/java/org/skyve/impl/sail/execution/ScriptExecutor.java
@@ -1,11 +1,15 @@
 package org.skyve.impl.sail.execution;
 
 import org.skyve.metadata.sail.language.step.Execute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class ScriptExecutor<T extends AutomationContext> extends ContextualExecutor<T> {
 	private StringBuilder script = new StringBuilder(4096);
 	private int indent = 0;
-	
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
 	public final ScriptExecutor<T> indent() {
 		for (int i = 0; i < indent; i++) {
 			script.append('\t');

--- a/skyve-core/src/main/java/org/skyve/impl/util/LoggingIteratorAdapter.java
+++ b/skyve-core/src/main/java/org/skyve/impl/util/LoggingIteratorAdapter.java
@@ -2,9 +2,13 @@ package org.skyve.impl.util;
 
 import java.util.Iterator;
 
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LoggingIteratorAdapter<T> implements Iterator<T> {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
 	private Iterator<T> adapted;
 	private int iterated = 0;
 
@@ -16,7 +20,7 @@ public class LoggingIteratorAdapter<T> implements Iterator<T> {
 	public boolean hasNext() {
 		boolean result = adapted.hasNext();
 		if ((! result) && (iterated >= 1000)) {
-			Util.LOGGER.info("Finished Iteration at " + iterated + " iterations");
+			LOGGER.trace("Finished Iteration at " + iterated + " iterations");
 		}
 		return result;
 	}
@@ -26,7 +30,7 @@ public class LoggingIteratorAdapter<T> implements Iterator<T> {
 		T result = adapted.next();
 		iterated++;
 		if (iterated % 1000 == 0) {
-			Util.LOGGER.info("Iterated " + iterated);
+			LOGGER.trace("Iterated " + iterated);
 		}
 		return result;
 	}

--- a/skyve-core/src/main/java/org/skyve/impl/util/UtilImpl.java
+++ b/skyve-core/src/main/java/org/skyve/impl/util/UtilImpl.java
@@ -17,7 +17,6 @@ import java.util.Scanner;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.deltaspike.core.api.provider.BeanProvider;
@@ -52,10 +51,16 @@ import org.skyve.persistence.DataStore;
 import org.skyve.util.BeanVisitor;
 import org.skyve.util.JSON;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.gcardone.junidecode.Junidecode;
 
 public class UtilImpl {
+
+    private static final Logger DIRTY_LOGGER = Category.DIRTY.logger();
+
 	/**
 	 * Disallow instantiation
 	 */
@@ -107,7 +112,9 @@ public class UtilImpl {
      * 
      */
     @Deprecated(since = "9.3.0", forRemoval = true)
-    public static final Logger LOGGER = Logger.getLogger("SKYVE.framework.legacy");
+    public static final java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(Category.LEGACY.getName());
+
+    private static final Logger utilLogger = LoggerFactory.getLogger(Util.class);
 
 	// the name of the application archive, e.g. typically projectName.war or projectName.ear
 	public static String ARCHIVE_NAME;
@@ -385,16 +392,16 @@ public class UtilImpl {
 			else {
 				URL url = Thread.currentThread().getContextClassLoader().getResource("schemas/common.xsd");
 				if (url == null) {
-					UtilImpl.LOGGER.severe("Cannot determine absolute base path. Where is schemas/common.xsd?");
+				    utilLogger.error("Cannot determine absolute base path. Where is schemas/common.xsd?");
 					ClassLoader cl = Thread.currentThread().getContextClassLoader();
 					if (cl instanceof URLClassLoader) {
-						UtilImpl.LOGGER.severe("The context classloader paths are:-");
+					    utilLogger.error("The context classloader paths are:-");
 						for (URL entry : ((URLClassLoader) cl).getURLs()) {
-							UtilImpl.LOGGER.severe(entry.getFile());
+						    utilLogger.error(entry.getFile());
 						}
 					}
 					else {
-						UtilImpl.LOGGER.severe("Cannot determine the context classloader paths...");
+					    utilLogger.error("Cannot determine the context classloader paths...");
 					}
 				}
 				else {
@@ -510,8 +517,9 @@ public class UtilImpl {
 
 			if (beanAccepted.isChanged()) {
 				changed = true;
-				if (UtilImpl.DIRTY_TRACE) {
-					UtilImpl.LOGGER.info("UtilImpl.hasChanged(): Bean " + beanAccepted.toString() + " with binding " + binding + " is DIRTY");
+                if (UtilImpl.DIRTY_TRACE) {
+                    DIRTY_LOGGER.info("UtilImpl.hasChanged(): Bean {} with binding {} is DIRTY", beanAccepted.toString(),
+                            binding);
 				}
 				return false;
 			}

--- a/skyve-core/src/main/java/org/skyve/impl/util/ValidationUtil.java
+++ b/skyve-core/src/main/java/org/skyve/impl/util/ValidationUtil.java
@@ -3,7 +3,6 @@ package org.skyve.impl.util;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.logging.Level;
 
 import org.skyve.CORE;
 import org.skyve.domain.Bean;
@@ -46,8 +45,15 @@ import org.skyve.metadata.user.User;
 import org.skyve.util.BeanValidator;
 import org.skyve.util.BeanVisitor;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ValidationUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ValidationUtil.class);
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
+
 	private ValidationUtil() {
 		// no implementation
 	}
@@ -82,7 +88,7 @@ public class ValidationUtil {
 		}
 
 		if (! e.getMessages().isEmpty()) {
-			UtilImpl.LOGGER.warning("Validation Failed for bean " + bean);
+			LOGGER.warn("Validation Failed for bean {}", bean);
 			throw e;
 		}
 	}
@@ -326,7 +332,7 @@ public class ValidationUtil {
 		}
 		catch (Exception e) {
 			e.printStackTrace();
-			UtilImpl.LOGGER.warning("Validation Failed for bean " + bean);
+			LOGGER.warn("Validation Failed for bean " + bean);
 			throw new ValidationException(new Message(binding, Util.nullSafeI18n(BeanValidator.VALIDATION_ACCESS_KEY)));
 		}
 
@@ -349,9 +355,21 @@ public class ValidationUtil {
 			CustomerImpl internalCustomer = (CustomerImpl) CORE.getUser().getCustomer();
 			boolean vetoed = internalCustomer.interceptBeforeValidate(bean, e);
 			if (! vetoed) {
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "validate", "Entering " + bizlet.getClass().getName() + ".validate: " + bean);
+				if (UtilImpl.BIZLET_TRACE)
+                    BIZLET_LOGGER.atInfo()
+                                 .addKeyValue("sourceClass", bizlet.getClass().getName())
+                                 .addKeyValue("sourceMethod", "validate")
+                                 .addArgument(bizlet.getClass().getName())
+                                 .addArgument(bean)
+                                 .log("Entering {}.validate: {}");
 				bizlet.validate(bean, e);
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "validate", "Exiting " + bizlet.getClass().getName() + ".validate: " + bean);
+				if (UtilImpl.BIZLET_TRACE) 
+                    BIZLET_LOGGER.atInfo()
+                                 .addKeyValue("sourceClass", bizlet.getClass().getName())
+                                 .addKeyValue("sourceMethod", "validate")
+                                 .addArgument(bizlet.getClass().getName())
+                                 .addArgument(bean)
+                                 .log("Exiting {}.validate: {}");
 				internalCustomer.interceptAfterValidate(bean, e);
 			}
 		}
@@ -375,7 +393,7 @@ public class ValidationUtil {
 		}
 
 		if (! e.getMessages().isEmpty()) {
-			UtilImpl.LOGGER.warning("Validation Failed for bean " + bean);
+			LOGGER.warn("Validation Failed for bean {}", bean);
 			throw e;
 		}
 	}
@@ -461,12 +479,12 @@ public class ValidationUtil {
 			}
 		}
 		catch (UniqueConstraintViolationException ve) {
-			UtilImpl.LOGGER.warning("Validation Failed for bean " + bean);
+			LOGGER.warn("Validation Failed for bean {}", bean);
 			throw ve;
 		}
 		catch (Exception ex) {
 			ex.printStackTrace();
-			UtilImpl.LOGGER.warning("Validation Failed for bean " + bean);
+			LOGGER.warn("Validation Failed for bean {}", bean);
 			throw new ValidationException(new Message("An error occurred checking collection unique constraints. - See stack trace in log"));
 		}
 	}

--- a/skyve-core/src/main/java/org/skyve/impl/util/ValidationUtil.java
+++ b/skyve-core/src/main/java/org/skyve/impl/util/ValidationUtil.java
@@ -356,20 +356,10 @@ public class ValidationUtil {
 			boolean vetoed = internalCustomer.interceptBeforeValidate(bean, e);
 			if (! vetoed) {
 				if (UtilImpl.BIZLET_TRACE)
-                    BIZLET_LOGGER.atInfo()
-                                 .addKeyValue("sourceClass", bizlet.getClass().getName())
-                                 .addKeyValue("sourceMethod", "validate")
-                                 .addArgument(bizlet.getClass().getName())
-                                 .addArgument(bean)
-                                 .log("Entering {}.validate: {}");
+                    BIZLET_LOGGER.info("Entering {}.validate: {}", bizlet.getClass().getName(), bean);
 				bizlet.validate(bean, e);
 				if (UtilImpl.BIZLET_TRACE) 
-                    BIZLET_LOGGER.atInfo()
-                                 .addKeyValue("sourceClass", bizlet.getClass().getName())
-                                 .addKeyValue("sourceMethod", "validate")
-                                 .addArgument(bizlet.getClass().getName())
-                                 .addArgument(bean)
-                                 .log("Exiting {}.validate: {}");
+                    BIZLET_LOGGER.info("Exiting {}.validate: {}", bizlet.getClass().getName(), bean);
 				internalCustomer.interceptAfterValidate(bean, e);
 			}
 		}

--- a/skyve-core/src/main/java/org/skyve/impl/util/XMLMetaData.java
+++ b/skyve-core/src/main/java/org/skyve/impl/util/XMLMetaData.java
@@ -45,6 +45,8 @@ import org.skyve.impl.metadata.repository.view.ViewMetaData;
 import org.skyve.metadata.MetaDataException;
 import org.skyve.metadata.sail.language.Automation;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import jakarta.xml.bind.JAXBContext;
@@ -75,6 +77,9 @@ import jakarta.xml.bind.Unmarshaller;
  * Therefore we have to resort to post processing the output with DOM4J.
  */
 public class XMLMetaData {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(XMLMetaData.class);
+
 	public static final String COMMON_NAMESPACE = "http://www.skyve.org/xml/common";
 	public static final String ROUTER_NAMESPACE = "http://www.skyve.org/xml/router";
 	public static final String CUSTOMER_NAMESPACE = "http://www.skyve.org/xml/customer";
@@ -236,7 +241,7 @@ public class XMLMetaData {
 		file.mkdirs();
 		filePath.append(customer.getName()).append(".xml");
 		file = new File(filePath.toString());
-		Util.LOGGER.info(String.format("Attempting to write %s.xml to %s", customer.getName(), file.getAbsolutePath()));
+		LOGGER.info("Attempting to write {}.xml to {}", customer.getName(), file.getAbsolutePath());
 
 		try (FileOutputStream fos = new FileOutputStream(file)) {
 			try (BufferedOutputStream bos = new BufferedOutputStream(fos)) {
@@ -336,7 +341,7 @@ public class XMLMetaData {
 		file.mkdirs();
 		filePath.append(module.getName()).append(".xml");
 		file = new File(filePath.toString());
-		Util.LOGGER.info(String.format("Attempting to write module.xml to %s", file.getAbsolutePath()));
+		LOGGER.info("Attempting to write module.xml to {}", file.getAbsolutePath());
 
 		try (FileOutputStream fos = new FileOutputStream(file)) {
 			try (BufferedOutputStream bos = new BufferedOutputStream(fos)) {
@@ -435,7 +440,7 @@ public class XMLMetaData {
 		file.mkdirs();
 		filePath.append(document.getName()).append(".xml");
 		file = new File(filePath.toString());
-		Util.LOGGER.info(String.format("Attempting to write document.xml to %s", file.getPath()));
+		LOGGER.info("Attempting to write document.xml to {}", file.getPath());
 
 		try (FileOutputStream fos = new FileOutputStream(file)) {
 			try (BufferedOutputStream bos = new BufferedOutputStream(fos)) {
@@ -532,7 +537,7 @@ public class XMLMetaData {
 		file.mkdirs();
 		filePath.append(file.getName()).append("Bizlet.xml");
 		file = new File(filePath.toString());
-		Util.LOGGER.info(String.format("Attempting to write bizlet.xml to %s", file.getPath()));
+		LOGGER.info("Attempting to write bizlet.xml to {}", file.getPath());
 
 		try (FileOutputStream fos = new FileOutputStream(file)) {
 			try (BufferedOutputStream bos = new BufferedOutputStream(fos)) {
@@ -633,7 +638,7 @@ public class XMLMetaData {
 		file.mkdirs();
 		filePath.append(action.getName()).append(".xml");
 		file = new File(filePath.toString());
-		Util.LOGGER.info(String.format("Attempting to write action.xml to %s", file.getPath()));
+		LOGGER.info("Attempting to write action.xml to {}", file.getPath());
 
 		try (FileOutputStream fos = new FileOutputStream(file)) {
 			try (BufferedOutputStream bos = new BufferedOutputStream(fos)) {
@@ -738,7 +743,7 @@ public class XMLMetaData {
 		file.mkdirs();
 		filePath.append(view.getName()).append(".xml");
 		file = new File(filePath.toString());
-		Util.LOGGER.info(String.format("Attempting to write view.xml to %s", file.getPath()));
+		LOGGER.info("Attempting to write view.xml to {}", file.getPath());
 
 		try (FileOutputStream fos = new FileOutputStream(file)) {
 			try (BufferedOutputStream bos = new BufferedOutputStream(fos)) {

--- a/skyve-core/src/main/java/org/skyve/metadata/model/document/Bizlet.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/model/document/Bizlet.java
@@ -10,6 +10,8 @@ import org.skyve.metadata.MetaData;
 import org.skyve.metadata.controller.ImplicitActionName;
 import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 
@@ -42,6 +44,9 @@ import jakarta.annotation.Nonnull;
  * @param <T>	The type of document bean we want to process with this Bizlet.
  */
 public class Bizlet<T extends Bean> implements MetaData {
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
 	/**
 	 * Key/Value pairs for domains defined.
 	 */

--- a/skyve-core/src/main/java/org/skyve/metadata/model/document/SingletonCachedBizlet.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/model/document/SingletonCachedBizlet.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ConcurrentMap;
 import org.skyve.CORE;
 import org.skyve.domain.PersistentBean;
 import org.skyve.domain.messages.DomainException;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.user.DocumentPermissionScope;
 import org.skyve.metadata.user.User;
 
@@ -19,6 +18,7 @@ import jakarta.annotation.Nonnull;
  * @param <T>
  */
 public abstract class SingletonCachedBizlet<T extends PersistentBean> extends SingletonBizlet<T> {
+
 	/**
 	 * Thread-safe map of module/document keys to singleton instance bizId.
 	 */
@@ -67,14 +67,12 @@ public abstract class SingletonCachedBizlet<T extends PersistentBean> extends Si
 				// replace the cached bizId if a new one exists in the data store
 				if (result.isPersisted()) {
 					INSTANCES.put(key, result.getBizId());
-					UtilImpl.LOGGER.warning("Cached instance " + key + '#' + bizId + 
-												" was replaced by " + newBizId + " in the data store.");
+					LOGGER.warn("Cached instance {}#{} was replaced by {} in the data store.", key, bizId, newBizId);
 				}
 				// remove from the cache if there is none in the data store
 				else {
 					INSTANCES.remove(key);
-					UtilImpl.LOGGER.warning("Cached instance " + key + '#' + bizId + 
-												" was removed  and a non-persistent instance " + newBizId + " was returned.");
+					LOGGER.warn("Cached instance {}#{} was removed and a non-persistent instance {} was returned.", key, bizId, newBizId);
 				}
 			}
 		}

--- a/skyve-core/src/main/java/org/skyve/metadata/view/model/list/DocumentQueryFilter.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/model/list/DocumentQueryFilter.java
@@ -8,8 +8,13 @@ import org.skyve.domain.types.Decimal;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.user.User;
 import org.skyve.persistence.DocumentFilter;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public class DocumentQueryFilter implements Filter {
+
+    private static final Logger QUERY_LOGGER = Category.QUERY.logger();
+
 	private DocumentFilter detailFilter;
 	private DocumentFilter summaryFilter;
 	private User user;
@@ -42,7 +47,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addTagged(String tagId, boolean tagged) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("add tagged %b with tagId %s", Boolean.valueOf(tagged), tagId));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("add tagged %b with tagId %s", Boolean.valueOf(tagged), tagId));
 		StringBuilder sb = new StringBuilder(64);
 		sb.append("exists (select 1 from adminTagged as tagged where tagged.tag.bizId = '");
 		sb.append(tagId);
@@ -68,7 +73,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNull(String binding) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s is null", binding));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s is null", binding));
 		detailFilter.addNull(binding);
 		if (summaryFilter != null) {
 			summaryFilter.addNull(binding);
@@ -78,7 +83,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotNull(String binding) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s is not null", binding));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s is not null", binding));
 		detailFilter.addNotNull(binding);
 		if (summaryFilter != null) {
 			summaryFilter.addNotNull(binding);
@@ -88,7 +93,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEquals(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s equals %s", binding, value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s equals %s", binding, value));
 		detailFilter.addEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addEquals(binding, value);
@@ -98,7 +103,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEquals(String binding, Date value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addEquals(binding, value);
@@ -108,7 +113,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEquals(String binding, Integer value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addEquals(binding, value);
@@ -118,7 +123,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEquals(String binding, Long value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addEquals(binding, value);
@@ -128,7 +133,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEquals(String binding, Decimal value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addEquals(binding, value);
@@ -138,7 +143,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEquals(String binding, Boolean value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addEquals(binding, value);
@@ -148,7 +153,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEquals(String binding, Enum<?> value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addEquals(binding, value);
@@ -158,7 +163,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEquals(String binding, Geometry value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s equals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addEquals(binding, value);
@@ -168,7 +173,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEquals(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value));
 		detailFilter.addNotEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addNotEquals(binding, value);
@@ -178,7 +183,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEquals(String binding, Date value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addNotEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addNotEquals(binding, value);
@@ -188,7 +193,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEquals(String binding, Integer value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addNotEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addNotEquals(binding, value);
@@ -198,7 +203,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEquals(String binding, Long value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addNotEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addNotEquals(binding, value);
@@ -208,7 +213,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEquals(String binding, Decimal value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addNotEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addNotEquals(binding, value);
@@ -218,7 +223,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEquals(String binding, Boolean value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addNotEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addNotEquals(binding, value);
@@ -228,7 +233,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEquals(String binding, Enum<?> value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addNotEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addNotEquals(binding, value);
@@ -238,7 +243,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEquals(String binding, Geometry value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEquals %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addNotEquals(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addNotEquals(binding, value);
@@ -248,7 +253,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEqualsIgnoreCase(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s equalsIgnoreCase %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s equalsIgnoreCase %s", binding, (value == null) ? "null" : value));
 		detailFilter.addLike(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLike(binding, value);
@@ -258,7 +263,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEqualsIgnoreCase(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEqualsIgnoreCase %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEqualsIgnoreCase %s", binding, (value == null) ? "null" : value));
 		detailFilter.addNotLike(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addNotLike(binding, value);
@@ -268,7 +273,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addContains(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s contains %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s contains %s", binding, (value == null) ? "null" : value));
 		String operand = new StringBuilder(32).append('%').append(value).append('%').toString();
 		detailFilter.addLike(binding, operand);
 		if (summaryFilter != null) {
@@ -279,7 +284,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotContains(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notContains %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notContains %s", binding, (value == null) ? "null" : value));
 		String operand = new StringBuilder(32).append('%').append(value).append('%').toString();
 		detailFilter.addNullOrNotLike(binding, operand);
 		if (summaryFilter != null) {
@@ -290,7 +295,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addStartsWith(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s startsWith %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s startsWith %s", binding, (value == null) ? "null" : value));
 		String operand = new StringBuilder(32).append(value).append('%').toString();
 		detailFilter.addLike(binding, operand);
 		if (summaryFilter != null) {
@@ -301,7 +306,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotStartsWith(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notStartsWith %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notStartsWith %s", binding, (value == null) ? "null" : value));
 		String operand = new StringBuilder(32).append(value).append('%').toString();
 		detailFilter.addNullOrNotLike(binding, operand);
 		if (summaryFilter != null) {
@@ -312,7 +317,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addEndsWith(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s endsWith %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s endsWith %s", binding, (value == null) ? "null" : value));
 		String operand = new StringBuilder(32).append('%').append(value).toString();
 		detailFilter.addLike(binding, operand);
 		if (summaryFilter != null) {
@@ -323,7 +328,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addNotEndsWith(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s notEndsWith %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s notEndsWith %s", binding, (value == null) ? "null" : value));
 		String operand = new StringBuilder(32).append('%').append(value).toString();
 		detailFilter.addNullOrNotLike(binding, operand);
 		if (summaryFilter != null) {
@@ -334,7 +339,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThan(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value));
 		detailFilter.addGreaterThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThan(binding, value);
@@ -344,7 +349,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThan(String binding, Date value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addGreaterThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThan(binding, value);
@@ -354,7 +359,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThan(String binding, Integer value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addGreaterThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThan(binding, value);
@@ -364,7 +369,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThan(String binding, Long value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addGreaterThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThan(binding, value);
@@ -374,7 +379,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThan(String binding, Decimal value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThan %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addGreaterThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThan(binding, value);
@@ -384,7 +389,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThanOrEqualTo(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value));
 		detailFilter.addGreaterThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThanOrEqualTo(binding, value);
@@ -394,7 +399,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThanOrEqualTo(String binding, Date value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addGreaterThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThanOrEqualTo(binding, value);
@@ -404,7 +409,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThanOrEqualTo(String binding, Integer value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addGreaterThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThanOrEqualTo(binding, value);
@@ -414,7 +419,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThanOrEqualTo(String binding, Long value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addGreaterThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThanOrEqualTo(binding, value);
@@ -424,7 +429,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addGreaterThanOrEqualTo(String binding, Decimal value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s greaterThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addGreaterThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addGreaterThanOrEqualTo(binding, value);
@@ -434,7 +439,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThan(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value));
 		detailFilter.addLessThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThan(binding, value);
@@ -444,7 +449,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThan(String binding, Date value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addLessThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThan(binding, value);
@@ -454,7 +459,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThan(String binding, Integer value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addLessThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThan(binding, value);
@@ -464,7 +469,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThan(String binding, Long value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addLessThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThan(binding, value);
@@ -474,7 +479,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThan(String binding, Decimal value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThan %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addLessThan(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThan(binding, value);
@@ -484,7 +489,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThanOrEqualTo(String binding, String value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value));
 		detailFilter.addLessThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThanOrEqualTo(binding, value);
@@ -494,7 +499,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThanOrEqualTo(String binding, Date value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addLessThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThanOrEqualTo(binding, value);
@@ -504,7 +509,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThanOrEqualTo(String binding, Integer value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addLessThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThanOrEqualTo(binding, value);
@@ -514,7 +519,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThanOrEqualTo(String binding, Long value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addLessThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThanOrEqualTo(binding, value);
@@ -524,7 +529,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addLessThanOrEqualTo(String binding, Decimal value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s lessThanOrEqualTo %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addLessThanOrEqualTo(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addLessThanOrEqualTo(binding, value);
@@ -534,7 +539,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addBetween(String binding, String start, String end) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s between %s and %s", 
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s between %s and %s", 
 																		binding, 
 																		(start == null) ? "null" : start,
 																		(end == null) ? "null" : end));
@@ -547,7 +552,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addBetween(String binding, Date start, Date end) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s between %s and %s", 
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s between %s and %s", 
 																		binding, 
 																		(start == null) ? "null" : start.toString(),
 																		(end == null) ? "null" : end.toString()));
@@ -560,7 +565,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addBetween(String binding, Integer start, Integer end) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s between %s and %s", 
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s between %s and %s", 
 																		binding, 
 																		(start == null) ? "null" : start.toString(),
 																		(end == null) ? "null" : end.toString()));
@@ -573,7 +578,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addBetween(String binding, Long start, Long end) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s between %s and %s", 
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s between %s and %s", 
 																		binding, 
 																		(start == null) ? "null" : start.toString(),
 																		(end == null) ? "null" : end.toString()));
@@ -586,7 +591,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addBetween(String binding, Decimal start, Decimal end) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s between %s and %s", 
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s between %s and %s", 
 																		binding, 
 																		(start == null) ? "null" : start.toString(),
 																		(end == null) ? "null" : end.toString()));
@@ -615,7 +620,7 @@ public class DocumentQueryFilter implements Filter {
 				sb.append(value).append(", ");
 			}
 			sb.setLength(sb.length() - 2);
-			UtilImpl.LOGGER.info(sb.toString());
+			QUERY_LOGGER.info(sb.toString());
 		}
 		if (values.length > 0) {
 			if (not) {
@@ -650,7 +655,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addWithin(String binding, Geometry value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s within %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s within %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addWithin(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addWithin(binding, value);
@@ -660,7 +665,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addContains(String binding, Geometry value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s contains %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s contains %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addContains(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addContains(binding, value);
@@ -670,7 +675,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addCrosses(String binding, Geometry value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s crosses %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s crosses %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addCrosses(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addCrosses(binding, value);
@@ -680,7 +685,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addDisjoint(String binding, Geometry value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s disjoint %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s disjoint %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addDisjoint(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addDisjoint(binding, value);
@@ -690,7 +695,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addIntersects(String binding, Geometry value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s intersects %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s intersects %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addIntersects(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addIntersects(binding, value);
@@ -700,7 +705,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addOverlaps(String binding, Geometry value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s overlaps %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s overlaps %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addOverlaps(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addOverlaps(binding, value);
@@ -710,7 +715,7 @@ public class DocumentQueryFilter implements Filter {
 	@Override
 	public void addTouches(String binding, Geometry value) {
 		empty = false;
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(String.format("%s touches %s", binding, (value == null) ? "null" : value.toString()));
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(String.format("%s touches %s", binding, (value == null) ? "null" : value.toString()));
 		detailFilter.addTouches(binding, value);
 		if (summaryFilter != null) {
 			summaryFilter.addTouches(binding, value);

--- a/skyve-core/src/main/java/org/skyve/metadata/view/model/list/RDBMSDynamicPersistenceListModel.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/view/model/list/RDBMSDynamicPersistenceListModel.java
@@ -30,7 +30,8 @@ import org.skyve.persistence.AutoClosingIterable;
 import org.skyve.persistence.Persistence;
 import org.skyve.util.Binder;
 import org.skyve.util.JSON;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 
@@ -78,6 +79,9 @@ import jakarta.annotation.Nonnull;
  *			}
  */
 public class RDBMSDynamicPersistenceListModel<T extends Bean> extends InMemoryListModel<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RDBMSDynamicPersistenceListModel.class);
+
 	// Used for the title in the list
 	private String description;
 	// The columns in the grid
@@ -325,7 +329,9 @@ public class RDBMSDynamicPersistenceListModel<T extends Bean> extends InMemoryLi
 						}
 						catch (Exception e) {
 							Document d = getDrivingDocument();
-							Util.LOGGER.warning("RDBMSDynamicPersistenceListModel: Schema evolution problem on projection of binding " + projection + " within document " + d.getOwningModuleName() + "." + d.getName() + " :- [" + value + "] cannot be coerced to type " + fieldType);
+                            LOGGER.warn(
+                                    "RDBMSDynamicPersistenceListModel: Schema evolution problem on projection of binding {} within document {}.{} :- [{}] cannot be coerced to type {}",
+                                    projection, d.getOwningModuleName(), d.getName(), value, fieldType);
 							e.printStackTrace();
 						}
 					}

--- a/skyve-core/src/main/java/org/skyve/util/RuntimeCompiler.java
+++ b/skyve-core/src/main/java/org/skyve/util/RuntimeCompiler.java
@@ -26,13 +26,17 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
 import org.skyve.domain.messages.DomainException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Compile a java class definition String and load the class or write it to the file system.
  */
 public class RuntimeCompiler {
 	public static String COMPILE_PATH = Util.getContentDirectory() + "compile/";
-	
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeCompiler.class);
+
 	/**
 	 * Diagnostic Listener that will throw an exception when something goes wrong with compilation.
 	 */
@@ -49,7 +53,7 @@ public class RuntimeCompiler {
 			if (Diagnostic.Kind.ERROR.equals(diagnostic.getKind())) {
 				throw new DomainException(message);
 			}
-			Util.LOGGER.warning(message);
+			LOGGER.warn(message);
 		}
 	}
 

--- a/skyve-core/src/main/java/org/skyve/util/Util.java
+++ b/skyve-core/src/main/java/org/skyve/util/Util.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.TreeMap;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -24,6 +23,8 @@ import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
 import org.skyve.util.test.TestUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -49,7 +50,9 @@ public class Util {
      * 
      */
     @Deprecated(since = "9.3.0", forRemoval = true)
-    public static final Logger LOGGER = UtilImpl.LOGGER;
+    public static final java.util.logging.Logger LOGGER = UtilImpl.LOGGER;
+
+    private static final Logger utilLogger = LoggerFactory.getLogger(Util.class);
 
 	/**
 	 * UTF-8 charset identifier
@@ -191,7 +194,7 @@ public class Util {
 			}
 		}
 		catch (@SuppressWarnings("unused") MissingResourceException e) {
-			UtilImpl.LOGGER.warning("Could not find bundle \"resources.i18n\"");
+		    utilLogger.warn("Could not find bundle \"resources.i18n\"");
 		}
 
 		return (result == null) ? key : result;

--- a/skyve-core/src/main/java/org/skyve/util/logging/Category.java
+++ b/skyve-core/src/main/java/org/skyve/util/logging/Category.java
@@ -1,0 +1,37 @@
+package org.skyve.util.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum Category {
+
+    XML("xml"),
+    HTTP("http"),
+    QUERY("query"),
+    COMMAND("command"),
+    FACES("faces"),
+    CONTENT("content"),
+    SECURITY("security"),
+    BIZLET("bizlet"),
+    DIRTY("dirty"),
+    LEGACY("legacy");
+
+    private static final String CATEGORY_PREFIX = "SKYVE.framework.";
+
+    private final String name;
+
+    Category(String name) {
+        this.name = new StringBuilder().append(CATEGORY_PREFIX)
+                                       .append(name)
+                                       .toString();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Logger logger() {
+        return LoggerFactory.getLogger(name);
+    }
+
+}

--- a/skyve-core/src/main/java/org/skyve/util/logging/Category.java
+++ b/skyve-core/src/main/java/org/skyve/util/logging/Category.java
@@ -3,6 +3,13 @@ package org.skyve.util.logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Logging categories for use within the Skyve framework. Typically associated with
+ * the trace flags set through the Admin > Instrumentation UI, or the application
+ * config JSON. 
+ * <p>
+ * Do not use these outside of framework code.
+ */
 public enum Category {
 
     XML("xml"),
@@ -14,8 +21,23 @@ public enum Category {
     SECURITY("security"),
     BIZLET("bizlet"),
     DIRTY("dirty"),
+    /**
+     * This category exists to (temporarily) unify the UtilImpl's logger with these
+     * other Categories.
+     * 
+     * @deprecated This category will be deleted along with the Util/UtilImpl LOGGER fields
+     *             in a subsequent release.
+     */
+    @Deprecated
     LEGACY("legacy");
 
+    /**
+     * This logging category prefix is shared by all of these categories. 
+     * It starts with "SKYVE" to maintain some backwards compatability with
+     * any existing logging configurations that may be in use (ie: any 
+     * handlers which filter on "SKYVE" will still capture all of these 
+     * categories).
+     */
     private static final String CATEGORY_PREFIX = "SKYVE.framework.";
 
     private final String name;
@@ -30,6 +52,12 @@ public enum Category {
         return name;
     }
 
+    /**
+     * Convenience method for getting an SLF4J logger named
+     * for this Category.
+     * 
+     * @return
+     */
     public Logger logger() {
         return LoggerFactory.getLogger(name);
     }

--- a/skyve-core/src/main/java/org/skyve/util/test/TestUtil.java
+++ b/skyve-core/src/main/java/org/skyve/util/test/TestUtil.java
@@ -28,7 +28,6 @@ import org.skyve.impl.bind.BindUtil;
 import org.skyve.impl.metadata.model.document.AssociationImpl;
 import org.skyve.impl.metadata.model.document.field.Decimal10;
 import org.skyve.impl.metadata.model.document.field.Decimal5;
-import org.skyve.impl.metadata.model.document.field.LengthField;
 import org.skyve.impl.metadata.model.document.field.LongInteger;
 import org.skyve.impl.metadata.model.document.field.Text;
 import org.skyve.impl.metadata.model.document.field.TextFormat;
@@ -49,7 +48,8 @@ import org.skyve.metadata.user.User;
 import org.skyve.persistence.DocumentQuery;
 import org.skyve.persistence.DocumentQuery.AggregateFunction;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.mifmif.common.regex.Generex;
 
@@ -57,7 +57,9 @@ import jakarta.annotation.Nonnull;
 
 public class TestUtil {
 
-	private static final Random RANDOM = new Random();
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestUtil.class);
+
+    private static final Random RANDOM = new Random();
 	private static final String NUMBERS = "0123456789";
 	private static final String LETTERS = "abcdefghijklmnopqrstuvwxyz";
 	private static final String ALPHA_NUMERIC = LETTERS + NUMBERS;
@@ -215,17 +217,17 @@ public class TestUtil {
 	 */
 	public static List<String> retrieveExcludedUpdateAttributes(Module module, Document document) {
 		String className = String.format("modules.%1$s.%2$s.%2$sFactory", module.getName(), document.getName());
-		Util.LOGGER.fine("Looking for factory class " + className);
+		LOGGER.debug("Looking for factory class " + className);
 		try {
 			Class<?> c = Thread.currentThread().getContextClassLoader().loadClass(className);
 			if (c.isAnnotationPresent(SkyveFactory.class)) {
-				Util.LOGGER.fine("Found class " + c.getName());
+				LOGGER.debug("Found class " + c.getName());
 				SkyveFactory annotation = c.getAnnotation(SkyveFactory.class);
 				return Arrays.asList(annotation.excludedUpdateAttributes());
 			}
 		}
 		catch (Exception e) {
-			Util.LOGGER.fine("Could not find factory class for: " + e.getMessage());
+			LOGGER.debug("Could not find factory class for: " + e.getMessage());
 		}
 		return Collections.emptyList();
 	}
@@ -558,7 +560,7 @@ public class TestUtil {
 
 			return result;
 		} catch (@SuppressWarnings("unused") Exception e) {
-			Util.LOGGER.warning("Couldnt generate compliant string for expression " + regularExpression);
+			LOGGER.warn("Couldnt generate compliant string for expression " + regularExpression);
 		}
 		return null;
 	}
@@ -599,17 +601,17 @@ public class TestUtil {
 				final String key = attributeKey(module, document, attribute.getName());
 				if (DATA_MAP_CACHE.containsKey(key)) {
 					fileName = DATA_MAP_CACHE.get(key);
-					Util.LOGGER.fine(String.format("Loaded %s filename from cache", key));
+					LOGGER.debug(String.format("Loaded %s filename from cache", key));
 				} else {
 					String className = String.format("modules.%1$s.%2$s.%2$sFactory", module.getName(), document.getName());
-					Util.LOGGER.fine("Looking for factory class " + className);
+					LOGGER.debug("Looking for factory class " + className);
 					try {
 						Class<?> c = Thread.currentThread().getContextClassLoader().loadClass(className);
 						if (c != null) {
-							Util.LOGGER.fine("Found class " + c.getName());
+							LOGGER.debug("Found class " + c.getName());
 							if (c.isAnnotationPresent(DataMap.class)) {
 								DataMap annotation = c.getAnnotation(DataMap.class);
-								Util.LOGGER.fine(
+								LOGGER.debug(
 										String.format("attributeName: %s fileName: %s", annotation.attributeName(),
 												annotation.fileName()));
 								if (attribute.getName().equals(annotation.attributeName())) {
@@ -620,7 +622,7 @@ public class TestUtil {
 								SkyveFactory annotation = c.getAnnotation(SkyveFactory.class);
 								DataMap[] values = annotation.value();
 								for (DataMap map : values) {
-									Util.LOGGER.fine(
+									LOGGER.debug(
 											String.format("attributeName: %s fileName: %s", map.attributeName(), map.fileName()));
 									if (attribute.getName().equals(map.attributeName())) {
 										fileName = map.fileName();
@@ -636,11 +638,11 @@ public class TestUtil {
 				}
 
 				// check if there is a data file for this field
-				Util.LOGGER.fine(String.format(
+				LOGGER.debug(String.format(
 						"Looking for test data file in data/%s.txt", fileName != null ? fileName : attribute.getName()));
 				String value = randomValueFromFile(customerName, module, document, attribute.getName(), fileName);
 				if (value != null) {
-					Util.LOGGER.fine(String.format("Random %s: %s", attribute.getName(), value));
+					LOGGER.debug(String.format("Random %s: %s", attribute.getName(), value));
 					return value;
 				}
 			}
@@ -673,7 +675,7 @@ public class TestUtil {
 				} else {
 					// check if this is an email address
 					if (text.getValidator() != null && ValidatorType.email.equals(text.getValidator().getType())) {
-						return randomEmail(((LengthField) text).getLength());
+						return randomEmail(text.getLength());
 					} else if (text.getValidator() != null && text.getValidator().getRegularExpression() != null) {
 						// check if this string has a regex via a validator type
 						String xeger = randomRegex(text.getValidator().getRegularExpression(), length);
@@ -710,7 +712,7 @@ public class TestUtil {
 							out = out.substring(0, out.lastIndexOf(".") + 1).trim();
 						}
 						if (out.length() > 0) {
-							Util.LOGGER.fine(String.format("Random %s for %s with length %d(%d): %s",
+							LOGGER.debug(String.format("Random %s for %s with length %d(%d): %s",
 									attribute.getAttributeType(),
 									attribute.getName(),
 									Integer.valueOf(r),
@@ -770,7 +772,7 @@ public class TestUtil {
 			List<String> values = null;
 			if (DATA_CACHE.containsKey(key)) {
 				values = DATA_CACHE.get(key);
-				Util.LOGGER.fine(String.format("Loaded %s list from cache", key));
+				LOGGER.debug(String.format("Loaded %s list from cache", key));
 			} else {
 				String fileToLoad = attributeName;
 				if (fileName != null && fileName.length == 1 && fileName[0] != null) {
@@ -782,7 +784,7 @@ public class TestUtil {
 					fileToLoad = fileToLoad + ".txt";
 				}
 
-				Util.LOGGER.fine("Attempting to find on the classpath: " + String.format("data/%s", fileToLoad));
+				LOGGER.debug("Attempting to find on the classpath: " + String.format("data/%s", fileToLoad));
 				File file = CORE.getRepository().findResourceFile(String.format("data/%s",
 						fileToLoad),
 						customerName,
@@ -791,9 +793,9 @@ public class TestUtil {
 					try (InputStream inputStream = new FileInputStream(file)) {
 						values = readFromInputStream(inputStream);
 						DATA_CACHE.put(key, values);
-						Util.LOGGER.fine(String.format("Caching attribute %s with filename %s", key, fileToLoad));
+						LOGGER.debug(String.format("Caching attribute %s with filename %s", key, fileToLoad));
 						if (values != null && values.size() > 0) {
-							Util.LOGGER.fine(String.format("Loaded %s list from %s. Found %d values.", attributeName, fileToLoad,
+							LOGGER.debug(String.format("Loaded %s list from %s. Found %d values.", attributeName, fileToLoad,
 									Integer.valueOf(values.size())));
 						}
 					}

--- a/skyve-ext/src/main/java/org/skyve/EXT.java
+++ b/skyve-ext/src/main/java/org/skyve/EXT.java
@@ -76,6 +76,8 @@ import org.skyve.util.JSON;
 import org.skyve.util.Mail;
 import org.skyve.util.PushMessage;
 import org.skyve.util.SecurityUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import jakarta.annotation.Nonnull;
@@ -88,6 +90,9 @@ import jakarta.websocket.Session;
  * See {@link org.skyve.CORE} for creating objects implemented in the skyve core API.
  */
 public class EXT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EXT.class);
+
 	/**
 	 * Disallow instantiation
 	 */
@@ -603,10 +608,10 @@ public class EXT {
 		q.getFilter().addEquals(AppConstants.USER_NAME_ATTRIBUTE_NAME, UtilImpl.BOOTSTRAP_USER);
 		PersistentBean user = q.beanResult();
 		if (user == null) {
-			UtilImpl.LOGGER.info(String.format("CREATING BOOTSTRAP USER %s/%s (%s)",
-												UtilImpl.BOOTSTRAP_CUSTOMER,
-												UtilImpl.BOOTSTRAP_USER,
-												UtilImpl.BOOTSTRAP_EMAIL));
+            LOGGER.info("CREATING BOOTSTRAP USER {}/{} ({})",
+                    UtilImpl.BOOTSTRAP_CUSTOMER,
+                    UtilImpl.BOOTSTRAP_USER,
+                    UtilImpl.BOOTSTRAP_EMAIL);
 
 			// Create user
 			user = userDoc.newInstance(u);
@@ -643,9 +648,9 @@ public class EXT {
 			p.save(user);
 		}
 		else {
-			UtilImpl.LOGGER.info(String.format("BOOTSTRAP USER %s/%s ALREADY EXISTS",
-												UtilImpl.BOOTSTRAP_CUSTOMER,
-												UtilImpl.BOOTSTRAP_USER));
+            LOGGER.info("BOOTSTRAP USER {}/{} ALREADY EXISTS",
+                    UtilImpl.BOOTSTRAP_CUSTOMER,
+                    UtilImpl.BOOTSTRAP_USER);
 		}
 	}
 
@@ -755,8 +760,8 @@ public class EXT {
 				throw new IllegalStateException(access.toString() + " not catered for");
 			}
 
-			UtilImpl.LOGGER.warning(warning.toString());
-			UtilImpl.LOGGER.info("If this user already has a document or action privilege, check if they were navigated to this page/resource programatically or by means other than the menu or views and need to be granted access via an <accesses> stanza in the module or view XML.");
+			LOGGER.warn(warning.toString());
+			LOGGER.info("If this user already has a document or action privilege, check if they were navigated to this page/resource programatically or by means other than the menu or views and need to be granted access via an <accesses> stanza in the module or view XML.");
 			throw new AccessException(resource, userName);
 		}
 	}

--- a/skyve-ext/src/main/java/org/skyve/impl/addin/PF4JAddInManager.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/addin/PF4JAddInManager.java
@@ -7,11 +7,13 @@ import org.pf4j.DefaultPluginManager;
 import org.pf4j.PluginManager;
 import org.pf4j.PluginWrapper;
 import org.skyve.addin.AddInManager;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PF4JAddInManager implements AddInManager {
 	private static final PF4JAddInManager INSTANCE = new PF4JAddInManager();
+	private static final Logger LOGGER = LoggerFactory.getLogger(PF4JAddInManager.class);
 
 	private PluginManager plugInManager;
 
@@ -26,20 +28,20 @@ public class PF4JAddInManager implements AddInManager {
 	@Override
 	public void startup() {
 		String addinsDirectory = Util.getAddinsDirectory();
-		UtilImpl.LOGGER.info("Add-Ins directory = " + addinsDirectory);
+		LOGGER.info("Add-Ins directory = " + addinsDirectory);
 		plugInManager = new DefaultPluginManager(Paths.get(Util.getAddinsDirectory()));
 		plugInManager.loadPlugins();
 		plugInManager.startPlugins();
 		
 		for (PluginWrapper plugin : plugInManager.getStartedPlugins()) {
-			UtilImpl.LOGGER.info("Add-in " + plugin.getPluginId() + " : " + plugin.getDescriptor() + " has started.");
+			LOGGER.info("Add-in " + plugin.getPluginId() + " : " + plugin.getDescriptor() + " has started.");
 			for (Class<?> extension : plugInManager.getExtensionClasses(plugin.getPluginId())) {
-				UtilImpl.LOGGER.info("    Extension " + extension + " has been registered.");
+				LOGGER.info("    Extension " + extension + " has been registered.");
 			}
 		}
 
 		for (PluginWrapper plugin : plugInManager.getUnresolvedPlugins()) {
-			UtilImpl.LOGGER.warning("Add-in " + plugin.getPluginId() + " : " + plugin.getDescriptor() + " is unresolved.");
+			LOGGER.warn("Add-in " + plugin.getPluginId() + " : " + plugin.getDescriptor() + " is unresolved.");
 		}
 	}
 	

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/AzureBlobStorageBackup.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/AzureBlobStorageBackup.java
@@ -10,7 +10,8 @@ import java.util.stream.Collectors;
 
 import org.skyve.CORE;
 import org.skyve.impl.util.UtilImpl;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
@@ -23,6 +24,9 @@ import com.azure.storage.blob.models.ParallelTransferOptions;
 import com.azure.storage.blob.specialized.BlobOutputStream;
 
 public class AzureBlobStorageBackup implements ExternalBackup {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureBlobStorageBackup.class);
+
 	public static final String AZURE_CONNECTION_STRING_KEY = "connectionString";
 	public static final String AZURE_CONTAINER_NAME_KEY = "containerName";
 
@@ -43,20 +47,20 @@ public class AzureBlobStorageBackup implements ExternalBackup {
 
 	@Override
 	public void downloadBackup(String backupName, OutputStream outputStream) {
-		UtilImpl.LOGGER.info("Downloading backup " + backupName + " from Azure");
+		LOGGER.info("Downloading backup " + backupName + " from Azure");
 		getBlobContainerClient().getBlobClient(getDirectoryName() + backupName).downloadStream(outputStream);
 	}
 
 	@Override
 	public void uploadBackup(String backupFilePath) {
-		UtilImpl.LOGGER.info("Uploading backup " + Paths.get(backupFilePath).getFileName().toString() + " to Azure");
+		LOGGER.info("Uploading backup " + Paths.get(backupFilePath).getFileName().toString() + " to Azure");
 		getBlobContainerClient().getBlobClient(getDirectoryName() + Paths.get(backupFilePath).getFileName().toString())
 				.uploadFromFile(backupFilePath);
 	}
 
 	@Override
 	public void deleteBackup(String backupName) {
-		UtilImpl.LOGGER.info("Deleting backup " + backupName + " from Azure");
+		LOGGER.info("Deleting backup " + backupName + " from Azure");
 		getBlobContainerClient().getBlobClient(getDirectoryName() + backupName).delete();
 	}
 
@@ -80,7 +84,7 @@ public class AzureBlobStorageBackup implements ExternalBackup {
 
 		try {
 			BlobClient destBlobClient = getBlobContainerClient().getBlobClient(getDirectoryName() + destBackupName);
-			Util.LOGGER.info("Copying from " + srcBackupName + " to " + destBackupName + " in Azure");
+			LOGGER.info("Copying from " + srcBackupName + " to " + destBackupName + " in Azure");
 
 			// copy the backup in chunks to workaround Azure's blob size limit
 			long blockSize = 4 * 1024 * 1024; // 4 MB
@@ -103,7 +107,7 @@ public class AzureBlobStorageBackup implements ExternalBackup {
 				}
 			}
 
-			Util.LOGGER.info("Successfully copied to " + destBackupName + " in Azure");
+			LOGGER.info("Successfully copied to " + destBackupName + " in Azure");
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/BackupJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/BackupJob.java
@@ -53,6 +53,8 @@ import org.skyve.util.FileUtil;
 import org.skyve.util.Mail;
 import org.skyve.util.PushMessage;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.supercsv.io.CsvMapWriter;
 import org.supercsv.prefs.CsvPreference;
 
@@ -71,6 +73,9 @@ import jakarta.annotation.Nullable;
  * of the content node - ie module name and document name are not known to the table.
  */
 public class BackupJob extends CancellableJob {
+    
+    private static final Logger SLOGGER = LoggerFactory.getLogger(BackupJob.class);
+
 	private File backupZip;
 
 	public File getBackupZip() {
@@ -97,7 +102,7 @@ public class BackupJob extends CancellableJob {
 		String trace = "Backup to " + directory.getAbsolutePath();
 		String causation = null;
 		log.add(trace);
-		UtilImpl.LOGGER.info(trace);
+		LOGGER.info(trace);
 		
 		// Are we including audits in this backup?
 		boolean includeAuditLog = getIncludeAuditLog(bean);
@@ -138,7 +143,7 @@ public class BackupJob extends CancellableJob {
 										try (ResultSet resultSet = statement.getResultSet()) {
 											trace = "Backup " + table.agnosticIdentifier;
 											log.add(trace);
-											UtilImpl.LOGGER.info(trace);
+											LOGGER.info(trace);
 											try (OutputStreamWriter out = new OutputStreamWriter(
 													new FileOutputStream(backupDir + File.separator + table.agnosticIdentifier + ".csv"), UTF_8)) {
 												try (CsvMapWriter writer = new CsvMapWriter(out, CsvPreference.STANDARD_PREFERENCE)) {
@@ -406,7 +411,7 @@ public class BackupJob extends CancellableJob {
 										problems.write(trace);
 										problems.newLine();
 										log.add(trace);
-										Util.LOGGER.severe(trace);
+										LOGGER.error(trace);
 										throw e;
 									}
 								}
@@ -428,14 +433,14 @@ public class BackupJob extends CancellableJob {
 				trace = "A problem backing up " + UtilImpl.ARCHIVE_NAME + " was encountered : " + t.getLocalizedMessage();
 				causation = trace;
 				log.add(trace);
-				Util.LOGGER.info(trace);
+				LOGGER.info(trace);
 				throw t;
 			}
 			finally {
 				if (directory.exists()) {
 					trace = "Created backup folder " + directory.getAbsolutePath();
 					log.add(trace);
-					Util.LOGGER.info(trace);
+					LOGGER.info(trace);
 					setPercentComplete(50);
 					try {
 						File zip = new File(directory.getParentFile(),
@@ -443,19 +448,19 @@ public class BackupJob extends CancellableJob {
 						FileUtil.createZipArchive(directory, zip);
 						trace = "Compressed backup to " + zip.getAbsolutePath();
 						log.add(trace);
-						Util.LOGGER.info(trace);
+						LOGGER.info(trace);
 						backupZip = zip;
 	
 						if (ExternalBackup.areExternalBackupsEnabled()) {
 							ExternalBackup.getInstance().uploadBackup(zip.getAbsolutePath());
 							final String uploadLogMessage = "Uploaded compressed backup";
 							log.add(uploadLogMessage);
-							Util.LOGGER.info(uploadLogMessage);
+							LOGGER.info(uploadLogMessage);
 	
 							FileUtil.delete(zip);
 							final String deleteLogMessage = "Deleted local backup";
 							log.add(deleteLogMessage);
-							Util.LOGGER.info(deleteLogMessage);
+							LOGGER.info(deleteLogMessage);
 						}
 					}
 					catch (Throwable t) {
@@ -465,18 +470,18 @@ public class BackupJob extends CancellableJob {
 							causation = trace;
 						}
 						log.add(trace);
-						Util.LOGGER.info(trace);
+						LOGGER.info(trace);
 						throw t;
 					}
 					finally {
 						FileUtil.delete(directory);
 						trace = "Deleted backup folder " + directory.getAbsolutePath();
 						log.add(trace);
-						Util.LOGGER.info(trace);
+						LOGGER.info(trace);
 						setPercentComplete(100);
 						trace = "Backup Completed" + (problem ? " with problems" : "");
 						log.add(trace);
-						Util.LOGGER.info(trace);
+						LOGGER.info(trace);
 						EXT.push(new PushMessage().user().growl(MessageSeverity.info, trace));
 					}
 				}
@@ -507,7 +512,7 @@ public class BackupJob extends CancellableJob {
 		else {
 			String trace = "Could not send a backup problem email as there is not a support email address defined - " + body;
 			jobLog.add(trace);
-			Util.LOGGER.info(trace);
+			SLOGGER.info(trace);
 		}
 	}
 

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/BackupUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/BackupUtil.java
@@ -61,8 +61,15 @@ import org.skyve.metadata.module.Module.DocumentRef;
 import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.persistence.DataStore;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class BackupUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackupUtil.class);
+    private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
+
 	private BackupUtil() {
 		// nothing to see here
 	}
@@ -226,7 +233,7 @@ final class BackupUtil {
 					persistence.newSQL(command).noTimeout().execute();
 				}
 				catch (Exception e) {
-					Util.LOGGER.severe("Could not execute SQL " + command);
+					LOGGER.error("Could not execute SQL " + command);
 					throw e;
 				}
 			}
@@ -247,7 +254,7 @@ final class BackupUtil {
 			if (table == null) {
 				table = new Table(agnosticIdentifier, persistentIdentifier);
 				tables.put(agnosticIdentifier, table);
-				if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("Table definition created for " + agnosticIdentifier);
+				if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("Table definition created for " + agnosticIdentifier);
 			}
 
 			table.addFieldsFromDocument(customer, document);
@@ -290,7 +297,7 @@ final class BackupUtil {
 												if (! tables.containsKey(joinAgnosticIdentifier)) {
 													JoinTable joinTable = new JoinTable(joinAgnosticIdentifier, joinPersistentIdentifier, ownerAgnosticIdentifier, ownerPersistentIdentifier, Boolean.TRUE.equals(collection.getOrdered()));
 													tables.put(joinAgnosticIdentifier, joinTable);
-													if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("Table definition created for " + joinAgnosticIdentifier);
+													if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("Table definition created for " + joinAgnosticIdentifier);
 												}
 											}
 										}
@@ -334,7 +341,7 @@ final class BackupUtil {
 										if (! tables.containsKey(joinAgnosticIdentifier)) {
 											JoinTable joinTable = new JoinTable(joinAgnosticIdentifier, joinPersistentIdentifier, ownerAgnosticIdentifier, ownerPersistentIdentifier, Boolean.TRUE.equals(collection.getOrdered()));
 											tables.put(joinAgnosticIdentifier, joinTable);
-											if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("Table definition created for " + joinAgnosticIdentifier);
+											if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("Table definition created for " + joinAgnosticIdentifier);
 										}
 									}
 									else {
@@ -343,7 +350,7 @@ final class BackupUtil {
 										if (! tables.containsKey(joinAgnosticIdentifier)) {
 											JoinTable joinTable = new JoinTable(joinAgnosticIdentifier, joinPersistentIdentifier, ownerAgnosticIdentifier, ownerPersistentIdentifier, Boolean.TRUE.equals(collection.getOrdered()));
 											tables.put(joinAgnosticIdentifier, joinTable);
-											if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("Table definition created for " + joinAgnosticIdentifier);
+											if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("Table definition created for " + joinAgnosticIdentifier);
 										}
 									}
 								}

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/ReindexAttachmentsJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/ReindexAttachmentsJob.java
@@ -12,7 +12,6 @@ import org.skyve.content.AttachmentContent;
 import org.skyve.content.ContentManager;
 import org.skyve.impl.content.AbstractContentManager;
 import org.skyve.impl.metadata.model.document.field.Field.IndexType;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.job.CancellableJob;
 import org.skyve.metadata.model.Attribute.AttributeType;
 
@@ -28,7 +27,7 @@ public class ReindexAttachmentsJob extends CancellableJob {
 		try (ContentManager cm = EXT.newContentManager()) {
 			trace = "Truncate Attachments";
 			log.add(trace);
-			UtilImpl.LOGGER.info(trace);
+			LOGGER.info(trace);
 			cm.truncateAttachments(customerName);
 		}
 
@@ -50,7 +49,7 @@ public class ReindexAttachmentsJob extends CancellableJob {
 					if (! hasContent(table)) {
 						trace = "Skipping table " + table.persistentIdentifier;
 						getLog().add(trace);
-						UtilImpl.LOGGER.info(trace);
+						LOGGER.info(trace);
                 		continue;
                 	}
 
@@ -62,7 +61,7 @@ public class ReindexAttachmentsJob extends CancellableJob {
 						try (ResultSet resultSet = statement.getResultSet()) {
 							trace = "Reindexing content for " + table.persistentIdentifier;
 							log.add(trace);
-							UtilImpl.LOGGER.info(trace);
+							LOGGER.info(trace);
 
 							while (resultSet.next()) {
 								if (isCancelled()) {
@@ -81,7 +80,7 @@ public class ReindexAttachmentsJob extends CancellableJob {
 													trace = String.format("Error reindexing content %s for field name %s for table %s - content does not exist",
 																			stringValue, name, table.persistentIdentifier);
 													log.add(trace);
-													UtilImpl.LOGGER.severe(trace);
+													LOGGER.error(trace);
 												}
 												else {
 													IndexType indexType = table.indexes.get(name);
@@ -95,7 +94,7 @@ public class ReindexAttachmentsJob extends CancellableJob {
 												trace = String.format("Error reindexing content %s for field name %s for table %s - caused by %s",
 																		stringValue, name, table.persistentIdentifier, e.getLocalizedMessage());
 												log.add(trace);
-												UtilImpl.LOGGER.severe(trace);
+												LOGGER.error(trace);
 												e.printStackTrace();
 											}
 										}
@@ -110,7 +109,7 @@ public class ReindexAttachmentsJob extends CancellableJob {
 		}
 		trace = "Reindexing content complete";
 		log.add(trace);
-		UtilImpl.LOGGER.info(trace);
+		LOGGER.info(trace);
 		setPercentComplete(100);
 	}
 	

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/ReindexBeansJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/ReindexBeansJob.java
@@ -12,7 +12,6 @@ import org.skyve.impl.metadata.model.document.field.Field;
 import org.skyve.impl.metadata.model.document.field.Field.IndexType;
 import org.skyve.impl.metadata.model.document.field.Memo;
 import org.skyve.impl.persistence.AbstractPersistence;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.job.CancellableJob;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.Attribute;
@@ -37,7 +36,7 @@ public class ReindexBeansJob extends CancellableJob {
 		try (ContentManager cm = EXT.newContentManager()) {
 			trace = "Truncate Beans";
 			log.add(trace);
-			UtilImpl.LOGGER.info(trace);
+			LOGGER.info(trace);
 			cm.truncateBeans(customer.getName());
 		}
 		
@@ -63,7 +62,7 @@ public class ReindexBeansJob extends CancellableJob {
 								// (i.e. a document field used to be indexed but now is not)
 								trace = String.format("Reindex document %s.%s", moduleName, documentName);
 								log.add(trace);
-								UtilImpl.LOGGER.info(trace);
+								LOGGER.info(trace);
 								if (document.isDynamic()) {
 									SQL query = persistence.newSQL(String.format("select %s from %s where %s = :%s and %s = :%s",
 																					Bean.DOCUMENT_ID,
@@ -103,7 +102,7 @@ public class ReindexBeansJob extends CancellableJob {
 					else {
 						trace = String.format("Skipping document %s.%s", document.getOwningModuleName(), document.getName());
 						getLog().add(trace);
-						UtilImpl.LOGGER.info(trace);
+						LOGGER.info(trace);
 					}
 				}
 			}
@@ -111,7 +110,7 @@ public class ReindexBeansJob extends CancellableJob {
 		}
 		trace = "Reindex beans complete";
 		log.add(trace);
-		UtilImpl.LOGGER.info(trace);
+		LOGGER.info(trace);
 		setPercentComplete(100);
 	}
 	

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/Table.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/Table.java
@@ -28,11 +28,15 @@ import org.skyve.metadata.model.document.Association.AssociationType;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.util.JSON;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 class Table {
 	static final ImmutablePair<AttributeType, Sensitivity> TEXT = ImmutablePair.of(AttributeType.text, Sensitivity.none);
 	static final ImmutablePair<AttributeType, Sensitivity> ASSOCIATION = ImmutablePair.of(AttributeType.association, Sensitivity.none);
 	static final ImmutablePair<AttributeType, Sensitivity> INTEGER = ImmutablePair.of(AttributeType.integer, Sensitivity.none);
+
+    private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
 
 	String agnosticIdentifier;
 	String persistentIdentifier;
@@ -127,7 +131,7 @@ class Table {
 							}
 							
 							fields.put(attributeName + "_id", ImmutablePair.of(attributeType, Sensitivity.none));
-							if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(agnosticIdentifier + " - Put " + attributeName + "_id -> " + attributeType);
+							if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(agnosticIdentifier + " - Put " + attributeName + "_id -> " + attributeType);
 						}
 					}
 				}
@@ -154,7 +158,7 @@ class Table {
 						Pair<AttributeType, Sensitivity> pair = fields.get(fieldName);
 						if (pair == null) {
 							fields.put(fieldName, MutablePair.of(attributeType, sensitivity));
-							if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(agnosticIdentifier + " - Put " + fieldName + " -> " + attributeType);
+							if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(agnosticIdentifier + " - Put " + fieldName + " -> " + attributeType);
 						}
 						else {
 							Sensitivity existing = pair.getRight();

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/Truncate.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/Truncate.java
@@ -17,8 +17,13 @@ import org.skyve.impl.persistence.AbstractPersistence;
 import org.skyve.impl.persistence.hibernate.AbstractHibernatePersistence;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.persistence.Persistence;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public class Truncate {
+
+    private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
+
 	public static void truncate(String schemaName, boolean database, boolean content) 
 	throws Exception {
 		Collection<Table> tables = getTables(schemaName);
@@ -50,7 +55,7 @@ public class Truncate {
 					sql.setLength(sql.length() - 1); // remove the comma
 
 					BackupUtil.secureSQL(sql, table, customerName);
-					if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("unlink table " + table.persistentIdentifier);
+					if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("unlink table " + table.persistentIdentifier);
 					persistence.newSQL(sql.toString()).noTimeout().execute();
 					persistence.commit(false);
 					persistence.begin();
@@ -63,7 +68,7 @@ public class Truncate {
 					sql.setLength(0);
 					sql.append("delete from ").append(table.persistentIdentifier);
 					BackupUtil.secureSQL(sql, table, customerName);
-					if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("delete joining table " + table.persistentIdentifier);
+					if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("delete joining table " + table.persistentIdentifier);
 					persistence.newSQL(sql.toString()).noTimeout().execute();
 					persistence.commit(false);
 					persistence.begin();
@@ -81,7 +86,7 @@ public class Truncate {
 				sql.setLength(0);
 				sql.append("delete from ").append(table.persistentIdentifier);
 				BackupUtil.secureSQL(sql, table, customerName);
-				if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("delete extension table " + table.persistentIdentifier);
+				if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("delete extension table " + table.persistentIdentifier);
 				persistence.newSQL(sql.toString()).noTimeout().execute();
 				persistence.commit(false);
 				persistence.begin();
@@ -98,7 +103,7 @@ public class Truncate {
 				sql.setLength(0);
 				sql.append("delete from ").append(table.persistentIdentifier);
 				BackupUtil.secureSQL(sql, table, customerName);
-				if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("delete table " + table.persistentIdentifier);
+				if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("delete table " + table.persistentIdentifier);
 				persistence.newSQL(sql.toString()).noTimeout().execute();
 				persistence.commit(false);
 				persistence.begin();

--- a/skyve-ext/src/main/java/org/skyve/impl/bizport/POISheetLoader.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/bizport/POISheetLoader.java
@@ -17,7 +17,6 @@ import org.skyve.domain.messages.DomainException;
 import org.skyve.domain.messages.UploadException;
 import org.skyve.domain.types.DateTime;
 import org.skyve.domain.types.converters.Converter;
-import org.skyve.util.Util;
 
 public class POISheetLoader extends AbstractDataFileLoader {
 
@@ -131,7 +130,7 @@ public class POISheetLoader extends AbstractDataFileLoader {
 				foundNonEmpty = true;
 				break;
 			} else if(debugMode){
-				Util.LOGGER.info(getWhere(field.getIndex().intValue()) + " No value was found at this location.");
+				LOGGER.info(getWhere(field.getIndex().intValue()) + " No value was found at this location.");
 			}
 		}
 

--- a/skyve-ext/src/main/java/org/skyve/impl/bizport/StandardGenerator.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/bizport/StandardGenerator.java
@@ -14,7 +14,6 @@ import org.skyve.domain.ChildBean;
 import org.skyve.domain.HierarchicalBean;
 import org.skyve.domain.PersistentBean;
 import org.skyve.impl.bind.BindUtil;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.Attribute;
 import org.skyve.metadata.model.Attribute.AttributeType;
@@ -30,6 +29,8 @@ import org.skyve.metadata.model.document.Relation;
 import org.skyve.metadata.module.Module;
 import org.skyve.util.BeanVisitor;
 import org.skyve.util.NullableBeanVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -41,6 +42,9 @@ import jakarta.annotation.Nullable;
  *
  */
 public final class StandardGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandardGenerator.class);
+
 	/**
 	 * The relevant customer for the generation.
 	 */
@@ -85,7 +89,7 @@ public final class StandardGenerator {
 											Document owningDocument,
 											Relation owningRelation,
 											Bean processBean) throws Exception {
-				UtilImpl.LOGGER.info("B = " + binding);
+				LOGGER.info("B = " + binding);
 
 				// stop recursive processing if we have matched an exclusion
 				for (String exclusion : exclusions) {

--- a/skyve-ext/src/main/java/org/skyve/impl/bizport/StandardLoader.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/bizport/StandardLoader.java
@@ -18,7 +18,6 @@ import org.skyve.domain.messages.Message;
 import org.skyve.domain.messages.MessageException;
 import org.skyve.domain.messages.UploadException;
 import org.skyve.impl.bind.BindUtil;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.Attribute;
 import org.skyve.metadata.model.Attribute.AttributeType;
@@ -31,6 +30,8 @@ import org.skyve.metadata.user.User;
 import org.skyve.persistence.Persistence;
 import org.skyve.util.Binder.TargetMetaData;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -49,6 +50,8 @@ import jakarta.annotation.Nullable;
  */
 public class StandardLoader {
 	private static final String REFERENCED_ROW_DNE_MESSAGE_KEY = "bizport.referencedRowDoesNotExist";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandardLoader.class);
 
 	private @Nonnull BizPortWorkbook workbook;
 	
@@ -622,9 +625,8 @@ public class StandardLoader {
 		BizPortColumn column = sheet.getColumn(Bean.DOCUMENT_ID);
 		Object sheetRowId = bizIdToSheetRowId.get(bean.getBizId());
 		sheet.moveToRow(sheetRowId);
+		LOGGER.error("An error has occurred when loading...", e);
 		if (e instanceof MessageException) {
-			UtilImpl.LOGGER.severe("An error has occurred when loading...");
-			e.printStackTrace();
 			Module module = customer.getModule(bean.getBizModule());
 			Document document = module.getDocument(customer, bean.getBizDocument());
 			for (Message em : ((MessageException) e).getMessages()) {
@@ -632,8 +634,6 @@ public class StandardLoader {
 			}
 		}
 		else {
-			UtilImpl.LOGGER.severe("An error has occurred when loading...");
-			e.printStackTrace();
 			sheet.addErrorAtCurrentRow(problems, column, e.getMessage());
 		}
 	}

--- a/skyve-ext/src/main/java/org/skyve/impl/cache/DefaultCaching.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/cache/DefaultCaching.java
@@ -36,8 +36,13 @@ import org.skyve.cache.HibernateCacheConfig;
 import org.skyve.cache.JCacheConfig;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultCaching implements Caching {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCaching.class);
+
 	private static final DefaultCaching INSTANCE = new DefaultCaching();
 
 	private static PersistentCacheManager ehCacheManager;
@@ -69,37 +74,37 @@ public class DefaultCaching implements Caching {
 				
 				// Create the conversations cache
 				if (UtilImpl.CONVERSATION_CACHE != null) {
-					UtilImpl.LOGGER.info("Create the conversation cache with config " + UtilImpl.CONVERSATION_CACHE);
+					LOGGER.info("Create the conversation cache with config " + UtilImpl.CONVERSATION_CACHE);
 					createEHCache(UtilImpl.CONVERSATION_CACHE);
 				}
 	
 				// Create the CSRF Token cache
 				if (UtilImpl.CSRF_TOKEN_CACHE != null) {
-					UtilImpl.LOGGER.info("Create the CSRF token cache with config " + UtilImpl.CSRF_TOKEN_CACHE);
+					LOGGER.info("Create the CSRF token cache with config " + UtilImpl.CSRF_TOKEN_CACHE);
 					createEHCache(UtilImpl.CSRF_TOKEN_CACHE);
 				}
 
 				// Create the Geo IP cache
 				if (UtilImpl.GEO_IP_CACHE != null) {
-					UtilImpl.LOGGER.info("Create the Geo IP cache with config " + UtilImpl.GEO_IP_CACHE);
+					LOGGER.info("Create the Geo IP cache with config " + UtilImpl.GEO_IP_CACHE);
 					createEHCache(UtilImpl.GEO_IP_CACHE);
 				}
 
 				// Create the sessions cache
 				if (UtilImpl.SESSION_CACHE != null) {
-					UtilImpl.LOGGER.info("Create the session cache with config " + UtilImpl.SESSION_CACHE);
+					LOGGER.info("Create the session cache with config " + UtilImpl.SESSION_CACHE);
 					createEHCache(UtilImpl.SESSION_CACHE);
 				}
 
 				// Create the app caches
 				for (CacheConfig<? extends Serializable, ? extends Serializable> config : UtilImpl.APP_CACHES) {
-					UtilImpl.LOGGER.info("Create app cache with config " + config);
+					LOGGER.info("Create app cache with config " + config);
 					createCache(config);
 				}
 				
 				// Create the hibernate caches
 				for (HibernateCacheConfig config : UtilImpl.HIBERNATE_CACHES) {
-					UtilImpl.LOGGER.info("Create hibernate cache with config " + config);
+					LOGGER.info("Create hibernate cache with config " + config);
 					createJCache(config);
 				}
 			}
@@ -233,7 +238,7 @@ public class DefaultCaching implements Caching {
 			result = statisticsService.getCacheStatistics(name);
 		}
 		catch (@SuppressWarnings("unused") Exception e) {
-			UtilImpl.LOGGER.warning("Cache Stats requested on EHCache " + name + "that does not exist");
+			LOGGER.warn("Cache Stats requested on EHCache " + name + "that does not exist");
 		}
 		return result;
 	}
@@ -251,7 +256,7 @@ public class DefaultCaching implements Caching {
 			objectName = new ObjectName("*:type=CacheStatistics,*,Cache=" + name);
 		}
 		catch (MalformedObjectNameException e) {
-			UtilImpl.LOGGER.severe("Could not create statistics object name for cache " + name);
+			LOGGER.error("Could not create statistics object name for cache " + name);
 			e.printStackTrace();
 		}
 		Set<ObjectName> beans = mbeanServer.queryNames(objectName, null);

--- a/skyve-ext/src/main/java/org/skyve/impl/cache/StateUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/cache/StateUtil.java
@@ -28,6 +28,8 @@ import org.skyve.domain.messages.SessionEndedException;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.AbstractWebContext;
 import org.skyve.util.IPGeolocation;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -35,6 +37,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
 public class StateUtil {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private StateUtil() {
 		// Disallow instantiation.
 	}
@@ -240,8 +245,8 @@ public class StateUtil {
 		logCacheStats(UtilImpl.CSRF_TOKEN_CACHE.getName(), "CSRF Token");
 		logCacheStats(UtilImpl.GEO_IP_CACHE.getName(), "Geo IP");
 		logCacheStats(UtilImpl.SESSION_CACHE.getName(), "User Session");
-		UtilImpl.LOGGER.info("Session count = " + SESSION_COUNT.get());
-		UtilImpl.LOGGER.info("********************************************************************************");
+		FACES_LOGGER.info("Session count = " + SESSION_COUNT.get());
+		FACES_LOGGER.info("********************************************************************************");
 	}
 	
 	private static void logCacheStats(@Nonnull String cacheName, @Nonnull String cacheDescription) {
@@ -252,21 +257,21 @@ public class StateUtil {
 			TierStatistics tier = caching.getEHTierStatistics(statistics, CacheTier.OnHeap);
 			if (tier != null) {
 				log.append(cacheDescription).append(" Count in heap memory = ").append(tier.getMappings());
-				UtilImpl.LOGGER.info(log.toString());
+				FACES_LOGGER.info(log.toString());
 				log.setLength(0);
 			}
 			tier = caching.getEHTierStatistics(statistics, CacheTier.OffHeap);
 			if (tier != null) {
 				log.append(cacheDescription).append(" Count/MB in off-heap memory = ").append(tier.getMappings());
 				log.append('/').append((long) (tier.getOccupiedByteSize() / 1024.0 / 1024.0 * 10.0) / 10.0);
-				UtilImpl.LOGGER.info(log.toString());
+				FACES_LOGGER.info(log.toString());
 				log.setLength(0);
 			}
 			tier = caching.getEHTierStatistics(statistics, CacheTier.Disk);
 			if (tier != null) {
 				log.append(cacheDescription).append(" Count/MB on disk = ").append(tier.getMappings());
 				log.append('/').append((long) (tier.getOccupiedByteSize() / 1024.0 / 1024.0 * 10.0) / 10.0);
-				UtilImpl.LOGGER.info(log.toString());
+				FACES_LOGGER.info(log.toString());
 			}
 		}
 	}

--- a/skyve-ext/src/main/java/org/skyve/impl/content/AbstractContentManager.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/content/AbstractContentManager.java
@@ -23,8 +23,14 @@ import org.skyve.metadata.MetaDataException;
 import org.skyve.metadata.user.User;
 import org.skyve.util.FileUtil;
 import org.skyve.util.JSON;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public abstract class AbstractContentManager implements ContentManager {
+
+    private static final Logger CONTENT_LOGGER = Category.CONTENT.logger();
+    private static final Logger SECURITY_LOGGER = Category.SECURITY.logger();
+
     public static final String META_JSON = "meta.json";
 	public static final String CONTENT = "content";
 	public static final String CONTENT_ID = "id";
@@ -36,7 +42,6 @@ public abstract class AbstractContentManager implements ContentManager {
 	protected static final String CLUSTER_NAME = "SKYVE_CONTENT";
     protected static final String MARKUP = "markup";
 
-    
 	public static Class<? extends AbstractContentManager> IMPLEMENTATION_CLASS;
 	
 	public static AbstractContentManager get() {
@@ -99,12 +104,12 @@ public abstract class AbstractContentManager implements ContentManager {
 		}
 		catch (@SuppressWarnings("unused") MetaDataException e) {
 			// This can happen when a document was indexed but then the customer access was taken away
-			if (UtilImpl.SECURITY_TRACE) System.err.println("Could not get the document for " + bizModule + '.' + bizDocument);
+			if (UtilImpl.SECURITY_TRACE) SECURITY_LOGGER.info("Could not get the document for " + bizModule + '.' + bizDocument);
 			return false;
 		}
 		catch (@SuppressWarnings("unused") DomainException e) {
 			// This happens when the data was deleted but the CMS was not kept in sync
-			if (UtilImpl.SECURITY_TRACE) System.err.println("Could not retrieve bean " + bizModule + '.' + bizDocument + " with ID " + bizId);
+			if (UtilImpl.SECURITY_TRACE) SECURITY_LOGGER.info("Could not retrieve bean " + bizModule + '.' + bizDocument + " with ID " + bizId);
 			return false;
 		}
 	}
@@ -200,12 +205,12 @@ public abstract class AbstractContentManager implements ContentManager {
 
 		File dir = new File(path);
 		if (! dir.exists()) {
-			if (UtilImpl.CONTENT_TRACE) UtilImpl.LOGGER.info("AbstractContentManager.get(" + path + ") - Dir DNE");
+			if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.info("AbstractContentManager.get(" + path + ") - Dir DNE");
 			return null;
 		}
 		File metaFile = new File(dir, META_JSON);
 		if (! metaFile.exists()) {
-			if (UtilImpl.CONTENT_TRACE) UtilImpl.LOGGER.info("AbstractContentManager.get(" + metaFile.getPath() + ") - Meta File DNE");
+			if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.info("AbstractContentManager.get(" + metaFile.getPath() + ") - Meta File DNE");
 			return null;
 		}
 		@SuppressWarnings("unchecked")
@@ -213,7 +218,7 @@ public abstract class AbstractContentManager implements ContentManager {
 
 		File file = new File(dir, CONTENT);
 		if (! file.exists()) {
-			if (UtilImpl.CONTENT_TRACE) UtilImpl.LOGGER.info("AbstractContentManager.get(" + file.getPath() + ") - File DNE");
+			if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.info("AbstractContentManager.get(" + file.getPath() + ") - File DNE");
 			return null;
 		}
 		
@@ -249,7 +254,7 @@ public abstract class AbstractContentManager implements ContentManager {
 		result.setLastModified(lastModified);
 		result.setContentType(contentType);
 		result.setContentId(contentId);
-		if (UtilImpl.CONTENT_TRACE) UtilImpl.LOGGER.info("AbstractContentManager.get(" + contentId + "): exists");
+		if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.info("AbstractContentManager.get(" + contentId + "): exists");
 
 		return result;
 	}

--- a/skyve-ext/src/main/java/org/skyve/impl/content/ejb/AbstractEJBRemoteContentManagerClient.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/content/ejb/AbstractEJBRemoteContentManagerClient.java
@@ -5,7 +5,8 @@ import org.skyve.content.BeanContent;
 import org.skyve.content.ContentIterable;
 import org.skyve.content.SearchResults;
 import org.skyve.impl.content.AbstractContentManager;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is used to talk to another skyve server's EJB content server.
@@ -38,6 +39,9 @@ import org.skyve.util.Util;
  * </pre>
  */
 public abstract class AbstractEJBRemoteContentManagerClient extends AbstractContentManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractEJBRemoteContentManagerClient.class);
+
 	@Override
 	public void startup() {
 		// nothing to do here
@@ -57,49 +61,49 @@ public abstract class AbstractEJBRemoteContentManagerClient extends AbstractCont
 	
 	@Override
 	public void put(BeanContent content) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.put() sent for " + content.getBizId());
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.put() sent for " + content.getBizId());
 		EJBRemoteContentManagerServer server = obtainServer();
 		server.put(content);
 	}
 
 	@Override
 	public void put(AttachmentContent content, boolean index) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.put() sent for " + content.getBizId() + " attribute " + content.getAttributeName());
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.put() sent for " + content.getBizId() + " attribute " + content.getAttributeName());
 		EJBRemoteContentManagerServer server = obtainServer();
 		content.setContentId(server.put(content, index));
 	}
 
 	@Override
 	public void update(AttachmentContent content) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.update() sent for " + content.getContentId());
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.update() sent for " + content.getContentId());
 		EJBRemoteContentManagerServer server = obtainServer();
 		server.update(content);
 	}
 	
 	@Override
 	public AttachmentContent getAttachment(String contentId) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.getAttachment() sent for " + contentId);
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.getAttachment() sent for " + contentId);
 		EJBRemoteContentManagerServer server = obtainServer();
 		return server.getAttachment(contentId);
 	}
 
 	@Override
 	public void removeBean(String bizId) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.removeBean() sent for " + bizId);
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.removeBean() sent for " + bizId);
 		EJBRemoteContentManagerServer server = obtainServer();
 		server.removeBean(bizId);
 	}
 
 	@Override
 	public void removeAttachment(String contentId) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.removeAttachment() sent for " + contentId);
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.removeAttachment() sent for " + contentId);
 		EJBRemoteContentManagerServer server = obtainServer();
 		server.removeAttachment(contentId);
 	}
 
 	@Override
 	public SearchResults google(String search, int maxResults) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.google() sent for '" + search + '\'');
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.google() sent for '" + search + '\'');
 		EJBRemoteContentManagerServer server = obtainServer();
 		return server.google(search, maxResults);
 	}

--- a/skyve-ext/src/main/java/org/skyve/impl/content/ejb/AbstractEJBRemoteContentManagerServerBean.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/content/ejb/AbstractEJBRemoteContentManagerServerBean.java
@@ -5,7 +5,8 @@ import org.skyve.content.AttachmentContent;
 import org.skyve.content.BeanContent;
 import org.skyve.content.ContentManager;
 import org.skyve.content.SearchResults;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend this to make a stateless session bean in the skyve server instance.
@@ -23,9 +24,12 @@ import org.skyve.util.Util;
  * </code>
  */
 public abstract class AbstractEJBRemoteContentManagerServerBean implements EJBRemoteContentManagerServer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractEJBRemoteContentManagerServerBean.class);
+
 	@Override
 	public void put(BeanContent content) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.put() received for " + content.getBizId());
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.put() received for " + content.getBizId());
 		try (ContentManager cm = EXT.newContentManager()) {
 			cm.put(content);
 		}
@@ -33,7 +37,7 @@ public abstract class AbstractEJBRemoteContentManagerServerBean implements EJBRe
 	
 	@Override
 	public String put(AttachmentContent content, boolean index) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.put() received for " + content.getBizId() + " attribute " + content.getAttributeName());
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.put() received for " + content.getBizId() + " attribute " + content.getAttributeName());
 		try (ContentManager cm = EXT.newContentManager()) {
 			cm.put(content, index);
 			return content.getContentId();
@@ -42,7 +46,7 @@ public abstract class AbstractEJBRemoteContentManagerServerBean implements EJBRe
 
 	@Override
 	public void update(AttachmentContent content) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.update() received for " + content.getContentId());
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.update() received for " + content.getContentId());
 		try (ContentManager cm = EXT.newContentManager()) {
 			cm.update(content);
 		}
@@ -50,7 +54,7 @@ public abstract class AbstractEJBRemoteContentManagerServerBean implements EJBRe
 	
 	@Override
 	public AttachmentContent getAttachment(String contentId) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.getAttachment() received for " + contentId);
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.getAttachment() received for " + contentId);
 		try (ContentManager cm = EXT.newContentManager()) {
 			return cm.getAttachment(contentId);
 		}
@@ -58,7 +62,7 @@ public abstract class AbstractEJBRemoteContentManagerServerBean implements EJBRe
 
 	@Override
 	public void removeBean(String bizId) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.removeBean() received for " + bizId);
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.removeBean() received for " + bizId);
 		try (ContentManager cm = EXT.newContentManager()) {
 			cm.removeBean(bizId);
 		}
@@ -66,7 +70,7 @@ public abstract class AbstractEJBRemoteContentManagerServerBean implements EJBRe
 
 	@Override
 	public void removeAttachment(String contentId) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.removeAttachment() received for " + contentId);
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.removeAttachment() received for " + contentId);
 		try (ContentManager cm = EXT.newContentManager()) {
 			cm.removeAttachment(contentId);
 		}
@@ -74,7 +78,7 @@ public abstract class AbstractEJBRemoteContentManagerServerBean implements EJBRe
 	
 	@Override
 	public SearchResults google(String search, int maxResults) throws Exception {
-		Util.LOGGER.info("Remote call to EJBRemoteContentManagerServer.google() received for '" + search + '\'');
+		LOGGER.info("Remote call to EJBRemoteContentManagerServer.google() received for '" + search + '\'');
 		try (ContentManager cm = EXT.newContentManager()) {
 			return cm.google(search, maxResults);
 		}

--- a/skyve-ext/src/main/java/org/skyve/impl/content/rest/RestRemoteContentManagerClient.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/content/rest/RestRemoteContentManagerClient.java
@@ -14,6 +14,8 @@ import org.skyve.impl.cache.StateUtil;
 import org.skyve.impl.content.AbstractContentManager;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is used to talk to another skyve server's REST content server.
@@ -44,6 +46,8 @@ import org.skyve.util.Util;
 public class RestRemoteContentManagerClient extends AbstractContentManager {
 	private static final String REST_CONTENT_PATH = "/rest/content";
 	
+	private static final Logger LOGGER = LoggerFactory.getLogger(RestRemoteContentManagerClient.class);
+	
 	@Override
 	public void startup() {
 		if (UtilImpl.CONTENT_REST_SERVER_URL == null) {
@@ -63,7 +67,7 @@ public class RestRemoteContentManagerClient extends AbstractContentManager {
 
 	@Override
 	public void put(BeanContent content) throws Exception {
-		Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.put() sent for " + content.getBizId());
+		LOGGER.info("Remote call to RestRemoteContentManagerServer.put() sent for " + content.getBizId());
 		StringBuilder url = new StringBuilder(128);
 		url.append(UtilImpl.CONTENT_REST_SERVER_URL).append(REST_CONTENT_PATH).append(RestRemoteContentManagerServer.BEAN_PATH);
 		call(url.toString(), "PUT", StateUtil.encode64(content));
@@ -71,7 +75,7 @@ public class RestRemoteContentManagerClient extends AbstractContentManager {
 
 	@Override
 	public void put(AttachmentContent content, boolean index) throws Exception {
-		Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.put() sent for " + content.getBizId() + " attribute " + content.getAttributeName());
+		LOGGER.info("Remote call to RestRemoteContentManagerServer.put() sent for " + content.getBizId() + " attribute " + content.getAttributeName());
 		StringBuilder url = new StringBuilder(128);
 		url.append(UtilImpl.CONTENT_REST_SERVER_URL).append(REST_CONTENT_PATH).append(RestRemoteContentManagerServer.ATTACHMENT_PATH);
 		url.append("?index=").append(index);
@@ -81,7 +85,7 @@ public class RestRemoteContentManagerClient extends AbstractContentManager {
 
 	@Override
 	public void update(AttachmentContent content) throws Exception {
-		Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.update() sent for " + content.getContentId());
+		LOGGER.info("Remote call to RestRemoteContentManagerServer.update() sent for " + content.getContentId());
 		StringBuilder url = new StringBuilder(128);
 		url.append(UtilImpl.CONTENT_REST_SERVER_URL).append(REST_CONTENT_PATH).append(RestRemoteContentManagerServer.ATTACHMENT_PATH);
 		call(url.toString(), "POST", StateUtil.encode64(content));
@@ -89,7 +93,7 @@ public class RestRemoteContentManagerClient extends AbstractContentManager {
 	
 	@Override
 	public AttachmentContent getAttachment(String contentId) throws Exception {
-		Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.getAttachment() sent for " + contentId);
+		LOGGER.info("Remote call to RestRemoteContentManagerServer.getAttachment() sent for " + contentId);
 		StringBuilder url = new StringBuilder(128);
 		url.append(UtilImpl.CONTENT_REST_SERVER_URL).append(REST_CONTENT_PATH).append(RestRemoteContentManagerServer.ATTACHMENT_PATH).append('/').append(contentId);
 		String result = call(url.toString(), "GET", null);
@@ -98,7 +102,7 @@ public class RestRemoteContentManagerClient extends AbstractContentManager {
 
 	@Override
 	public void removeBean(String bizId) throws Exception {
-		Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.removeBean() sent for " + bizId);
+		LOGGER.info("Remote call to RestRemoteContentManagerServer.removeBean() sent for " + bizId);
 		StringBuilder url = new StringBuilder(128);
 		url.append(UtilImpl.CONTENT_REST_SERVER_URL).append(REST_CONTENT_PATH).append(RestRemoteContentManagerServer.BEAN_PATH).append('/').append(bizId);
 		call(url.toString(), "DELETE", null);
@@ -106,7 +110,7 @@ public class RestRemoteContentManagerClient extends AbstractContentManager {
 
 	@Override
 	public void removeAttachment(String contentId) throws Exception {
-		Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.removeAttachment() sent for " + contentId);
+		LOGGER.info("Remote call to RestRemoteContentManagerServer.removeAttachment() sent for " + contentId);
 		StringBuilder url = new StringBuilder(128);
 		url.append(UtilImpl.CONTENT_REST_SERVER_URL).append(REST_CONTENT_PATH).append(RestRemoteContentManagerServer.ATTACHMENT_PATH).append('/').append(contentId);
 		call(url.toString(), "DELETE", null);

--- a/skyve-ext/src/main/java/org/skyve/impl/content/rest/RestRemoteContentManagerServer.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/content/rest/RestRemoteContentManagerServer.java
@@ -6,7 +6,8 @@ import org.skyve.content.BeanContent;
 import org.skyve.content.ContentManager;
 import org.skyve.domain.Bean;
 import org.skyve.impl.cache.StateUtil;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.ws.rs.DELETE;
@@ -76,6 +77,8 @@ public class RestRemoteContentManagerServer {
 	protected static final String ATTACHMENT_PATH = "/attachment";
 	protected static final String BEAN_PATH = "/bean";
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestRemoteContentManagerServer.class);
+
 	@PUT
 	@Path(BEAN_PATH)
 	@Produces(MediaType.TEXT_PLAIN)
@@ -83,7 +86,7 @@ public class RestRemoteContentManagerServer {
 	public Response put(String content) {
 		try (ContentManager cm = EXT.newContentManager()) {
 			BeanContent result = StateUtil.decode64(content);
-			Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.put() received for " + result.getBizId());
+			LOGGER.info("Remote call to RestRemoteContentManagerServer.put() received for " + result.getBizId());
 		
 			cm.put(result);
 			return Response.ok().build();
@@ -101,7 +104,7 @@ public class RestRemoteContentManagerServer {
 	public Response put(String content, @QueryParam("index") boolean index) {
 		try (ContentManager cm = EXT.newContentManager()) {
 			AttachmentContent result = StateUtil.decode64(content);
-			Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.put() received for " + result.getBizId() + " attribute " + result.getAttributeName());
+			LOGGER.info("Remote call to RestRemoteContentManagerServer.put() received for " + result.getBizId() + " attribute " + result.getAttributeName());
 
 			cm.put(result, index);
 			return Response.ok(result.getContentId()).build();
@@ -119,7 +122,7 @@ public class RestRemoteContentManagerServer {
 	public Response update(String content) {
 		try (ContentManager cm = EXT.newContentManager()) {
 			AttachmentContent result = StateUtil.decode64(content);
-			Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.update() received for " + result.getContentId());
+			LOGGER.info("Remote call to RestRemoteContentManagerServer.update() received for " + result.getContentId());
 
 			cm.update(result);
 			return Response.ok().build();
@@ -135,7 +138,7 @@ public class RestRemoteContentManagerServer {
 	@Produces(MediaType.TEXT_PLAIN)
 	@SuppressWarnings("static-method")
 	public Response getAttachment(@PathParam("contentId") String contentId) {
-		Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.getAttachment() received for " + contentId);
+		LOGGER.info("Remote call to RestRemoteContentManagerServer.getAttachment() received for " + contentId);
 		try (ContentManager cm = EXT.newContentManager()) {
 			AttachmentContent content = cm.getAttachment(contentId);
 			if (content != null) {
@@ -155,7 +158,7 @@ public class RestRemoteContentManagerServer {
 	@Produces(MediaType.TEXT_PLAIN)
 	@SuppressWarnings("static-method")
 	public Response removeBean(@PathParam(Bean.DOCUMENT_ID) String bizId) {
-		Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.removeBean() received for " + bizId);
+		LOGGER.info("Remote call to RestRemoteContentManagerServer.removeBean() received for " + bizId);
 		try (ContentManager cm = EXT.newContentManager()) {
 			cm.removeBean(bizId);
 			return Response.ok().build();
@@ -171,7 +174,7 @@ public class RestRemoteContentManagerServer {
 	@Produces(MediaType.TEXT_PLAIN)
 	@SuppressWarnings("static-method")
 	public Response removeAttachment(@PathParam("contentId") String contentId) {
-		Util.LOGGER.info("Remote call to RestRemoteContentManagerServer.removeAttachment() received for " + contentId);
+		LOGGER.info("Remote call to RestRemoteContentManagerServer.removeAttachment() received for " + contentId);
 		try (ContentManager cm = EXT.newContentManager()) {
 			cm.removeAttachment(contentId);
 			return Response.ok().build();

--- a/skyve-ext/src/main/java/org/skyve/impl/create/MavenSkyveProject.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/create/MavenSkyveProject.java
@@ -19,9 +19,13 @@ import org.skyve.domain.app.AppConstants;
 import org.skyve.impl.metadata.repository.document.DocumentMetaData;
 import org.skyve.impl.metadata.repository.module.ModuleMetaData;
 import org.skyve.impl.script.SkyveScriptInterpreter;
-import org.skyve.impl.util.UtilImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MavenSkyveProject {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenSkyveProject.class);
+
 	private static final Path SKYVE_WAR_PATH = Paths.get("skyve-war");
 	public static final Path SKYVE_SRC_PATH = SKYVE_WAR_PATH.resolve("src").resolve("main").resolve("java");
 	public static final Path SKYVE_SRC_RESOURCES_PATH = SKYVE_WAR_PATH.resolve("src").resolve("main").resolve("resources");
@@ -251,7 +255,7 @@ public class MavenSkyveProject {
 			}
 		}
 		else {
-			UtilImpl.LOGGER.warning("No modules were detected, please check your script.");
+			LOGGER.warn("No modules were detected, please check your script.");
 		}
 	}
 
@@ -401,7 +405,7 @@ public class MavenSkyveProject {
 			Files.write(abstractTestFilePath, testContent.getBytes());
 		}
 		catch (@SuppressWarnings("unused") IOException e) {
-			UtilImpl.LOGGER.warning("Failed to update customer, tests will likely fail.");
+			LOGGER.warn("Failed to update customer, tests will likely fail.");
 		}
 	}
 
@@ -446,12 +450,12 @@ public class MavenSkyveProject {
 				Files.write(scriptFile.toPath(), script.getBytes());
 			}
 			catch (IOException e) {
-				UtilImpl.LOGGER.warning("Failed to write Skyve script to file.");
+				LOGGER.warn("Failed to write Skyve script to file.");
 				e.printStackTrace();
 			}
 		}
 		else {
-			UtilImpl.LOGGER.warning("Failed to create directories for the Skyve script.");
+			LOGGER.warn("Failed to create directories for the Skyve script.");
 		}
 	}
 

--- a/skyve-ext/src/main/java/org/skyve/impl/generate/jasperreports/JasperReportRenderer.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/generate/jasperreports/JasperReportRenderer.java
@@ -32,7 +32,8 @@ import org.skyve.metadata.module.query.MetaDataQueryDefinition;
 import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.model.list.ListModel;
 import org.skyve.report.ReportFormat;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.sf.jasperreports.engine.DefaultJasperReportsContext;
 import net.sf.jasperreports.engine.JRBand;
@@ -81,6 +82,9 @@ import net.sf.jasperreports.engine.type.VerticalTextAlignEnum;
 import net.sf.jasperreports.engine.xml.JRXmlWriter;
 
 public class JasperReportRenderer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JasperReportRenderer.class);
+
 	public static final String DESIGN_SPEC_PARAMETER_NAME = "DESIGN_SPEC";
 	protected final JasperDesign jasperDesign;
 	protected final DesignSpecification designSpecification;
@@ -764,7 +768,7 @@ public class JasperReportRenderer {
 				query.addTextChunk("\n where a.bizId = $P{ID}");
 			}
 			else if (DesignSpecification.ReportType.subreport.equals(designSpecification.getReportType())) {
-				Util.LOGGER.info("SUBREPORT " + designSpecification.getName() + " IS " + designSpecification.getCollectionType().name());
+				LOGGER.info("SUBREPORT " + designSpecification.getName() + " IS " + designSpecification.getCollectionType().name());
 
 				// join to either parent or joiner table
 				if (Collection.CollectionType.child.equals(designSpecification.getCollectionType())) {

--- a/skyve-ext/src/main/java/org/skyve/impl/generate/jasperreports/Renderer.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/generate/jasperreports/Renderer.java
@@ -26,9 +26,12 @@ import org.skyve.metadata.model.Persistent.ExtensionStrategy;
 import org.skyve.metadata.model.document.Collection.CollectionType;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Renderer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Renderer.class);
 
 	public static final int defaultReportWith = 842;
 	public static final int defaultReportHeight = 595;
@@ -669,7 +672,7 @@ public class Renderer {
 				if (ReportType.report.equals(design.getReportType())) {
 					sb.append("\n where ").append("a").append(".bizId = $P{ID}");
 				} else if (ReportType.subreport.equals(design.getReportType())) {
-					Util.LOGGER.info("SUBREPORT " + design.getName() + " IS " + design.getCollectionType().name());
+					LOGGER.info("SUBREPORT " + design.getName() + " IS " + design.getCollectionType().name());
 
 					// join to either parent or joiner table
 					if (CollectionType.child.equals(design.getCollectionType())) {
@@ -913,7 +916,7 @@ public class Renderer {
 				band.getElements().add(tE);
 			}
 		} catch (@SuppressWarnings("unused") Exception e) {
-			Util.LOGGER.warning("UNABLE TO CREATE REPORT ELEMENT IN BAND FOR " + name);
+			LOGGER.warn("UNABLE TO CREATE REPORT ELEMENT IN BAND FOR " + name);
 		}
 
 		return band;
@@ -989,7 +992,7 @@ public class Renderer {
 			}
 			Path reportPath = filePath.resolve(design.getName() + ".jrxml");
 			File file = reportPath.toFile();
-			UtilImpl.LOGGER.info("Output is written to " + file.getCanonicalPath());
+			LOGGER.info("Output is written to " + file.getCanonicalPath());
 			try (PrintWriter out = new PrintWriter(file)) {
 				out.println(reportRenderer.getJrxml());
 				out.flush();
@@ -1048,14 +1051,14 @@ public class Renderer {
 		if (design.getRepositoryPath() != null) {
 			Path reportPath = filePath.resolve(design.getName() + ".jrxml");
 			File file = reportPath.toFile();
-			UtilImpl.LOGGER.info("Output is written to " + file.getCanonicalPath());
+			LOGGER.info("Output is written to " + file.getCanonicalPath());
 			try (PrintWriter out = new PrintWriter(file)) {
 				try {
 					final JasperReportRenderer reportRenderer = new JasperReportRenderer(design);
 					out.println(reportRenderer.getJrxml());
 					out.flush();
 				} catch (@SuppressWarnings("unused") NullPointerException npe) {
-					Util.LOGGER.warning(String.format("NullPointerException while writing report to %s", reportPath.toString()));
+					LOGGER.warn("NullPointerException while writing report to {}", reportPath.toString());
 				}
 			}
 		}

--- a/skyve-ext/src/main/java/org/skyve/impl/generate/jasperreports/ReportDesignGenerator.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/generate/jasperreports/ReportDesignGenerator.java
@@ -11,9 +11,12 @@ import org.skyve.metadata.model.document.Association;
 import org.skyve.metadata.model.document.Collection;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class ReportDesignGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReportDesignGenerator.class);
 
     public DesignSpecification generateDesign() {
         return populateDesign(new DesignSpecification());
@@ -346,7 +349,7 @@ public abstract class ReportDesignGenerator {
                 }
             }
         } catch (@SuppressWarnings("unused") Exception e) {
-            Util.LOGGER.warning("COULD NOT CONSTRUCT FIELD FROM BINDING " + binding + " FOR DOCUMENT " + document.getName());
+            LOGGER.warn("COULD NOT CONSTRUCT FIELD FROM BINDING " + binding + " FOR DOCUMENT " + document.getName());
         }
         if (result != null) {
             result.setBinding(binding);

--- a/skyve-ext/src/main/java/org/skyve/impl/generate/jasperreports/ReportViewVisitor.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/generate/jasperreports/ReportViewVisitor.java
@@ -83,7 +83,6 @@ import org.skyve.metadata.model.document.Collection;
 import org.skyve.metadata.model.document.Collection.CollectionType;
 import org.skyve.metadata.view.widget.FilterParameter;
 import org.skyve.metadata.view.widget.bound.Parameter;
-import org.skyve.util.Util;
 
 public class ReportViewVisitor extends ViewVisitor {
 	public static final double TWIP_TO_PIXEL = 0.0666666667;
@@ -210,7 +209,7 @@ public class ReportViewVisitor extends ViewVisitor {
 			width = design.getColumnWidth().intValue();
 
 		} catch (Exception e) {
-			Util.LOGGER.warning("COULD NOT CONSTRUCT BAND " + detailBands.size() + " FOR WIDGET_ID " + widgetId);
+			LOGGER.warn("COULD NOT CONSTRUCT BAND " + detailBands.size() + " FOR WIDGET_ID " + widgetId);
 			e.printStackTrace();
 		}
 	}
@@ -663,7 +662,7 @@ public class ReportViewVisitor extends ViewVisitor {
 	protected void addElementFromItem(String binding, ReportElement.ElementType elementType, Integer pixelWidth, Integer percentageWidth, Integer responsiveWidth, Integer pixelHeight, 
 			String valueFontName, String invisibleConditionName) {
 		
-		Util.LOGGER.info(binding + subreport);
+		LOGGER.info(binding + subreport);
 		
 		if (subreport) {
 //			Module subModule = customer.getModule(sub.getModuleName());
@@ -924,7 +923,7 @@ public class ReportViewVisitor extends ViewVisitor {
 	}
 	
 	public void visitDataWidget(AbstractDataWidget widget) {
-		Util.LOGGER.info("DATA GRID WITH BINDING" + widget.getBinding());
+		LOGGER.info("DATA GRID WITH BINDING" + widget.getBinding());
 		addContainer(widget.getWidgetId()
 				, widget.getLocalisedTitle()
 				, (widget.getTitle()==null?Boolean.FALSE: Boolean.TRUE)
@@ -976,8 +975,7 @@ public class ReportViewVisitor extends ViewVisitor {
 		try {
 			subReportGenerator.populateDesign(sub);
 		} catch (Exception e){
-			Util.LOGGER.info("COULD NOT CREATE DEFAULT DESIGN FOR SUB REPORT " + sub.getName());
-			e.printStackTrace();
+			LOGGER.info("COULD NOT CREATE DEFAULT DESIGN FOR SUB REPORT {}", sub.getName(), e);
 		}
 		
 		design.getSubReports().add(sub);

--- a/skyve-ext/src/main/java/org/skyve/impl/geoip/IPInfoIo.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/geoip/IPInfoIo.java
@@ -12,12 +12,16 @@ import org.locationtech.jts.geom.Point;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.IPGeolocation;
 import org.skyve.util.JSON;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Client for the ipinfo.io geoip service.
  */
 public class IPInfoIo extends AbstractCachingGeoIPService {
 	private static final String IPINFO_DOMAIN = "https://ipinfo.io/";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IPInfoIo.class);
 
 	@Override
 	protected IPGeolocation doGeolocation(String ipAddress) {
@@ -49,12 +53,11 @@ public class IPInfoIo extends AbstractCachingGeoIPService {
 				result = new IPGeolocation(city, region, countryCode, location);
 			}
 			else {
-				UtilImpl.LOGGER.severe("Error fetching data IP : " + ipAddress + " : HTTP Error - " + response.statusCode());
+				LOGGER.error("Error fetching data IP : " + ipAddress + " : HTTP Error - " + response.statusCode());
 			}
 		}
 		catch (Exception e) {
-			UtilImpl.LOGGER.severe("Error fetching data: IP " + ipAddress);
-			e.printStackTrace();
+			LOGGER.error("Error fetching data: IP {}", ipAddress, e);
 		}
 		
 		return result;

--- a/skyve-ext/src/main/java/org/skyve/impl/job/AbstractSkyveJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/job/AbstractSkyveJob.java
@@ -24,7 +24,8 @@ import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractSkyveJob implements InterruptableJob, MetaData {
 	public static final String DISPLAY_NAME_JOB_PARAMETER_KEY = "displayName";
@@ -39,6 +40,12 @@ public abstract class AbstractSkyveJob implements InterruptableJob, MetaData {
 	private JobStatus status = null;
 	private List<String> log = Collections.synchronizedList(new ArrayList<>());
 	private Bean bean;
+	
+    /**
+     * Logger suitable for use by extending classes. Category name will match the implementing
+     * classes' name.
+     */
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	public String getDisplayName() {
 		return displayName;
@@ -144,7 +151,7 @@ public abstract class AbstractSkyveJob implements InterruptableJob, MetaData {
 			persistence.setAsyncThread(true);
 			persistence.begin();
 			UtilImpl.inject(this);
-			Util.LOGGER.info("Execute job " + displayName);
+			LOGGER.info("Execute job " + displayName);
 			execute();
 			if (JobStatus.cancelled == status) { // job was cancelled - log and rollback
 				if (shouldRollbackOnCancel()) {

--- a/skyve-ext/src/main/java/org/skyve/impl/job/ContentGarbageCollectionJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/job/ContentGarbageCollectionJob.java
@@ -3,7 +3,6 @@ package org.skyve.impl.job;
 import java.util.Date;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.logging.Level;
 
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
@@ -26,7 +25,9 @@ import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.metadata.view.model.list.RDBMSDynamicPersistenceListModel;
 import org.skyve.persistence.Persistence;
 import org.skyve.persistence.SQL;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This job removes orphaned uploads and any textually indexed data left from delete/truncate SQL statements issued.
@@ -35,14 +36,17 @@ import org.skyve.util.Util;
  */
 public class ContentGarbageCollectionJob implements Job {
 	private static final long CONTENT_GC_ELIGIBLE_AGE_MILLIS = UtilImpl.CONTENT_GC_ELIGIBLE_AGE_MINUTES * 60000L;
-	
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContentGarbageCollectionJob.class);
+    private static final Logger CONTENT_LOGGER = Category.CONTENT.logger();
+
 	private Set<String> orphanedAttachmentContentIds = new TreeSet<>();
 	private Set<String> orphanedBeanBizIds = new TreeSet<>();
 	
 	@Override
 	public void execute(JobExecutionContext context)
 	throws JobExecutionException {
-		Util.LOGGER.info("Start Content Garbage Collection");
+		LOGGER.info("Start Content Garbage Collection");
 		try {
 			ContentChecker contentChecker = new ContentChecker();
 			ProvidedRepository r = ProvidedRepositoryFactory.get();
@@ -70,7 +74,7 @@ public class ContentGarbageCollectionJob implements Job {
 							String bizId = result.getBizId();
 							String contentId = result.getContentId();
 							Date lastModified = result.getLastModified();
-							if (UtilImpl.CONTENT_TRACE) UtilImpl.LOGGER.finest("ContentGarbageCollectionJob: FOUND customer=" + customerName + 
+							if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.trace("ContentGarbageCollectionJob: FOUND customer=" + customerName + 
 																				" : module=" + moduleName + 
 																				" : document=" + documentName + 
 																				" : bizId=" + bizId + 
@@ -82,10 +86,10 @@ public class ContentGarbageCollectionJob implements Job {
 							// content that hasn't been saved (not pointed to yet in the database) won't be removed.
 							if (lastModified == null) {
 								if (result.isAttachment()) {
-									UtilImpl.LOGGER.warning("ContentGarbageCollectionJob: Cannot determine whether to remove attachment content with bizId/contentId " + bizId + "/" + contentId);
+									LOGGER.warn("ContentGarbageCollectionJob: Cannot determine whether to remove attachment content with bizId/contentId " + bizId + "/" + contentId);
 								}
 								else {
-									UtilImpl.LOGGER.warning("ContentGarbageCollectionJob: Cannot determine whether to remove bean content with bizId " + bizId);
+									LOGGER.warn("ContentGarbageCollectionJob: Cannot determine whether to remove bean content with bizId " + bizId);
 								}
 							}
 							else if ((System.currentTimeMillis() - lastModified.getTime()) > CONTENT_GC_ELIGIBLE_AGE_MILLIS) { // of eligible age
@@ -95,20 +99,20 @@ public class ContentGarbageCollectionJob implements Job {
 								Persistent persistent = document.getPersistent();
 								if (persistent == null) { // was persistent with content but now transient
 									if (result.isAttachment()) {
-										UtilImpl.LOGGER.warning("ContentGarbageCollectionJob: Cannot determine whether to remove attachment content with bizId/contentId " + bizId + "/" + contentId + " as the owning document " + moduleName + "." + documentName + " is not persistent");
+										LOGGER.warn("ContentGarbageCollectionJob: Cannot determine whether to remove attachment content with bizId/contentId " + bizId + "/" + contentId + " as the owning document " + moduleName + "." + documentName + " is not persistent");
 									}
 									else {
-										UtilImpl.LOGGER.warning("ContentGarbageCollectionJob: Cannot determine whether to remove bean content with bizId " + bizId + " as the owning document " + moduleName + "." + documentName + " is not persistent");
+										LOGGER.warn("ContentGarbageCollectionJob: Cannot determine whether to remove bean content with bizId " + bizId + " as the owning document " + moduleName + "." + documentName + " is not persistent");
 									}
 									continue;
 								}
 								String persistentIdentifier = persistent.getPersistentIdentifier();
 								if (persistentIdentifier == null) { // was persistent with content but now transient
 									if (result.isAttachment()) {
-										UtilImpl.LOGGER.warning("ContentGarbageCollectionJob: Cannot determine whether to remove attachment content with bizId/contentId " + bizId + "/" + contentId + " as the owning document " + moduleName + "." + documentName + " is not directly persistent");
+										LOGGER.warn("ContentGarbageCollectionJob: Cannot determine whether to remove attachment content with bizId/contentId " + bizId + "/" + contentId + " as the owning document " + moduleName + "." + documentName + " is not directly persistent");
 									}
 									else {
-										UtilImpl.LOGGER.warning("ContentGarbageCollectionJob: Cannot determine whether to remove bean content with bizId " + bizId + " as the owning document " + moduleName + "." + documentName + " is not directly persistent");
+										LOGGER.warn("ContentGarbageCollectionJob: Cannot determine whether to remove bean content with bizId " + bizId + " as the owning document " + moduleName + "." + documentName + " is not directly persistent");
 									}
 									continue;
 								}
@@ -156,28 +160,28 @@ public class ContentGarbageCollectionJob implements Job {
 									query.putParameter(Bean.DOCUMENT_ID, bizId, false);
 								}
 								
-								if (UtilImpl.CONTENT_TRACE) UtilImpl.LOGGER.finest("ContentGarbageCollectionJob: TEST REMOVAL with " + sql.toString());
+								if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.trace("ContentGarbageCollectionJob: TEST REMOVAL with {}", sql);
 								if (query.scalarResults(Integer.class).isEmpty()) {
 									if (result.isAttachment()) {
 										String bogusContentReference = contentChecker.bogusContentReference(contentId, customer);
 										if (bogusContentReference == null) {
 											orphanedAttachmentContentIds.add(contentId);
-											UtilImpl.LOGGER.info("ContentGarbageCollectionJob: Remove attachment content with bizid/contentId " + contentId + "/" + bizId);
+											LOGGER.info("ContentGarbageCollectionJob: Remove attachment content with bizid/contentId " + contentId + "/" + bizId);
 										}
 										else {
-											UtilImpl.LOGGER.severe("ContentGarbageCollectionJob: Cannot remove unreferenced attachment content with bizId/contentId " + contentId + "/" + bizId + " and owning document of " + moduleName + "." + documentName + " as it is actually referenced by Table#BizId " + bogusContentReference);
+											LOGGER.error("ContentGarbageCollectionJob: Cannot remove unreferenced attachment content with bizId/contentId " + contentId + "/" + bizId + " and owning document of " + moduleName + "." + documentName + " as it is actually referenced by Table#BizId " + bogusContentReference);
 										}
 									}
 									else {
 										orphanedBeanBizIds.add(bizId);
-										UtilImpl.LOGGER.info("ContentGarbageCollectionJob: Remove bean content with bizId " + bizId);
+										LOGGER.info("ContentGarbageCollectionJob: Remove bean content with bizId " + bizId);
 									}
 								}
 							}
 						}
 						catch (Exception e) {
-							Util.LOGGER.warning("ContentGarbageCollectionJob retrieve problem..." + e.getLocalizedMessage());
-							if (UtilImpl.CONTENT_TRACE) Util.LOGGER.log(Level.WARNING, "ContentGarbageCollectionJob.execute() problem...", e);
+							LOGGER.warn("ContentGarbageCollectionJob retrieve problem..." + e.getLocalizedMessage());
+							if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.warn("ContentGarbageCollectionJob.execute() problem...", e);
 						}
 					}
 					
@@ -186,8 +190,8 @@ public class ContentGarbageCollectionJob implements Job {
 							cm.removeAttachment(contentId);
 						}
 						catch (Exception e) {
-							Util.LOGGER.warning("ContentGarbageCollectionJob remove problem..." + e.getLocalizedMessage());
-							if (UtilImpl.CONTENT_TRACE) Util.LOGGER.log(Level.WARNING, "ContentGarbageCollectionJob.execute() problem...", e);
+							LOGGER.warn("ContentGarbageCollectionJob remove problem..." + e.getLocalizedMessage());
+							if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.warn("ContentGarbageCollectionJob.execute() problem...", e);
 						}
 					}
 					orphanedAttachmentContentIds.clear();
@@ -197,8 +201,8 @@ public class ContentGarbageCollectionJob implements Job {
 							cm.removeBean(bizId);
 						}
 						catch (Exception e) {
-							Util.LOGGER.warning("ContentGarbageCollectionJob remove problem..." + e.getLocalizedMessage());
-							if (UtilImpl.CONTENT_TRACE) Util.LOGGER.log(Level.WARNING, "ContentGarbageCollectionJob.execute() problem...", e);
+							LOGGER.warn("ContentGarbageCollectionJob remove problem..." + e.getLocalizedMessage());
+							if (UtilImpl.CONTENT_TRACE) CONTENT_LOGGER.warn("ContentGarbageCollectionJob.execute() problem...", e);
 						}
 					}
 					orphanedBeanBizIds.clear();
@@ -207,7 +211,7 @@ public class ContentGarbageCollectionJob implements Job {
 			finally {
 				p.commit(true);
 			}
-			Util.LOGGER.info("Successfully performed Content Garbage Collection");
+			LOGGER.info("Successfully performed Content Garbage Collection");
 		}
 		catch (Exception e) {
 			throw new JobExecutionException("Error encountered whilst performing CMS garbage collection", e);

--- a/skyve-ext/src/main/java/org/skyve/impl/job/ContentStartupJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/job/ContentStartupJob.java
@@ -5,7 +5,8 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.skyve.EXT;
 import org.skyve.content.ContentManager;
-import org.skyve.impl.util.UtilImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This job fires up the content management system - this can take a while 
@@ -14,6 +15,9 @@ import org.skyve.impl.util.UtilImpl;
  * @author mike
  */
 public class ContentStartupJob implements Job {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContentStartupJob.class);
+
 	@Override
 	public void execute(JobExecutionContext context)
 	throws JobExecutionException {
@@ -21,7 +25,7 @@ public class ContentStartupJob implements Job {
 			cm.startup();
 		}
 		catch (Exception e) {
-			UtilImpl.LOGGER.info("Could not startup the content manager - this is non-fatal but requires investigation");
+			LOGGER.info("Could not startup the content manager - this is non-fatal but requires investigation");
 			e.printStackTrace();
 		}
 	}

--- a/skyve-ext/src/main/java/org/skyve/impl/job/EvictStateJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/job/EvictStateJob.java
@@ -4,7 +4,8 @@ import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.skyve.impl.cache.StateUtil;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This job evicts expired conversations from the conversations cache.
@@ -12,17 +13,19 @@ import org.skyve.util.Util;
  * @author sandsm01
  */
 public class EvictStateJob implements Job {
-	
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EvictStateJob.class);
+
 	@Override
 	public void execute(JobExecutionContext context)
 	throws JobExecutionException {
 		try {
-			Util.LOGGER.info("Evict expired conversations");
+			LOGGER.info("Evict expired conversations");
 			StateUtil.evictExpiredConversations();
-			Util.LOGGER.info("Successfully evicted expired conversations");
-			Util.LOGGER.info("Evict expired session CSRF tokens");
+			LOGGER.info("Successfully evicted expired conversations");
+			LOGGER.info("Evict expired session CSRF tokens");
 			StateUtil.evictExpiredSessionTokens();
-			Util.LOGGER.info("Successfully evicted expired session CSRF tokens");
+			LOGGER.info("Successfully evicted expired session CSRF tokens");
 		}
 		catch (Exception e) {
 			throw new JobExecutionException("Error encountered whilst evicting expired web state", e);

--- a/skyve-ext/src/main/java/org/skyve/impl/job/QuartzJobScheduler.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/job/QuartzJobScheduler.java
@@ -43,7 +43,6 @@ import org.skyve.metadata.module.JobMetaData;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.metadata.user.User;
-import org.skyve.util.Util;
 import org.skyve.web.BackgroundTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -183,10 +182,10 @@ public class QuartzJobScheduler implements JobScheduler {
 									.build();
 		try {
 			JOB_SCHEDULER.scheduleJob(detail, trigger);
-			Util.LOGGER.info("CMS Garbage Collection Job scheduled for " + trigger.getNextFireTime());
+			LOGGER.info("CMS Garbage Collection Job scheduled for " + trigger.getNextFireTime());
 		}
 		catch (SchedulerException e) {
-			Util.LOGGER.severe("CMS Garbage Collection Job was not scheduled because - " + e.getLocalizedMessage());
+			LOGGER.error("CMS Garbage Collection Job was not scheduled because - " + e.getLocalizedMessage());
 		}
 
 		scheduleArchiveJob();
@@ -206,14 +205,14 @@ public class QuartzJobScheduler implements JobScheduler {
 										.build();
 			try {
 				JOB_SCHEDULER.scheduleJob(detail, trigger);
-				Util.LOGGER.info("Evict Expired State Job scheduled for " + trigger.getNextFireTime());
+				LOGGER.info("Evict Expired State Job scheduled for " + trigger.getNextFireTime());
 			}
 			catch (SchedulerException e) {
-				Util.LOGGER.severe("Evict Expired State Job was not scheduled because - " + e.getLocalizedMessage());
+				LOGGER.error("Evict Expired State Job was not scheduled because - " + e.getLocalizedMessage());
 			}
 		}
 		else {
-			Util.LOGGER.info("Evict Expired State Job was not scheduled because there was no conversations.evictCron in the json.");
+			LOGGER.info("Evict Expired State Job was not scheduled because there was no conversations.evictCron in the json.");
 		}
 	}
 
@@ -424,7 +423,7 @@ public class QuartzJobScheduler implements JobScheduler {
 		if (firstFireTime != null) {
 			trace.append(" first at ").append(firstFireTime);
 		}
-		UtilImpl.LOGGER.info(trace.toString());
+		LOGGER.info(trace.toString());
 	}
 
 	@Override
@@ -433,7 +432,7 @@ public class QuartzJobScheduler implements JobScheduler {
 		String customerName = customer.getName();
 		try {
 			JOB_SCHEDULER.unscheduleJob(new TriggerKey(bizId, customerName));
-			Util.LOGGER.info("Unscheduled Job " + bizId + " for customer " + customerName);
+			LOGGER.info("Unscheduled Job " + bizId + " for customer " + customerName);
 		}
 		catch (SchedulerException e) {
 			throw new DomainException("Cannot unschedule job " + bizId + " for customer " + customerName, e);
@@ -525,7 +524,7 @@ public class QuartzJobScheduler implements JobScheduler {
 		if (firstFireTime != null) {
 			trace.append(" first at ").append(firstFireTime);
 		}
-		UtilImpl.LOGGER.info(trace.toString());
+		LOGGER.info(trace.toString());
 	}
 
 	@Override
@@ -535,7 +534,7 @@ public class QuartzJobScheduler implements JobScheduler {
 			String customerName = customer.getName();
 			try {
 				JOB_SCHEDULER.unscheduleJob(new TriggerKey(bizId, customerName));
-				Util.LOGGER.info("Unscheduled report " + bizId + " for customer " + customerName);
+				LOGGER.info("Unscheduled report " + bizId + " for customer " + customerName);
 			}
 			catch (SchedulerException e) {
 				throw new DomainException("Cannot unschedule report " + bizId + " for customer " + customerName, e);
@@ -581,7 +580,7 @@ public class QuartzJobScheduler implements JobScheduler {
 	public boolean cancelJob(String instanceId) {
 		try {
 			boolean result = JOB_SCHEDULER.interrupt(instanceId);
-			Util.LOGGER.info((result ? "Cancelled job " : "Unable to cancel job ") + instanceId);
+			LOGGER.info((result ? "Cancelled job " : "Unable to cancel job ") + instanceId);
 			return result;
 		}
 		catch (UnableToInterruptJobException e) {

--- a/skyve-ext/src/main/java/org/skyve/impl/job/ValidateMetaDataJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/job/ValidateMetaDataJob.java
@@ -6,7 +6,8 @@ import org.quartz.JobExecutionException;
 import org.skyve.impl.generate.DomainGenerator;
 import org.skyve.impl.metadata.repository.ProvidedRepositoryFactory;
 import org.skyve.metadata.repository.ProvidedRepository;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This job visits all the metadata for each customer after app deployment.
@@ -15,16 +16,19 @@ import org.skyve.util.Util;
  * @author mike
  */
 public class ValidateMetaDataJob implements Job {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ValidateMetaDataJob.class);
+
 	@Override
 	public void execute(JobExecutionContext context)
 	throws JobExecutionException {
 		try {
-			Util.LOGGER.info("Validate metadata");
+			LOGGER.info("Validate metadata");
 			ProvidedRepository repository = ProvidedRepositoryFactory.get();
 			for (String customerName : repository.getAllCustomerNames()) {
 				DomainGenerator.validate(repository, customerName);
 			}
-			Util.LOGGER.info("Successfully validated metadata");
+			LOGGER.info("Successfully validated metadata");
 		}
 		catch (Exception e) {
 			throw new JobExecutionException("Error encountered whilst validating metadata", e);

--- a/skyve-ext/src/main/java/org/skyve/impl/metadata/repository/LocalDataStoreRepository.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/metadata/repository/LocalDataStoreRepository.java
@@ -28,6 +28,9 @@ import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.Role;
 import org.skyve.metadata.user.User;
 import org.skyve.persistence.SQL;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Adds security integration to LocalDesignRepository.
@@ -35,6 +38,10 @@ import org.skyve.persistence.SQL;
  * @author Mike
  */
 public class LocalDataStoreRepository extends LocalDesignRepository {
+
+    private static final Logger QUERY_LOGGER = Category.QUERY.logger();
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalDataStoreRepository.class);
+
 	@Override
 	public UserImpl retrieveUser(String userPrincipal) {
 		if (userPrincipal == null) {
@@ -143,7 +150,7 @@ public class LocalDataStoreRepository extends LocalDesignRepository {
 			}
 
 			String query = sql.toString();
-			if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(query + " executed on thread " + Thread.currentThread() + ", connection = " + connection);
+			if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(query + " executed on thread " + Thread.currentThread() + ", connection = " + connection);
 			try (PreparedStatement s = connection.prepareStatement(query)) {
 				s.setString(1, user.getName());
 				if (UtilImpl.CUSTOMER == null) { // multi-tenant
@@ -354,7 +361,7 @@ public class LocalDataStoreRepository extends LocalDesignRepository {
 			result = s.retrieveScalar(String.class);
 		}
 		catch (Exception e) {
-			UtilImpl.LOGGER.warning("Could not retrieve public user for customer " + customerName);
+			LOGGER.warn("Could not retrieve public user for customer {}", customerName, e);
 			e.printStackTrace();
 		}
 		

--- a/skyve-ext/src/main/java/org/skyve/impl/persistence/RDBMSDynamicPersistence.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/persistence/RDBMSDynamicPersistence.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.logging.Level;
 
 import org.skyve.domain.Bean;
 import org.skyve.domain.DynamicPersistentBean;
@@ -45,7 +44,9 @@ import org.skyve.persistence.Persistence;
 import org.skyve.persistence.SQL;
 import org.skyve.util.BeanVisitor;
 import org.skyve.util.JSON;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 
@@ -54,6 +55,9 @@ import jakarta.annotation.Nonnull;
 // The idea here is to completely persist all beans reachable, no matter the relationship.
 public class RDBMSDynamicPersistence implements DynamicPersistence {
 	private static final long serialVersionUID = -6445760028486705253L;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(RDBMSDynamicPersistence.class);
+	private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
 
 	private static final Integer NEW_VERSION = Integer.valueOf(0);
 
@@ -420,9 +424,9 @@ public class RDBMSDynamicPersistence implements DynamicPersistence {
 			if (! vetoed) {
 				Bizlet<Bean> bizlet = ((DocumentImpl) document).getBizlet(customer);
 				if (bizlet != null) {
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preDelete", "Entering " + bizlet.getClass().getName() + ".preDelete: " + bean);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preDelete: " + bean);
 					bizlet.preDelete(bean);
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preDelete", "Exiting " + bizlet.getClass().getName() + ".preDelete");
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preDelete");
 				}
 				internalCustomer.interceptAfterPreDelete(bean);
 			}
@@ -448,9 +452,9 @@ public class RDBMSDynamicPersistence implements DynamicPersistence {
 			if (! vetoed) {
 				Bizlet<Bean> bizlet = ((DocumentImpl) document).getBizlet(customer);
 				if (bizlet != null) {
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "postDelete", "Entering " + bizlet.getClass().getName() + ".postDelete: " + bean);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".postDelete: " + bean);
 					bizlet.postDelete(bean);
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "postDelete", "Exiting " + bizlet.getClass().getName() + ".postDelete");
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".postDelete");
 				}
 				internalCustomer.interceptAfterPostDelete(bean);
 			}
@@ -578,7 +582,9 @@ public class RDBMSDynamicPersistence implements DynamicPersistence {
 							value = BindUtil.fromSerialised(type, value.toString());
 						}
 						catch (Exception e) {
-							Util.LOGGER.warning("RDBMSDynamicPersistence: Schema evolution problem on populate of " + d.getOwningModuleName() + "." + d.getName() + "#" + bean.getBizId() + " :- [" + value + "] cannot be coerced to type " + type);
+                            LOGGER.warn(
+                                    "RDBMSDynamicPersistence: Schema evolution problem on populate of {}.{}#{} :- [{}] cannot be coerced to type {}",
+                                    d.getOwningModuleName(), d.getName(), bean.getBizId(), value, type, e);
 							e.printStackTrace();
 						}
 					}

--- a/skyve-ext/src/main/java/org/skyve/impl/persistence/hibernate/HibernateQueryDelegate.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/persistence/hibernate/HibernateQueryDelegate.java
@@ -19,10 +19,15 @@ import org.skyve.impl.bind.BindUtil;
 import org.skyve.impl.persistence.AbstractQuery;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.persistence.AutoClosingIterable;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.persistence.QueryTimeoutException;
 
 class HibernateQueryDelegate {
+
+    private static final Logger QUERY_LOGGER = Category.QUERY.logger();
+
 	private AbstractHibernatePersistence persistence;
 	private int firstResult = Integer.MIN_VALUE;
 	private int maxResults = Integer.MIN_VALUE;
@@ -45,7 +50,7 @@ class HibernateQueryDelegate {
 		// This needs to be be before we set the driving document (below)
 		// as it sets the driving document in a BizQL
 		String queryString = query.toQueryString();
-		if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(queryString + " executed on thread " + Thread.currentThread());
+		if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(queryString + " executed on thread " + Thread.currentThread());
 
 		drivingModuleName = query.getDrivingModuleName();
 		drivingDocumentName = query.getDrivingDocumentName();

--- a/skyve-ext/src/main/java/org/skyve/impl/persistence/hibernate/dialect/DDLDelegate.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/persistence/hibernate/dialect/DDLDelegate.java
@@ -32,9 +32,13 @@ import org.hibernate.tool.schema.internal.exec.JdbcContext;
 import org.hibernate.tool.schema.spi.SchemaManagementTool;
 import org.skyve.EXT;
 import org.skyve.impl.persistence.hibernate.dialect.SkyveDialect.RDBMS;
-import org.skyve.impl.util.UtilImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DDLDelegate {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DDLDelegate.class);
+
 	public static List<String> migrate(ServiceRegistry standardRegistry, Metadata metadata, SkyveDialect skyveDialect, boolean execute)
 	throws SQLException {
 		List<String> result = new ArrayList<>(20);
@@ -102,13 +106,12 @@ public class DDLDelegate {
 																	metadata)) {
 	                        		result.add(ddl);
 	                        		if (execute) {
-		                        		UtilImpl.LOGGER.info(ddl);
+		                        		LOGGER.info(ddl);
 		                        		try {
 		                        			statement.executeUpdate(ddl);
 		                        		}
 		                        		catch (Exception e) {
-		                    				UtilImpl.LOGGER.severe("Could not apply skyve extra schema update of " + ddl);
-		                    				e.printStackTrace();
+		                    				LOGGER.error("Could not apply skyve extra schema update of {}", ddl, e);
 		                        		}
 	                        		}
 								}

--- a/skyve-ext/src/main/java/org/skyve/impl/report/freemarker/FreemarkerReportUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/report/freemarker/FreemarkerReportUtil.java
@@ -38,6 +38,8 @@ import org.skyve.metadata.user.DocumentPermissionScope;
 import org.skyve.persistence.DocumentQuery;
 import org.skyve.report.ReportFormat;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.xhtmlrenderer.pdf.ITextOutputDevice;
@@ -64,6 +66,9 @@ import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
 
 public final class FreemarkerReportUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreemarkerReportUtil.class);
+
 	private static Configuration cfg;
 	private static PathMatchingResourcePatternResolver resolver;
 	private static StringTemplateLoader strl;
@@ -512,11 +517,10 @@ public final class FreemarkerReportUtil {
 						try {
 							File f = r.getFile();
 							renderer.getFontResolver().addFont(f.toString(), true);
-							Util.LOGGER.info("Loaded font for PDF: " + r.getFilename());
+							LOGGER.info("Loaded font for PDF: " + r.getFilename());
 						}
 						catch (DocumentException | IOException e) {
-							Util.LOGGER.warning("Error loading font file: " + r.getFilename());
-							e.printStackTrace();
+							LOGGER.warn("Error loading font file: {}", r.getFilename(), e);
 						}
 					});
 
@@ -527,17 +531,16 @@ public final class FreemarkerReportUtil {
 							File f = r.getFile();
 							// required to load unicode fonts
 							renderer.getFontResolver().addFont(f.toString(), BaseFont.IDENTITY_H, true);
-							Util.LOGGER.info("Loaded unicode font for PDF: " + r.getFilename());
+							LOGGER.info("Loaded unicode font for PDF: " + r.getFilename());
 						}
 						catch (DocumentException | IOException e) {
-							Util.LOGGER.warning("Error loading unicode font file: " + r.getFilename());
-							e.printStackTrace();
+							LOGGER.warn("Error loading unicode font file: {}", r.getFilename(), e);
 						}
 					});
 		}
 		catch (FileNotFoundException fnfe) {
 			// fonts directory not defined or empty
-			Util.LOGGER.warning("Error loading fonts for report: " + fnfe.getMessage());
+			LOGGER.warn("Error loading fonts for report: " + fnfe.getMessage());
 		}
 	}
 

--- a/skyve-ext/src/main/java/org/skyve/impl/report/jasperreports/JasperReportUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/report/jasperreports/JasperReportUtil.java
@@ -27,6 +27,8 @@ import org.skyve.metadata.user.UserAccess;
 import org.skyve.metadata.view.model.list.ListModel;
 import org.skyve.persistence.AutoClosingIterable;
 import org.skyve.report.ReportFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 import net.sf.jasperreports.engine.JRAbstractExporter;
@@ -63,6 +65,9 @@ import net.sf.jasperreports.export.SimpleXmlExporterOutput;
 import net.sf.jasperreports.web.util.WebHtmlResourceHandler;
 
 public final class JasperReportUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JasperReportUtil.class);
+
 	private JasperReportUtil() {
 		// disallow instantiation
 	}
@@ -126,14 +131,14 @@ public final class JasperReportUtil {
 											OutputStream out)
 	throws Exception {
 		String queryLanguage = jasperReport.getQuery().getLanguage();
-		UtilImpl.LOGGER.info("QUERY LNG = " + queryLanguage);
+		LOGGER.info("QUERY LNG = " + queryLanguage);
 
 		JasperPrint result = null;
 		if ("sql".equalsIgnoreCase(queryLanguage)) {
 			result = fillSqlReport(jasperReport, parameters, format, out);
 		}
 		else if ("document".equalsIgnoreCase(queryLanguage)) {
-			UtilImpl.LOGGER.info("FILL REPORT");
+			LOGGER.info("FILL REPORT");
 			Bean reportBean = bean;
 			// if we have no bean then see if there is a bizId parameter
 			if (reportBean == null) {
@@ -147,9 +152,9 @@ public final class JasperReportUtil {
 				}
 			}
 			result = JasperFillManager.fillReport(jasperReport, parameters, new SkyveDataSource(user, reportBean));
-			UtilImpl.LOGGER.info("PUMP REPORT");
+			LOGGER.info("PUMP REPORT");
 			runReport(result, format, out);
-			UtilImpl.LOGGER.info("PUMPED REPORT");
+			LOGGER.info("PUMPED REPORT");
 		}
 
 		return result;
@@ -162,15 +167,15 @@ public final class JasperReportUtil {
 											ReportFormat format,
 											OutputStream out)
 	throws Exception {
-		UtilImpl.LOGGER.info("FILL REPORT");
+		LOGGER.info("FILL REPORT");
 		JasperPrint result;
 		try (AutoClosingIterable<Bean> iterable = listModel.iterate()) {
 			final JRDataSource dataSource = new SkyveDataSource(user, iterable.iterator());
 			result = JasperFillManager.fillReport(jasperReport, parameters, dataSource);
 		}
-		UtilImpl.LOGGER.info("PUMP REPORT");
+		LOGGER.info("PUMP REPORT");
 		runReport(result, format, out);
-		UtilImpl.LOGGER.info("PUMPED REPORT");
+		LOGGER.info("PUMPED REPORT");
 
 		return result;
 	}
@@ -180,13 +185,13 @@ public final class JasperReportUtil {
 										ReportFormat format,
 										OutputStream out)
 	throws Exception {
-		UtilImpl.LOGGER.info("FILL REPORT");
+		LOGGER.info("FILL REPORT");
 		JasperPrint result;
 		try (Connection connection = EXT.getDataStoreConnection()) {
 			result = JasperFillManager.fillReport(jasperReport, parameters, connection);
-			UtilImpl.LOGGER.info("PUMP REPORT");
+			LOGGER.info("PUMP REPORT");
 			runReport(result, format, out);
-			UtilImpl.LOGGER.info("PUMPED REPORT");
+			LOGGER.info("PUMPED REPORT");
 		}
 		return result;
 	}
@@ -204,18 +209,18 @@ public final class JasperReportUtil {
 			final JasperReport jasperReport = (JasperReport) JRLoader.loadObject(new File(reportFileName));
 			final String queryLanguage = jasperReport.getQuery().getLanguage();
 
-			UtilImpl.LOGGER.info("QUERY LNG = " + queryLanguage);
+			LOGGER.info("QUERY LNG = " + queryLanguage);
 			if ("sql".equalsIgnoreCase(queryLanguage)) {
-				UtilImpl.LOGGER.info("FILL REPORT");
+				LOGGER.info("FILL REPORT");
 				try (Connection connection = EXT.getDataStoreConnection()) {
 					result.add(JasperFillManager.fillReport(jasperReport, reportParameter.getParameters(), connection));
-					UtilImpl.LOGGER.info("PUMP REPORT");
+					LOGGER.info("PUMP REPORT");
 					runReport(result, format, out);
-					UtilImpl.LOGGER.info("PUMPED REPORT");
+					LOGGER.info("PUMPED REPORT");
 				}
 			}
 			else if ("document".equalsIgnoreCase(queryLanguage)) {
-				UtilImpl.LOGGER.info("FILL REPORT");
+				LOGGER.info("FILL REPORT");
 				Bean reportBean = reportParameter.getBean();
 				// if we have no bean then see if there is a bizId parameter
 				if (reportBean == null) {
@@ -233,9 +238,9 @@ public final class JasperReportUtil {
 			}
 		}
 
-		UtilImpl.LOGGER.info("PUMP REPORT");
+		LOGGER.info("PUMP REPORT");
 		runReport(result, format, out);
-		UtilImpl.LOGGER.info("PUMPED REPORT");
+		LOGGER.info("PUMPED REPORT");
 
 		return result;
 	}

--- a/skyve-ext/src/main/java/org/skyve/impl/sail/execution/InlineSeleneseExecutor.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/sail/execution/InlineSeleneseExecutor.java
@@ -1,10 +1,9 @@
 package org.skyve.impl.sail.execution;
 
+import org.skyve.metadata.sail.language.Automation;
+import org.skyve.metadata.sail.language.Interaction;
 import org.skyve.metadata.sail.language.Procedure;
 import org.skyve.metadata.sail.language.Step;
-import org.skyve.util.Util;
-import org.skyve.metadata.sail.language.Interaction;
-import org.skyve.metadata.sail.language.Automation;
 
 public abstract class InlineSeleneseExecutor<T extends AutomationContext> extends SeleneseExecutor<T> {
 	@Override
@@ -34,7 +33,7 @@ public abstract class InlineSeleneseExecutor<T extends AutomationContext> extend
 	
 	@Override
 	public void executeInteraction(Interaction interaction) {
-		Util.LOGGER.info("Execute Interaction " + interaction.getName());
+		LOGGER.info("Execute Interaction " + interaction.getName());
 		startTest(interaction.getName());
 		Procedure before = interaction.getBefore();
 		if (before != null) {

--- a/skyve-ext/src/main/java/org/skyve/impl/sail/execution/InlineWebDriverExecutor.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/sail/execution/InlineWebDriverExecutor.java
@@ -1,10 +1,9 @@
 package org.skyve.impl.sail.execution;
 
+import org.skyve.metadata.sail.language.Automation;
+import org.skyve.metadata.sail.language.Interaction;
 import org.skyve.metadata.sail.language.Procedure;
 import org.skyve.metadata.sail.language.Step;
-import org.skyve.util.Util;
-import org.skyve.metadata.sail.language.Interaction;
-import org.skyve.metadata.sail.language.Automation;
 
 public abstract class InlineWebDriverExecutor<T extends AutomationContext> extends WebDriverExecutor<T> {
 	@Override
@@ -35,7 +34,7 @@ public abstract class InlineWebDriverExecutor<T extends AutomationContext> exten
 	
 	@Override
 	public void executeInteraction(Interaction interaction) {
-		Util.LOGGER.info("Execute Interaction " + interaction.getName());
+		LOGGER.info("Execute Interaction " + interaction.getName());
 		startTest(interaction.getName());
 		Procedure before = interaction.getBefore();
 		if (before != null) {

--- a/skyve-ext/src/main/java/org/skyve/impl/script/SkyveScriptInterpreter.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/script/SkyveScriptInterpreter.java
@@ -45,9 +45,12 @@ import org.skyve.metadata.model.document.Collection.CollectionType;
 import org.skyve.metadata.user.DocumentPermission;
 import org.skyve.metadata.view.View.ViewType;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SkyveScriptInterpreter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkyveScriptInterpreter.class);
 
 	private List<DocumentMetaData> documents;
 	private List<ModuleMetaData> modules;
@@ -409,13 +412,13 @@ public class SkyveScriptInterpreter {
 	 * Adds a new critical error to the list of errors for this script.
 	 */
 	private void addCritical(String message) {
-		Util.LOGGER.warning(message);
+		LOGGER.warn(message);
 		getErrors().add(new SkyveScriptException(ExceptionType.critical, message, currentLine));
 
 	}
 
 	private void addError(String message) {
-		Util.LOGGER.warning(message);
+		LOGGER.warn(message);
 		getErrors().add(new SkyveScriptException(ExceptionType.error, message, currentLine));
 	}
 
@@ -442,7 +445,7 @@ public class SkyveScriptInterpreter {
 	}
 
 	private void addWarning(String message) {
-		Util.LOGGER.info(message);
+		LOGGER.info(message);
 		getErrors().add(new SkyveScriptException(ExceptionType.warning, message, currentLine));
 	}
 

--- a/skyve-ext/src/main/java/org/skyve/impl/security/HIBPPasswordValidator.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/security/HIBPPasswordValidator.java
@@ -8,7 +8,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 
@@ -18,6 +19,8 @@ import jakarta.annotation.Nonnull;
  * @author Simeon Solomou
  */
 public class HIBPPasswordValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HIBPPasswordValidator.class);
 
 	private static final String HIBP_API_URL = "https://api.pwnedpasswords.com/range/";
 
@@ -52,8 +55,7 @@ public class HIBPPasswordValidator {
 			
 			return isHashSuffixPresent(body, suffix);
 		} catch (Exception e) {
-			Util.LOGGER.warning("HaveIBeenPwned API call failed");
-			e.printStackTrace();
+			LOGGER.warn("HaveIBeenPwned API call failed", e);
 		}
 
 		return false;

--- a/skyve-ext/src/main/java/org/skyve/impl/security/SkyveLegacyAuthenticationProvider.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/security/SkyveLegacyAuthenticationProvider.java
@@ -10,8 +10,9 @@ import java.util.Collections;
 
 import org.apache.commons.codec.binary.Base64;
 import org.skyve.EXT;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
@@ -20,6 +21,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 
 public class SkyveLegacyAuthenticationProvider implements AuthenticationProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkyveLegacyAuthenticationProvider.class);
+
 	private String hashedPasswordSql;
 	
 	@Override
@@ -32,7 +36,7 @@ public class SkyveLegacyAuthenticationProvider implements AuthenticationProvider
 			md = MessageDigest.getInstance(Util.getPasswordHashingAlgorithm());
 		}
 		catch (NoSuchAlgorithmException e) {
-			UtilImpl.LOGGER.severe("Could not authenticate user " + name + ". No such hashing algorithm " + Util.getPasswordHashingAlgorithm());
+			LOGGER.error("Could not authenticate user " + name + ". No such hashing algorithm " + Util.getPasswordHashingAlgorithm());
 			throw new InternalAuthenticationServiceException("Could not authenticate user " + name, e);
 		}
 		Base64 base64Codec = new Base64();
@@ -52,20 +56,20 @@ public class SkyveLegacyAuthenticationProvider implements AuthenticationProvider
 					if (rs.next()) {
 						String storedPasswordHash = rs.getString(1);
 						if (storedPasswordHash == null) {
-							UtilImpl.LOGGER.severe("User " + name + " has no password");
+							LOGGER.error("User " + name + " has no password");
 							throw new InternalAuthenticationServiceException("User " + name + " has no password");
 						}
 						if (rs.next()) {
-							UtilImpl.LOGGER.severe("User " + name + " is not unique");
+							LOGGER.error("User " + name + " is not unique");
 							throw new InternalAuthenticationServiceException("User " + name + " is not unique");
 						}
 						if (! storedPasswordHash.equals(hashedPassword)) {
-							UtilImpl.LOGGER.severe("Password mismatch for user " + name);
+							LOGGER.error("Password mismatch for user " + name);
 							throw new BadCredentialsException("Invalid Credential");
 						}
 					}
 					else {
-						UtilImpl.LOGGER.severe("User " + name + " not found");
+						LOGGER.error("User " + name + " not found");
 						throw new BadCredentialsException("Invalid Credential");
 					}
 				}

--- a/skyve-ext/src/main/java/org/skyve/impl/security/SkyveRememberMeTokenRepository.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/security/SkyveRememberMeTokenRepository.java
@@ -8,7 +8,8 @@ import org.skyve.domain.types.OptimisticLock;
 import org.skyve.impl.util.UUIDv7;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.persistence.Persistence;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -21,6 +22,9 @@ import org.springframework.security.web.authentication.rememberme.PersistentToke
 import jakarta.annotation.Nonnull;
 
 public class SkyveRememberMeTokenRepository extends JdbcDaoSupport implements PersistentTokenRepository {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkyveRememberMeTokenRepository.class);
+
 	private String getTokenForSeriesSql = "select userName, series, token, lastUsed from ADM_UserToken where series = ?";
 	private String createNewTokenSql = "insert into ADM_UserToken (bizId, bizVersion, bizLock, bizKey, bizCustomer, bizUserId, userName, series, token, lastUsed) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 	private String updateTokenSql = "update ADM_UserToken set token = ?, lastUsed = ? where series = ?";
@@ -94,14 +98,13 @@ public class SkyveRememberMeTokenRepository extends JdbcDaoSupport implements Pe
 						seriesId);
 		}
 		catch (@SuppressWarnings("unused") EmptyResultDataAccessException zeroResults) {
-			Util.LOGGER.warning("Querying token for series " + seriesId + " returned no result");
+			LOGGER.warn("Querying token for series " + seriesId + " returned no result");
 		}
 		catch (@SuppressWarnings("unused") IncorrectResultSizeDataAccessException moreThanOne) {
-			Util.LOGGER.warning("Querying token for series " + seriesId + " returned many results");
+			LOGGER.warn("Querying token for series " + seriesId + " returned many results");
 		}
 		catch (DataAccessException e) {
-			Util.LOGGER.severe("Failed to find token for series " + seriesId);
-			e.printStackTrace();
+			LOGGER.error("Failed to find token for series {}", seriesId, e);
 		}
 
 		return null;

--- a/skyve-ext/src/main/java/org/skyve/impl/snapshot/SmartClientSnapshotAdapter.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/snapshot/SmartClientSnapshotAdapter.java
@@ -205,8 +205,7 @@ class SmartClientSnapshotAdapter extends SnapshotAdapter {
 			}
 		}
 		catch (Exception e) {
-			UtilImpl.LOGGER.warning("Snapshot could not be created from SmartClient Payload " + payload);
-			e.printStackTrace();
+			LOGGER.warn("Snapshot could not be created from SmartClient Payload {}", payload, e);
 			result = null;
 		}
 		

--- a/skyve-ext/src/main/java/org/skyve/impl/snapshot/SnapshotAdapter.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/snapshot/SnapshotAdapter.java
@@ -1,5 +1,8 @@
 package org.skyve.impl.snapshot;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jakarta.annotation.Nullable;
 
 /**
@@ -7,6 +10,9 @@ import jakarta.annotation.Nullable;
  * This class can be used as a validator or converter of different client snapshot payload types.
  */
 public abstract class SnapshotAdapter {
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
 	/**
 	 * SmartClient adapter.
 	 */

--- a/skyve-ext/src/main/java/org/skyve/impl/snapshot/VueSnapshotAdapter.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/snapshot/VueSnapshotAdapter.java
@@ -223,8 +223,7 @@ class VueSnapshotAdapter extends SnapshotAdapter {
 			}
 		}
 		catch (Exception e) {
-			UtilImpl.LOGGER.warning("Snapshot could not be created from Vue Payload " + payload);
-			e.printStackTrace();
+			LOGGER.warn("Snapshot could not be created from Vue Payload {}", payload, e);
 			result = null;
 		}
 		
@@ -263,7 +262,7 @@ class VueSnapshotAdapter extends SnapshotAdapter {
 					// If this was a SmartClient snapshot definition, send that...
 					Map<String, Object> sourceSmartClientCriteria = snapshot.getSourceSmartClientCriteria();
 					if (sourceSmartClientCriteria != null) {
-						UtilImpl.LOGGER.warning("SmartClient Filter for snapshot could not be converted to a Vue Payload - using original SmartClient Filter :- " + sourceSmartClientCriteria);
+						LOGGER.warn("SmartClient Filter for snapshot could not be converted to a Vue Payload - using original SmartClient Filter :- " + sourceSmartClientCriteria);
 						result.put(VUE_SMART_CLIENT_CRITERIA, sourceSmartClientCriteria);
 					}
 					else {
@@ -318,7 +317,7 @@ class VueSnapshotAdapter extends SnapshotAdapter {
 			return JSON.marshall(result);
 		}
 		catch (Exception e) {
-			UtilImpl.LOGGER.severe("Vue Filter for snapshot could not be converted to a Vue Payload - " + e.getLocalizedMessage());
+			LOGGER.error("Vue Filter for snapshot could not be converted to a Vue Payload - " + e.getLocalizedMessage());
 			return null;
 		}
 	}

--- a/skyve-ext/src/main/java/org/skyve/impl/util/ExportedReferenceVisitor.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/util/ExportedReferenceVisitor.java
@@ -20,6 +20,7 @@ import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.model.document.Reference.ReferenceType;
 import org.skyve.metadata.module.Module;
 import org.skyve.persistence.SQL;
+import org.skyve.util.logging.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,9 @@ import org.slf4j.LoggerFactory;
  * The Dereferencer convenience class does just this.
  */
 public abstract class ExportedReferenceVisitor {
+
+    private static final Logger QUERY_LOGGER = Category.QUERY.logger();
+
 	public void visit(Bean bean)
 	throws Exception {
 		CustomerImpl c = (CustomerImpl) CORE.getUser().getCustomer();
@@ -243,7 +247,7 @@ public abstract class ExportedReferenceVisitor {
 						statement.append(" = :").append(PersistentBean.OWNER_COLUMN_NAME);
 						statement.append(" where ").append(PersistentBean.ELEMENT_COLUMN_NAME);
 						statement.append(" = :").append(Bean.DOCUMENT_ID);
-						if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(statement.toString());
+						if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(statement.toString());
 						logger.debug(statement.toString());
 						SQL sql = CORE.getPersistence().newSQL(statement.toString());
 						sql.putParameter(Bean.DOCUMENT_ID, bizId, false);
@@ -257,7 +261,7 @@ public abstract class ExportedReferenceVisitor {
 						statement.append(persistentIdentifier);
 						statement.append('_').append(exportedReference.getReferenceFieldName());
 						statement.append(" where ").append(PersistentBean.ELEMENT_COLUMN_NAME).append(" = :").append(Bean.DOCUMENT_ID);
-						if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(statement.toString());
+						if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(statement.toString());
 						logger.debug(statement.toString());
 						CORE.getPersistence().newSQL(statement.toString()).putParameter(Bean.DOCUMENT_ID, bizId, false).execute();
 					}
@@ -271,7 +275,7 @@ public abstract class ExportedReferenceVisitor {
 				statement.append("update ").append(persistentIdentifier);
 				statement.append(" set ").append(referenceFieldName).append("_id = :newBizId");
 				statement.append(" where ").append(referenceFieldName).append("_id = :").append(Bean.DOCUMENT_ID);
-				if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(statement.toString());
+				if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(statement.toString());
 				logger.debug(statement.toString());
 				SQL sql = CORE.getPersistence().newSQL(statement.toString());
 				sql.putParameter(Bean.DOCUMENT_ID, bizId, false);
@@ -293,7 +297,7 @@ public abstract class ExportedReferenceVisitor {
 				statement.append("update ").append(persistentIdentifier);
 				statement.append(" set ").append(HierarchicalBean.PARENT_ID).append(" = :newBizId");
 				statement.append(" where ").append(HierarchicalBean.PARENT_ID).append(" = :").append(Bean.DOCUMENT_ID);
-				if (UtilImpl.QUERY_TRACE) UtilImpl.LOGGER.info(statement.toString());
+				if (UtilImpl.QUERY_TRACE) QUERY_LOGGER.info(statement.toString());
 				logger.debug(statement.toString());
 				SQL sql = CORE.getPersistence().newSQL(statement.toString());
 				sql.putParameter(Bean.DOCUMENT_ID, bizId, false);

--- a/skyve-ext/src/main/java/org/skyve/impl/util/MailUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/util/MailUtil.java
@@ -8,12 +8,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.logging.Level;
 
 import org.skyve.content.MimeType;
 import org.skyve.domain.messages.ValidationException;
 import org.skyve.util.Mail;
 import org.skyve.util.MailAttachment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.activation.DataHandler;
 import jakarta.activation.DataSource;
@@ -32,6 +33,9 @@ import jakarta.mail.internet.MimeMultipart;
 import jakarta.mail.util.ByteArrayDataSource;
 
 public class MailUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailUtil.class);
+
 	private MailUtil() {
 		// no-op
 	}
@@ -45,7 +49,7 @@ public class MailUtil {
 			}
 		}
 		catch (Exception e) {
-			UtilImpl.LOGGER.log(Level.SEVERE, "Email was not written", e);
+			LOGGER.error("Email was not written", e);
 			throw new ValidationException(new org.skyve.domain.messages.Message("Email was not written..."));
 		}
 	}
@@ -59,7 +63,7 @@ public class MailUtil {
 			}
 		}
 		catch (Exception e) {
-			UtilImpl.LOGGER.log(Level.SEVERE, "Email was not sent", e);
+			LOGGER.error("Email was not sent", e);
 			throw new ValidationException(new org.skyve.domain.messages.Message("Email was not sent..."));
 		}
 	}
@@ -76,42 +80,42 @@ public class MailUtil {
 		Map<String, String> headers = mail.getHeaders();
 		List<MailAttachment> attachments = mail.getAttachments();
 		
-		UtilImpl.LOGGER.info("@@@@@@@@@@@@ EMAIL @@@@@@@@@@@@");
-		UtilImpl.LOGGER.info("TO:");
+		LOGGER.info("@@@@@@@@@@@@ EMAIL @@@@@@@@@@@@");
+		LOGGER.info("TO:");
 		if (UtilImpl.SMTP_TEST_RECIPIENT != null) {
-			UtilImpl.LOGGER.info("    SMTP_TEST_RECIPIENT - " + UtilImpl.SMTP_TEST_RECIPIENT);
+			LOGGER.info("    SMTP_TEST_RECIPIENT - " + UtilImpl.SMTP_TEST_RECIPIENT);
 		}
 		else {
 			if (recipientEmailAddresses != null) {
 				for (String to : recipientEmailAddresses) {
-					UtilImpl.LOGGER.info("    " + to);
+					LOGGER.info("    " + to);
 				}
 			}
 		}
-		UtilImpl.LOGGER.info("CC:");
+		LOGGER.info("CC:");
 		if (UtilImpl.SMTP_TEST_RECIPIENT == null) {
-			UtilImpl.LOGGER.info("    " + UtilImpl.SMTP_TEST_RECIPIENT);
+			LOGGER.info("    " + UtilImpl.SMTP_TEST_RECIPIENT);
 			if (ccEmailAddresses != null) {
 				for (String cc : ccEmailAddresses) {
-					UtilImpl.LOGGER.info("    " + cc);
+					LOGGER.info("    " + cc);
 				}
 			}
 		}
-		UtilImpl.LOGGER.info("BCC:");
+		LOGGER.info("BCC:");
 		if (UtilImpl.SMTP_TEST_RECIPIENT == null) {
-			UtilImpl.LOGGER.info("    " + UtilImpl.SMTP_TEST_RECIPIENT);
+			LOGGER.info("    " + UtilImpl.SMTP_TEST_RECIPIENT);
 			if (bccEmailAddresses != null) {
 				for (String bcc : bccEmailAddresses) {
-					UtilImpl.LOGGER.info("    " + bcc);
+					LOGGER.info("    " + bcc);
 				}
 			}
 		}
 
-		UtilImpl.LOGGER.info("SENDER: " + senderEmailAddress);
-		UtilImpl.LOGGER.info("SUBJECT " + subject);
-		UtilImpl.LOGGER.info("BODY " + body);
-		UtilImpl.LOGGER.info("CONTENT TYPE: " + contentType);
-		UtilImpl.LOGGER.info("@@@@@@@@@@@@ EMAIL @@@@@@@@@@@@");
+		LOGGER.info("SENDER: " + senderEmailAddress);
+		LOGGER.info("SUBJECT " + subject);
+		LOGGER.info("BODY " + body);
+		LOGGER.info("CONTENT TYPE: " + contentType);
+		LOGGER.info("@@@@@@@@@@@@ EMAIL @@@@@@@@@@@@");
 
 		// Get system properties and add our mail server
 		Session session = null;

--- a/skyve-ext/src/main/java/org/skyve/impl/util/PluralUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/util/PluralUtil.java
@@ -10,7 +10,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.skyve.impl.util.ArticleNode.Data;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Pluarlise function converted and enhanced Java implementation of
@@ -21,6 +22,8 @@ import org.skyve.util.Util;
  * Licence: Apache 2.0
  */
 public class PluralUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PluralUtil.class);
 
 	final static String LOWERCASE_PATTERN = "\\b[a-z'\\-]+\\b";
 	final static String TITLECASE_PATTERN = "\\b[A-Z][a-z'\\-]+\\b";
@@ -33,7 +36,7 @@ public class PluralUtil {
 		static {
 			Instant start = Instant.now();
 			fill("", articleRoot, ARTICLE_DICTIONARY);
-			Util.LOGGER.info("Time to fill dictionary: " + Duration.between(start, Instant.now()));
+			LOGGER.info("Time to fill dictionary: " + Duration.between(start, Instant.now()));
 		}
 	}
 
@@ -578,7 +581,7 @@ public class PluralUtil {
 		node.data.setPrefix(prefix);
 		node.data.setArticle(n.get(0) >= n.get(1) ? "a" : "an");
 
-		Util.LOGGER.fine(String.format("Filling for prefix:  %s  %d  %d", prefix, n.get(0), n.get(1)));
+		LOGGER.debug("Filling for prefix:  {}  {}  {}", prefix, n.get(0), n.get(1));
 
 		String d2 = dict.substring(1 + String.join(";", a).length() > dict.length() ? 0 : 1 + String.join(";", a).length());
 		for (int i = 0; i < n.get(2); i++) {

--- a/skyve-ext/src/main/java/org/skyve/impl/web/UserAgent.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/web/UserAgent.java
@@ -9,8 +9,9 @@ import org.skyve.domain.messages.DomainException;
 import org.skyve.impl.metadata.repository.router.Router;
 import org.skyve.metadata.router.UxUi;
 import org.skyve.metadata.router.UxUiSelector;
-import org.skyve.util.Util;
 import org.skyve.web.UserAgentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.blueconic.browscap.BrowsCapField;
 import com.blueconic.browscap.Capabilities;
@@ -22,6 +23,9 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
 public class UserAgent {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserAgent.class);
+
 	/**
 	 * Prevent instantiation
 	 */
@@ -33,9 +37,9 @@ public class UserAgent {
 	// NB Initiased here so its thread safe.
 	static {
 		try {
-			Util.LOGGER.info("Load BrowsCap");
+			LOGGER.info("Load BrowsCap");
 			parser = new UserAgentService().loadParser(Collections.singleton(BrowsCapField.DEVICE_TYPE));
-			Util.LOGGER.info("Loaded BrowsCap");
+			LOGGER.info("Loaded BrowsCap");
 		}
 		catch (Exception e) {
 			throw new DomainException("Cannot initialise Browscap.", e);

--- a/skyve-ext/src/main/java/org/skyve/job/IteratingJob.java
+++ b/skyve-ext/src/main/java/org/skyve/job/IteratingJob.java
@@ -3,8 +3,6 @@ package org.skyve.job;
 import java.util.Collection;
 
 import org.skyve.persistence.Persistence;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import jakarta.inject.Inject;
 
@@ -12,7 +10,6 @@ import jakarta.inject.Inject;
  * A job that performs an operation over a collection of elements.
  */
 public abstract class IteratingJob<T> extends CancellableJob {
-	private static final Logger LOGGER = LoggerFactory.getLogger(IteratingJob.class);
 
 	@Inject
 	private transient Persistence persistence;

--- a/skyve-ext/src/main/java/org/skyve/job/ViewBackgroundTask.java
+++ b/skyve-ext/src/main/java/org/skyve/job/ViewBackgroundTask.java
@@ -10,8 +10,9 @@ import org.skyve.impl.persistence.AbstractPersistence;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.AbstractWebContext;
 import org.skyve.metadata.user.User;
-import org.skyve.util.Util;
 import org.skyve.web.BackgroundTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is the default implementation of BackgroundTask integration and serves as the extension point.
@@ -20,6 +21,9 @@ import org.skyve.web.BackgroundTask;
  * @param <T>	The type of bean the task is operating on - usually the conversation bean.
  */
 public abstract class ViewBackgroundTask<T extends Bean> implements BackgroundTask<T>, org.quartz.Job {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ViewBackgroundTask.class);
+
 	private AbstractWebContext webContext;
 	private T bean;
 	private User user;
@@ -72,8 +76,7 @@ public abstract class ViewBackgroundTask<T extends Bean> implements BackgroundTa
 			execute(bean);
 		}
 		catch (Throwable t) {
-			Util.LOGGER.severe(getClass().getName() + " failed to execute - Exception caught : " + t.getLocalizedMessage());
-		    t.printStackTrace();
+			LOGGER.error("{} failed to execute - Exception caught : {}", getClass().getName(), t.getLocalizedMessage(), t);
 	    	if (persistence != null) {
 	    		persistence.rollback();
 	    	}

--- a/skyve-ext/src/main/java/org/skyve/util/CommunicationUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/util/CommunicationUtil.java
@@ -4,7 +4,6 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 
 import org.skyve.CORE;
 import org.skyve.EXT;
@@ -34,8 +33,13 @@ import org.skyve.metadata.user.User;
 import org.skyve.persistence.DocumentQuery;
 import org.skyve.persistence.Persistence;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CommunicationUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommunicationUtil.class);
+
 	private static final String EMAIL_ADDRESS_DELIMETERS = "[,;]";
 	private static final String INVALID_RESOLVED_EMAIL_ADDRESS = "The sendTo address could not be resolved to a valid email address";
 	public static final String SPECIAL_BEAN_URL = "{#url}";
@@ -241,7 +245,7 @@ public class CommunicationUtil {
 				fos.flush();
 			} catch (Exception e) {
 				if (ResponseMode.SILENT.equals(responseMode)) {
-					Util.LOGGER.log(Level.WARNING, e.toString());
+					LOGGER.warn(e.toString(), e);
 				} else {
 					throw e;
 				}
@@ -322,7 +326,7 @@ public class CommunicationUtil {
 				v.validate(CORE.getUser(), address, "email1", "Email", null, ve);
 				if (!ve.getMessages().isEmpty()) {
 					if (ResponseMode.SILENT.equals(responseMode)) {
-						Util.LOGGER.log(Level.ALL, "The resolved email address " + address + " could not be validated.");
+						LOGGER.trace("The resolved email address {} could not be validated.", address);
 					} else {
 						throw ve;
 					}

--- a/skyve-ext/src/main/java/org/skyve/util/FileUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/util/FileUtil.java
@@ -32,6 +32,8 @@ import org.skyve.content.MimeType;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.SortDirection;
 import org.skyve.metadata.controller.Download;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -43,6 +45,8 @@ import jakarta.annotation.Nullable;
  * 
  */
 public class FileUtil {
+
+    private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
 
 	public FileUtil() {
 		// no op
@@ -306,7 +310,7 @@ public class FileUtil {
 			String zipFilePath = file.getCanonicalPath().substring(directoryToZip.getCanonicalPath().length() + 1,
 																	file.getCanonicalPath().length());
 			zipFilePath = zipFilePath.replace('\\', '/');
-			if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(String.format("Writing '%s' to zip file", zipFilePath));
+			if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(String.format("Writing '%s' to zip file", zipFilePath));
 			ZipEntry zipEntry = new ZipEntry(zipFilePath);
 			zos.putNextEntry(zipEntry);
 
@@ -323,7 +327,7 @@ public class FileUtil {
 	private static void extractFile(@Nonnull ZipInputStream in, @Nonnull File outdir, @Nonnull String name)
 	throws IOException {
 		File file = new File(outdir, name);
-		if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(String.format("Writing '%s' from zip file to %s", name, file));
+		if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(String.format("Writing '%s' from zip file to %s", name, file));
 		try (FileOutputStream fos = new FileOutputStream(file)) {
 			try (BufferedOutputStream out = new BufferedOutputStream(fos)) {
 				byte[] bytes = new byte[1024];
@@ -363,7 +367,7 @@ public class FileUtil {
 					String name = entry.getName();
 					if (entry.isDirectory()) {
 						mkdirs(outdir, name);
-						if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("create dir " + name);
+						if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("create dir " + name);
 						continue;
 					}
 					/* this part is necessary because file entry can come before
@@ -375,7 +379,7 @@ public class FileUtil {
 					String dir = dirpart(name);
 					if (dir != null) {
 						mkdirs(outdir, dir);
-						if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("create dir " + name);
+						if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("create dir " + name);
 					}
 					extractFile(zin, outdir, name);
 				}

--- a/skyve-ext/src/main/java/org/skyve/util/Thumbnail.java
+++ b/skyve-ext/src/main/java/org/skyve/util/Thumbnail.java
@@ -19,6 +19,8 @@ import org.skyve.content.MimeType;
 import org.skyve.impl.content.AbstractContentManager;
 import org.skyve.impl.util.ImageUtil;
 import org.skyve.impl.util.UtilImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -30,6 +32,9 @@ import net.coobird.thumbnailator.Thumbnails;
  * @author mike
  */
 public class Thumbnail {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Thumbnail.class);
+
 	/**
 	 * This is a marker file to indicate that this piece of content is not an image.
 	 * A file type SVG will be returned in this case.
@@ -236,8 +241,7 @@ public class Thumbnail {
 					ImageUtil.burnSvg(image, markup);
 				}
 				catch (Exception e) {
-					UtilImpl.LOGGER.warning("Could not burn markup onto image - markis = " + markup);
-					e.printStackTrace();
+					LOGGER.warn("Could not burn markup onto image - markis = {}", markup, e);
 				}
 			}
 

--- a/skyve-maven-plugin/pom.xml
+++ b/skyve-maven-plugin/pom.xml
@@ -127,12 +127,6 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup</groupId>

--- a/skyve-war/pom.xml
+++ b/skyve-war/pom.xml
@@ -207,11 +207,6 @@
 			<artifactId>slf4j-api</artifactId>
 			<scope>compile</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<scope>runtime</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.apache.poi</groupId>

--- a/skyve-war/src/main/java/modules/admin/Audit/AuditBizlet.java
+++ b/skyve-war/src/main/java/modules/admin/Audit/AuditBizlet.java
@@ -26,16 +26,12 @@ import org.skyve.persistence.Persistence;
 import org.skyve.util.Binder;
 import org.skyve.util.Util;
 import org.skyve.web.WebContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import jakarta.inject.Inject;
 import modules.admin.domain.Audit;
 import modules.admin.domain.Audit.Operation;
 
 public class AuditBizlet extends Bizlet<Audit> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuditBizlet.class);
 
     private ArchiveRetriever retriever = ArchiveRetriever.getInstance();
 

--- a/skyve-war/src/main/java/modules/admin/ChangePassword/SendPasswordChangeNotificationJob.java
+++ b/skyve-war/src/main/java/modules/admin/ChangePassword/SendPasswordChangeNotificationJob.java
@@ -7,7 +7,6 @@ import org.skyve.impl.bind.BindUtil;
 import org.skyve.job.Job;
 import org.skyve.util.CommunicationUtil;
 import org.skyve.util.CommunicationUtil.ResponseMode;
-import org.skyve.util.Util;
 
 import modules.admin.domain.Configuration;
 import modules.admin.domain.Contact;
@@ -64,7 +63,7 @@ public class SendPasswordChangeNotificationJob extends Job {
 		if (!Configuration.newInstance().isEmailConfigured()) {
 			String warningMessage = "Email is not configured. Failed to send password change notification.";
 			log.add(warningMessage);
-			Util.LOGGER.warning(warningMessage);
+			LOGGER.warn(warningMessage);
 			return;
 		}
 
@@ -73,7 +72,7 @@ public class SendPasswordChangeNotificationJob extends Job {
 		if (user == null) {
 			String warningMessage = "No user has been parsed. Failed to send password change notification.";
 			log.add(warningMessage);
-			Util.LOGGER.warning(warningMessage);
+			LOGGER.warn(warningMessage);
 			return;
 		}
 		Contact contact = user.getContact();
@@ -83,7 +82,7 @@ public class SendPasswordChangeNotificationJob extends Job {
 		if (startup.getEnvironmentSupportEmail() == null) {
 			String warningMessage = "There is no environment support email specified. Failed to send password change notification.";
 			log.add(warningMessage);
-			Util.LOGGER.warning(warningMessage);
+			LOGGER.warn(warningMessage);
 			return;
 		}
 
@@ -117,11 +116,11 @@ public class SendPasswordChangeNotificationJob extends Job {
 			}
 			String successMessage = "Successfully sent password change notification to " + contact.getName();
 			log.add(successMessage);
-			Util.LOGGER.info(successMessage);
+			LOGGER.info(successMessage);
 		} catch (Exception e) {
 			String failureMessage = "Failed to send password change notification to " + contact.getName();
 			log.add(failureMessage);
-			Util.LOGGER.severe(failureMessage);
+			LOGGER.error(failureMessage);
 			e.printStackTrace();
 		}
 

--- a/skyve-war/src/main/java/modules/admin/Configuration/DiskSpaceSummary.java
+++ b/skyve-war/src/main/java/modules/admin/Configuration/DiskSpaceSummary.java
@@ -8,7 +8,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.NumberFormat;
 
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.ModulesUtil;
 
@@ -16,6 +17,9 @@ import modules.admin.ModulesUtil;
  * Determine the total file system sizings.
  */
 public final class DiskSpaceSummary {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiskSpaceSummary.class);
+
 	private long totalAvailable;
 	private long totalSpace;
 	private long totalAvailableLevel;
@@ -41,8 +45,7 @@ public final class DiskSpaceSummary {
 
 			}
 			catch (IOException e) {
-				Util.LOGGER.severe("Error querying available disk space:");
-				e.printStackTrace();
+				LOGGER.error("Error querying available disk space:", e);
 			}
 		}
 		this.totalAvailableLevel = (100 * totalAvailable / totalSpace);

--- a/skyve-war/src/main/java/modules/admin/DataMaintenance/BackupJob.java
+++ b/skyve-war/src/main/java/modules/admin/DataMaintenance/BackupJob.java
@@ -15,7 +15,6 @@ import org.skyve.impl.util.UtilImpl;
 import org.skyve.job.Job;
 import org.skyve.metadata.SortDirection;
 import org.skyve.util.FileUtil;
-import org.skyve.util.Util;
 
 import modules.admin.domain.DataMaintenance;
 
@@ -46,7 +45,7 @@ public class BackupJob extends Job {
 			// warn the user if no backup was set and shortcut out
 			trace = "No backup taken by the BackupJob as no retention periods were set on the Data Maintenance Backup/Restore tab.";
 			log.add(trace);
-			Util.LOGGER.info(trace);
+			LOGGER.info(trace);
 			setPercentComplete(0);
 			return;
 		}
@@ -54,20 +53,20 @@ public class BackupJob extends Job {
 		if (daily > 0) {
 			trace = "Take backup...";
 			log.add(trace);
-			Util.LOGGER.warning(trace);
+			LOGGER.warn(trace);
 			org.skyve.impl.backup.BackupJob backupJob = new org.skyve.impl.backup.BackupJob();
 			execute(backupJob);
 			backupZip = backupJob.getBackupZip();
 		} else {
 			trace = "No daily backup taken by the BackupJob as dailyBackupRetention in DataMaintenance is null or zero";
 			log.add(trace);
-			Util.LOGGER.warning(trace);
+			LOGGER.warn(trace);
 		}
 
 		if (backupZip != null) {
 			trace = "Backup made to zip " + backupZip.getAbsolutePath();
 			log.add(trace);
-			Util.LOGGER.warning(trace);
+			LOGGER.warn(trace);
 
 			// move the zip archive
 			File backupDir = backupZip.getParentFile();
@@ -79,7 +78,7 @@ public class BackupJob extends Job {
 					trace = String.format("Failed to move external backup for %s from %s to %s",
 							UtilImpl.ARCHIVE_NAME, backupZip.getName(), dailyZip.getName());
 					log.add(trace);
-					Util.LOGGER.warning(trace);
+					LOGGER.warn(trace);
 					e.printStackTrace();
 					org.skyve.impl.backup.BackupJob.emailProblem(log, trace);
 				}
@@ -89,7 +88,7 @@ public class BackupJob extends Job {
 				}
 				trace = String.format("Backup moved from %s to %s", backupZip.getAbsolutePath(), dailyZip.getAbsolutePath());
 				log.add(trace);
-				Util.LOGGER.info(trace);
+				LOGGER.info(trace);
 			}
 
 			// copy daily to weekly
@@ -104,20 +103,20 @@ public class BackupJob extends Job {
 						trace = String.format("Failed to copy external backup for %s from %s to %s",
 								UtilImpl.ARCHIVE_NAME, dailyZip.getName(), copy.getName());
 						log.add(trace);
-						Util.LOGGER.warning(trace);
+						LOGGER.warn(trace);
 						e.printStackTrace();
 						org.skyve.impl.backup.BackupJob.emailProblem(log, trace);
 					}
 				} else {
 					trace = String.format("Copy Backup %s to %s", backupZip.getAbsolutePath(), copy.getAbsolutePath());
 					log.add(trace);
-					Util.LOGGER.info(trace);
+					LOGGER.info(trace);
 					FileUtil.copy(dailyZip, copy);
 				}
 			} else {
 				trace = "No weekly backup taken by the BackupJob as weeklyBackupRetention in DataMaintenance is null or zero";
 				log.add(trace);
-				Util.LOGGER.warning(trace);
+				LOGGER.warn(trace);
 			}
 			// copy daily to monthly
 			if (monthly > 0) {
@@ -131,21 +130,21 @@ public class BackupJob extends Job {
 						trace = String.format("Failed to copy external backup for %s from %s to %s",
 								UtilImpl.ARCHIVE_NAME, dailyZip.getName(), copy.getName());
 						log.add(trace);
-						Util.LOGGER.warning(trace);
+						LOGGER.warn(trace);
 						e.printStackTrace();
 						org.skyve.impl.backup.BackupJob.emailProblem(log, trace);
 					}
 				} else {
 					trace = String.format("Copy Backup %s to %s", backupZip.getAbsolutePath(), copy.getAbsolutePath());
 					log.add(trace);
-					Util.LOGGER.info(trace);
+					LOGGER.info(trace);
 					FileUtil.copy(dailyZip, copy);
 				}
 			}
 			else {
 				trace = "No monthly backup taken by the BackupJob as monthlyBackupRetention in DataMaintenance is null or zero";
 				log.add(trace);
-				Util.LOGGER.warning(trace);
+				LOGGER.warn(trace);
 			}
 			// copy daily to yearly
 			if (yearly > 0) {
@@ -158,13 +157,13 @@ public class BackupJob extends Job {
 					} catch (@SuppressWarnings("unused") Exception e) {
 						trace = String.format("Failed to copy external backup from %s to %s", dailyZip.getName(), copy.getName());
 						log.add(trace);
-						Util.LOGGER.warning(trace);
+						LOGGER.warn(trace);
 						org.skyve.impl.backup.BackupJob.emailProblem(log, trace);
 					}
 				} else {
 					trace = String.format("Copy Backup %s to %s", backupZip.getAbsolutePath(), copy.getAbsolutePath());
 					log.add(trace);
-					Util.LOGGER.info(trace);
+					LOGGER.info(trace);
 					FileUtil.copy(dailyZip, copy);
 				}
 			}
@@ -185,7 +184,7 @@ public class BackupJob extends Job {
 		setPercentComplete(100);
 		trace = String.format("Finished Backup of customer %s at %s", CORE.getUser().getCustomerName(), new Date());
 		log.add(trace);
-		Util.LOGGER.info(trace);
+		LOGGER.info(trace);
 	}
 
 	private void cull(File backupDir, String prefix, int retain)
@@ -204,7 +203,7 @@ public class BackupJob extends Job {
 						files[i].getAbsolutePath(),
 						Integer.valueOf(retain));
 				log.add(trace);
-				Util.LOGGER.info(trace);
+				LOGGER.info(trace);
 				FileUtil.delete(files[i]);
 			}
 		}
@@ -219,18 +218,18 @@ public class BackupJob extends Job {
 							matchingBackups.get(i),
 							Integer.valueOf(retain));
 					log.add(trace);
-					Util.LOGGER.info(trace);
+					LOGGER.info(trace);
 					try {
 						ExternalBackup.getInstance().deleteBackup(matchingBackups.get(i));
 					} catch (@SuppressWarnings("unused") Exception e) {
 						trace = String.format("Failed to cull external backup %s", matchingBackups.get(i));
 						log.add(trace);
-						Util.LOGGER.warning(trace);
+						LOGGER.warn(trace);
 						org.skyve.impl.backup.BackupJob.emailProblem(log, trace);
 					}
 				}
 			} catch (Exception e) {
-				Util.LOGGER.warning("Failed to cull external backups " + e.getMessage());
+				LOGGER.warn("Failed to cull external backups " + e.getMessage());
 			}
 		}
 	}

--- a/skyve-war/src/main/java/modules/admin/DataMaintenance/actions/DeleteBackup.java
+++ b/skyve-war/src/main/java/modules/admin/DataMaintenance/actions/DeleteBackup.java
@@ -9,10 +9,15 @@ import org.skyve.metadata.controller.ServerSideActionResult;
 import org.skyve.util.FileUtil;
 import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.domain.DataMaintenance;
 
 public class DeleteBackup implements ServerSideAction<DataMaintenance> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteBackup.class);
+
 	@Override
 	public ServerSideActionResult<DataMaintenance> execute(DataMaintenance bean, WebContext webContext)
 			throws Exception {
@@ -22,11 +27,11 @@ public class DeleteBackup implements ServerSideAction<DataMaintenance> {
 		if (ExternalBackup.areExternalBackupsEnabled()) {
 			String backupName = bean.getSelectedBackupName();
 			if (ExternalBackup.getInstance().exists(backupName)) {
-				Util.LOGGER.info("Deleting backup " + backupName);
+				LOGGER.info("Deleting backup " + backupName);
 				ExternalBackup.getInstance().deleteBackup(bean.getSelectedBackupName());
-				Util.LOGGER.info("Deleted backup " + backupName);
+				LOGGER.info("Deleted backup " + backupName);
 			} else {
-				Util.LOGGER.info("Backup " + backupName + " no longer exists");
+				LOGGER.info("Backup " + backupName + " no longer exists");
 			}
 		}
 		// delete from local content
@@ -36,11 +41,11 @@ public class DeleteBackup implements ServerSideAction<DataMaintenance> {
 				File.separator,
 				bean.getSelectedBackupName()));
 		if (backup.exists()) {
-			Util.LOGGER.info("Deleting backup " + backup.getAbsolutePath());
+			LOGGER.info("Deleting backup " + backup.getAbsolutePath());
 			FileUtil.delete(backup);
-			Util.LOGGER.info("Deleted backup " + backup.getAbsolutePath());
+			LOGGER.info("Deleted backup " + backup.getAbsolutePath());
 		} else {
-			Util.LOGGER.info("Backup " + backup.getAbsolutePath() + " no longer exists");
+			LOGGER.info("Backup " + backup.getAbsolutePath() + " no longer exists");
 		}
 
 		// deselect the deleted backup

--- a/skyve-war/src/main/java/modules/admin/DataMaintenance/actions/DownloadBackup.java
+++ b/skyve-war/src/main/java/modules/admin/DataMaintenance/actions/DownloadBackup.java
@@ -12,10 +12,15 @@ import org.skyve.metadata.controller.Download;
 import org.skyve.metadata.controller.DownloadAction;
 import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.domain.DataMaintenance;
 
 public class DownloadBackup extends DownloadAction<DataMaintenance> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DownloadBackup.class);
+
 	@Override
 	public void prepare(DataMaintenance bean, WebContext webContext) throws Exception {
 		String selectedBackupName = bean.getSelectedBackupName();
@@ -31,7 +36,7 @@ public class DownloadBackup extends DownloadAction<DataMaintenance> {
 													selectedBackupName));
 			backupExists = backup.exists();
 			if (! backup.exists()) {
-				Util.LOGGER.warning("Backup " + backup.getAbsolutePath() + " DNE");
+				LOGGER.warn("Backup " + backup.getAbsolutePath() + " DNE");
 			}
 		}
 

--- a/skyve-war/src/main/java/modules/admin/DataMaintenance/actions/UploadBackup.java
+++ b/skyve-war/src/main/java/modules/admin/DataMaintenance/actions/UploadBackup.java
@@ -13,10 +13,14 @@ import org.skyve.metadata.controller.Upload;
 import org.skyve.metadata.controller.UploadAction;
 import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.domain.DataMaintenance;
 
 public class UploadBackup extends UploadAction<DataMaintenance> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UploadBackup.class);
 
 	@Override
 	public DataMaintenance upload(final DataMaintenance bean, final Upload upload,
@@ -48,13 +52,13 @@ public class UploadBackup extends UploadAction<DataMaintenance> {
 			Files.copy(in, Paths.get(backup.getAbsolutePath()));
 		}
 		if (backup.exists()) {
-			Util.LOGGER.info("Uploaded backup " + backup.getAbsolutePath());
+			LOGGER.info("Uploaded backup " + backup.getAbsolutePath());
 		}
 
 		if (ExternalBackup.areExternalBackupsEnabled()) {
 			ExternalBackup.getInstance().uploadBackup(backup.getAbsolutePath());
 			if (! backup.delete()) {
-				Util.LOGGER.warning("Backup " + backup.getAbsolutePath() + " was successfully uploaded externally but could not be deleted on disk.");
+				LOGGER.warn("Backup " + backup.getAbsolutePath() + " was successfully uploaded externally but could not be deleted on disk.");
 			}
 		}
 

--- a/skyve-war/src/main/java/modules/admin/DataMaintenance/models/ContentModel.java
+++ b/skyve-war/src/main/java/modules/admin/DataMaintenance/models/ContentModel.java
@@ -28,12 +28,16 @@ import org.skyve.metadata.view.model.list.Filter;
 import org.skyve.metadata.view.model.list.ListModel;
 import org.skyve.metadata.view.model.list.Page;
 import org.skyve.persistence.AutoClosingIterable;
-import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.domain.Content;
 import modules.admin.domain.DataMaintenance;
 
 public class ContentModel extends ListModel<DataMaintenance> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContentModel.class);
+
 	private Document drivingDocument = null;
 	private Set<String> projections = new TreeSet<>();
 	private List<MetaDataQueryColumn> columns = new ArrayList<>(1);
@@ -189,11 +193,8 @@ public class ContentModel extends ListModel<DataMaintenance> {
 			Page page = new Page();
 			page.setTotalRows(it.getTotalHits());
 			page.setRows(rows);
-			Util.LOGGER.info(String.format("Content Model start = %d : end = %d : size = %d : total rows = %d ",
-											Integer.valueOf(start),
-											Integer.valueOf(end),
-											Integer.valueOf(page.getRows().size()),
-											Long.valueOf(page.getTotalRows())));
+            LOGGER.info("Content Model start = {} : end = {} : size = {} : total rows = {} ", 
+                    start, end, page.getRows().size(), page.getTotalRows());
 
 			Map<String, Object> properties = new TreeMap<>();
 			properties.put(PersistentBean.FLAG_COMMENT_NAME, null);

--- a/skyve-war/src/main/java/modules/admin/ImportExport/actions/RunImport.java
+++ b/skyve-war/src/main/java/modules/admin/ImportExport/actions/RunImport.java
@@ -22,8 +22,9 @@ import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.persistence.Persistence;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.ImportExport.ImportExportBizlet;
 import modules.admin.ImportExportColumn.ImportExportColumnBizlet;
@@ -32,6 +33,8 @@ import modules.admin.domain.ImportExport.RollbackErrors;
 import modules.admin.domain.ImportExportColumn;
 
 public class RunImport implements ServerSideAction<ImportExport> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RunImport.class);
 
 	@Override
 	public ServerSideActionResult<ImportExport> execute(ImportExport bean, WebContext webContext)
@@ -137,11 +140,11 @@ public class RunImport implements ServerSideAction<ImportExport> {
 					}
 
 					if (loader.isDebugMode()) {
-						Util.LOGGER.info(sb.toString());
+						LOGGER.info(sb.toString());
 					}
 					loader.addField(f);
 					if (loader.isDebugMode()) {
-						Util.LOGGER.info("Field added at position " + f.getIndex().toString());
+						LOGGER.info("Field added at position " + f.getIndex().toString());
 					}
 				}
 
@@ -151,7 +154,7 @@ public class RunImport implements ServerSideAction<ImportExport> {
 
 					// stop at empty row
 					if (loader.isNoData()) {
-						Util.LOGGER.info("End of import found at " + loader.getWhere());
+						LOGGER.info("End of import found at " + loader.getWhere());
 						break;
 					}
 
@@ -159,9 +162,9 @@ public class RunImport implements ServerSideAction<ImportExport> {
 
 					if (loader.isDebugMode()) {
 						if (b == null) {
-							Util.LOGGER.info("Loaded failed at " + loader.getWhere());
+							LOGGER.info("Loaded failed at " + loader.getWhere());
 						} else {
-							Util.LOGGER.info(b.getBizKey() + " - Loaded successfully");
+							LOGGER.info(b.getBizKey() + " - Loaded successfully");
 						}
 					}
 					try {
@@ -173,7 +176,7 @@ public class RunImport implements ServerSideAction<ImportExport> {
 
 						b = persistence.save(b);
 						if (loader.isDebugMode()) {
-							Util.LOGGER.info(b.getBizKey() + " - Saved successfully");
+							LOGGER.info(b.getBizKey() + " - Saved successfully");
 						}
 						persistence.evictCached(b);
 

--- a/skyve-war/src/main/java/modules/admin/Job/actions/RerunJob.java
+++ b/skyve-war/src/main/java/modules/admin/Job/actions/RerunJob.java
@@ -10,12 +10,15 @@ import org.skyve.metadata.controller.ServerSideAction;
 import org.skyve.metadata.controller.ServerSideActionResult;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.module.JobMetaData;
-import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.domain.Job;
 
 public class RerunJob implements ServerSideAction<Job> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RerunJob.class);
 
 	@Override
 	public ServerSideActionResult<Job> execute(Job bean, WebContext webContext) {
@@ -67,8 +70,7 @@ public class RerunJob implements ServerSideAction<Job> {
 				}
 			}
 		} catch (Exception e) {
-			Util.LOGGER.warning("Error getting running jobs");
-			e.printStackTrace();
+			LOGGER.warn("Error getting running jobs", e);
 		}
 
 		return false;

--- a/skyve-war/src/main/java/modules/admin/JobSchedule/actions/RunJobNow.java
+++ b/skyve-war/src/main/java/modules/admin/JobSchedule/actions/RunJobNow.java
@@ -13,10 +13,15 @@ import org.skyve.metadata.user.User;
 import org.skyve.persistence.Persistence;
 import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.domain.JobSchedule;
 
 public class RunJobNow implements ServerSideAction<JobSchedule> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RunJobNow.class);
+
 	@Override
 	public ServerSideActionResult<JobSchedule> execute(JobSchedule bean, WebContext webContext) throws Exception {
 
@@ -31,7 +36,7 @@ public class RunJobNow implements ServerSideAction<JobSchedule> {
 		Customer customer = user.getCustomer();
 
 		// don't know which module this is in
-		Util.LOGGER.info("Job requested for immediate execution: " + bean.getJobName());
+		LOGGER.info("Job requested for immediate execution: " + bean.getJobName());
 
 		String[] parts = bean.getJobName().split("\\.");
 		if (parts.length < 2) {

--- a/skyve-war/src/main/java/modules/admin/LoggingInterceptor.java
+++ b/skyve-war/src/main/java/modules/admin/LoggingInterceptor.java
@@ -1,7 +1,6 @@
 package modules.admin;
 
 import java.util.List;
-import java.util.logging.Level;
 
 import org.skyve.bizport.BizPortWorkbook;
 import org.skyve.domain.Bean;
@@ -14,205 +13,189 @@ import org.skyve.metadata.controller.ServerSideActionResult;
 import org.skyve.metadata.controller.Upload;
 import org.skyve.metadata.model.document.Bizlet.DomainValue;
 import org.skyve.metadata.model.document.Document;
-import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LoggingInterceptor extends Interceptor {
-	private boolean veto = false;
-	
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingInterceptor.class);
+
+    private boolean veto = false;
+
 	@Override
 	public boolean beforeNewInstance(Bean bean) {
-		Util.LOGGER.log(Level.INFO, "beforeNewInstance - {0}", bean);
+		LOGGER.info("beforeNewInstance - {}", bean);
 		return veto;
 	}
 
 	@Override
 	public void afterNewInstance(Bean bean) {
-		Util.LOGGER.log(Level.INFO, "afterNewInstance - {0}", bean);
+		LOGGER.info("afterNewInstance - {}", bean);
 	}
 
 	@Override
 	public boolean beforeValidate(Bean bean, ValidationException e) {
-		Util.LOGGER.log(Level.INFO, "beforeValidate - {0}", bean);
+		LOGGER.info("beforeValidate - {}", bean);
 		return veto;
 	}
 
 	@Override
 	public void afterValidate(Bean bean, ValidationException e) {
-		Util.LOGGER.log(Level.INFO, "afterValidate - {0}", bean);
+		LOGGER.info("afterValidate - {}", bean);
 	}
 
 	@Override
 	public boolean beforeGetConstantDomainValues(String attributeName) {
-		Util.LOGGER.log(Level.INFO, "beforeGetConstantDomainValues - attribute = {0}", attributeName);
+		LOGGER.info("beforeGetConstantDomainValues - attribute = {}", attributeName);
 		return veto;
 	}
 
 	@Override
 	public void afterGetConstantDomainValues(String attributeName, List<DomainValue> result) {
-		Util.LOGGER.log(Level.INFO, "afterGetConstantDomainValues - attribute = {0}", attributeName);
+		LOGGER.info("afterGetConstantDomainValues - attribute = {}", attributeName);
 	}
 
 	@Override
 	public boolean beforeGetVariantDomainValues(String attributeName) {
-		Util.LOGGER.log(Level.INFO, "beforeGetVariantDomainValues - attribute = {0}", attributeName);
+		LOGGER.info("beforeGetVariantDomainValues - attribute = {}", attributeName);
 		return veto;
 	}
 
 	@Override
 	public void afterGetVariantDomainValues(String attributeName, List<DomainValue> result) {
-		Util.LOGGER.log(Level.INFO, "afterGetVariantDomainValues - attribute = {0}", attributeName);
+		LOGGER.info("afterGetVariantDomainValues - attribute = {}", attributeName);
 	}
 
 	@Override
 	public boolean beforeGetDynamicDomainValues(String attributeName, Bean bean) {
-		Util.LOGGER.log(Level.INFO, "beforeGetDynamicDomainValues - attribute = {0}", attributeName);
+		LOGGER.info("beforeGetDynamicDomainValues - attribute = {}", attributeName);
 		return veto;
 	}
 
 	@Override
 	public void afterGetDynamicDomainValues(String attributeName, Bean bean, List<DomainValue> result) {
-		Util.LOGGER.log(Level.INFO, "afterGetDynamicDomainValues - attribute = {0}", attributeName);
+		LOGGER.info("afterGetDynamicDomainValues - attribute = {}", attributeName);
 	}
 
 	@Override
 	public boolean beforeSave(Document document, PersistentBean bean) throws Exception {
-		Util.LOGGER.log(Level.INFO, "beforeSave - bean = {0}", bean);
+		LOGGER.info("beforeSave - bean = {}", bean);
 		return veto;
 	}
 
 	@Override
 	public void afterSave(Document document, final PersistentBean result) throws Exception {
-		Util.LOGGER.log(Level.INFO, "afterSave - result = {0}", result);
+		LOGGER.info("afterSave - result = {}", result);
 	}
 
 	@Override
 	public boolean beforePreSave(Bean bean) {
-		Util.LOGGER.log(Level.INFO, "beforePreSave - {0}", bean);
+		LOGGER.info("beforePreSave - {}", bean);
 		return veto;
 	}
 
 	@Override
 	public void afterPreSave(Bean bean) {
-		Util.LOGGER.log(Level.INFO, "afterPreSave - {0}", bean);
+		LOGGER.info("afterPreSave - {}", bean);
 	}
 
 	@Override
 	public boolean beforePostSave(Bean bean) {
-		Util.LOGGER.log(Level.INFO, "beforePostSave - {0}", bean);
+		LOGGER.info("beforePostSave - {}", bean);
 		return veto;
 	}
 
 	@Override
 	public void afterPostSave(Bean bean) {
-		Util.LOGGER.log(Level.INFO, "afterPostSave - {0}", bean);
+		LOGGER.info("afterPostSave - {}", bean);
 	}
 
 	@Override
 	public boolean beforeDelete(Document document, PersistentBean bean) {
-		Util.LOGGER.log(Level.INFO, "beforeDelete - {0}", bean);
+		LOGGER.info("beforeDelete - {}", bean);
 		return veto;
 	}
 
 	@Override
 	public void afterDelete(Document document, PersistentBean bean) {
-		Util.LOGGER.log(Level.INFO, "afterDelete - {0}", bean);
+		LOGGER.info("afterDelete - {}", bean);
 	}
 
 	@Override
 	public boolean beforePreDelete(PersistentBean bean) {
-		Util.LOGGER.log(Level.INFO, "beforePreDelete - {0}", bean);
+		LOGGER.info("beforePreDelete - {}", bean);
 		return veto;
 	}
 
 	@Override
 	public void afterPreDelete(PersistentBean bean) {
-		Util.LOGGER.log(Level.INFO, "afterPreDelete - {0}", bean);
+		LOGGER.info("afterPreDelete - {}", bean);
 	}
 
 	@Override
 	public boolean beforePostLoad(PersistentBean bean) {
-		Util.LOGGER.log(Level.INFO, "beforePostLoad - {0}", bean);
+		LOGGER.info("beforePostLoad - {}", bean);
 		return veto;
 	}
 
 	@Override
 	public void afterPostLoad(PersistentBean bean) {
-		Util.LOGGER.log(Level.INFO, "afterPostLoad - {0}", bean);
+		LOGGER.info("afterPostLoad - {}", bean);
 	}
 
 	@Override
 	public boolean beforePreExecute(ImplicitActionName actionName, Bean bean, Bean parentBean, WebContext webContext) {
-		Util.LOGGER.log(Level.INFO, 
-							"beforePreExecute - action = {0}, bean = {1}, parent = {2}",
-							new Object[] {actionName, bean, parentBean});
+		LOGGER.info("beforePreExecute - action = {}, bean = {}, parent = {}", actionName, bean, parentBean);
 		return veto;
 	}
 
 	@Override
 	public void afterPreExecute(ImplicitActionName actionName, Bean result, Bean parentBean, WebContext webContext) {
-		Util.LOGGER.log(Level.INFO, 
-							"afterPreExecute - action = {0}, bean = {1}, parent = {2}",
-							new Object[] {actionName, result, parentBean});
+		LOGGER.info("afterPreExecute - action = {}, bean = {}, parent = {}", actionName, result, parentBean);
 	}
 
 	@Override
 	public boolean beforeServerSideAction(Document document, String actionName, Bean bean, WebContext webContext) {
-		Util.LOGGER.log(Level.INFO, 
-							"beforeServerSideAction - doc = {0}.{1}, action = {2}, bean = {3}",
-							new Object[] {document.getOwningModuleName(), document.getName(), actionName, bean});
+		LOGGER.info("beforeServerSideAction - doc = {}.{}, action = {}, bean = {}", document.getOwningModuleName(), document.getName(), actionName, bean);
 		return veto;
 	}
 
 	@Override
 	public void afterServerSideAction(Document document, String actionName, ServerSideActionResult<Bean> result, WebContext webContext) {
-		Util.LOGGER.log(Level.INFO, 
-							"afterServerSideAction - doc = {0}.{1}, action = {2}, result = {3}",
-							new Object[] {document.getOwningModuleName(), document.getName(), actionName, result});
+		LOGGER.info("afterServerSideAction - doc = {}.{}, action = {}, result = {}", document.getOwningModuleName(), document.getName(), actionName, result);
 	}
 
 	@Override
 	public boolean beforeUploadAction(Document document, String actionName, Bean bean, Upload upload, WebContext webContext) {
-		Util.LOGGER.log(Level.INFO, 
-							"beforeUploadAction - doc = {0}.{1}, action = {2}, bean = {3}, file = {4}",
-							new Object[] {document.getOwningModuleName(), document.getName(), actionName, bean, upload});
+		LOGGER.info("beforeUploadAction - doc = {}.{}, action = {}, bean = {}, file = {}", document.getOwningModuleName(), document.getName(), actionName, bean, upload);
 		return veto;
 	}
 
 	@Override
 	public void afterUploadAction(Document document, String actionName, Bean bean, Upload upload, WebContext webContext) {
-		Util.LOGGER.log(Level.INFO, 
-							"afterUploadAction - doc = {0}.{1}, action = {2}, bean = {3}, file = {4}",
-							new Object[] {document.getOwningModuleName(), document.getName(), actionName, bean, upload});
+		LOGGER.info("afterUploadAction - doc = {}.{}, action = {}, bean = {}, file = {}", document.getOwningModuleName(), document.getName(), actionName, bean, upload);
 	}
 
 	@Override
 	public boolean beforeBizImportAction(Document document, String actionName, BizPortWorkbook bizPortable, UploadException problems) {
-		Util.LOGGER.log(Level.INFO, 
-							"beforeBizImportAction - doc = {0}.{1}, action = {2}, bean = {3}, workbook = {4}",
-							new Object[] {document.getOwningModuleName(), document.getName(), actionName, bizPortable});
+		LOGGER.info("beforeBizImportAction - doc = {}.{}, action = {}, bean = {}, workbook = {}", document.getOwningModuleName(), document.getName(), actionName, bizPortable);
 		return veto;
 	}
 
 	@Override
 	public void afterBizImportAction(Document document, String actionName, BizPortWorkbook bizPortable, UploadException problems) {
-		Util.LOGGER.log(Level.INFO, 
-							"afterBizImportAction - doc = {0}.{1}, action = {2}, bean = {3}, workbook = {4}",
-							new Object[] {document.getOwningModuleName(), document.getName(), actionName, bizPortable});
+		LOGGER.info("afterBizImportAction - doc = {}.{}, action = {}, bean = {}, workbook = {}", document.getOwningModuleName(), document.getName(), actionName, bizPortable);
 	}
 
 	@Override
 	public boolean beforeBizExportAction(Document document, String actionName, WebContext webContext) {
-		Util.LOGGER.log(Level.INFO, 
-							"beforeBizExportAction - doc = {0}.{1}, action = {2}",
-							new Object[] {document.getOwningModuleName(), document.getName(), actionName});
+		LOGGER.info("beforeBizExportAction - doc = {}.{}, action = {}", document.getOwningModuleName(), document.getName(), actionName);
 		return veto;
 	}
 
 	@Override
 	public void afterBizExportAction(Document document, String actionName, BizPortWorkbook result, WebContext webContext) {
-		Util.LOGGER.log(Level.INFO, 
-							"beforeBizExportAction - doc = {0}.{1}, action = {2}, result = {3}",
-							new Object[] {document.getOwningModuleName(), document.getName(), actionName, result});
+		LOGGER.info("beforeBizExportAction - doc = {}.{}, action = {}, result = {}", document.getOwningModuleName(), document.getName(), actionName, result);
 	}
 }

--- a/skyve-war/src/main/java/modules/admin/ReportDataset/ReportDatasetExtension.java
+++ b/skyve-war/src/main/java/modules/admin/ReportDataset/ReportDatasetExtension.java
@@ -21,8 +21,6 @@ import org.skyve.persistence.BizQL;
 import org.skyve.persistence.SQL;
 import org.skyve.util.Binder;
 import org.skyve.util.Time;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import jakarta.enterprise.inject.spi.CDI;
 import modules.admin.ReportParameter.ReportParameterExtension;
@@ -32,7 +30,6 @@ import modules.admin.domain.ReportParameter;
 public class ReportDatasetExtension extends ReportDataset {
 
 	private static final long serialVersionUID = -688307133122437337L;
-	private static final Logger LOGGER = LoggerFactory.getLogger(ReportDatasetExtension.class);
 
 	/**
 	 * Regular expression to locate date sentinel values within a query

--- a/skyve-war/src/main/java/modules/admin/ReportDesign/ReportDesignBizlet.java
+++ b/skyve-war/src/main/java/modules/admin/ReportDesign/ReportDesignBizlet.java
@@ -26,6 +26,8 @@ import org.skyve.metadata.module.query.QueryDefinition;
 import org.skyve.persistence.Persistence;
 import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.domain.ReportDesign;
 import modules.admin.domain.ReportDesign.CollectionType;
@@ -35,6 +37,9 @@ import modules.admin.domain.ReportDesign.Orientation;
 import modules.admin.domain.ReportDesign.ReportType;
 
 public class ReportDesignBizlet extends Bizlet<ReportDesign> {
+
+    private static final Logger STATIC_LOGGER = LoggerFactory.getLogger(ReportDesignBizlet.class);
+
 	@Override
 	public ReportDesign newInstance(ReportDesign bean) throws Exception {
 		ReportDesign rd = super.newInstance(beanDesignFromSpecification(bean, new DesignSpecification()));
@@ -64,7 +69,7 @@ public class ReportDesignBizlet extends Bizlet<ReportDesign> {
 		}
 		if (spec.getReportType() != null) {
 			result.setReportType(ReportType.valueOf(spec.getReportType().name()));
-			Util.LOGGER.info("RESULT REPORT TYPE IS " + result.getReportType().toLocalisedDescription());
+			STATIC_LOGGER.info("RESULT REPORT TYPE IS " + result.getReportType().toLocalisedDescription());
 		}
 		result.setModuleName(spec.getModuleName());
 		result.setDocumentName(spec.getDocumentName());
@@ -149,7 +154,7 @@ public class ReportDesignBizlet extends Bizlet<ReportDesign> {
 		}
 		if (spec.getReportType() != null) {
 			result.setReportType(org.skyve.impl.generate.jasperreports.DesignSpecification.ReportType.valueOf(spec.getReportType().name()));
-			Util.LOGGER.info("SPEC REPORT TYPE IS " + result.getReportType().toString());
+			STATIC_LOGGER.info("SPEC REPORT TYPE IS " + result.getReportType().toString());
 		}
 		result.setModuleName(spec.getModuleName());
 		result.setDocumentName(spec.getDocumentName());

--- a/skyve-war/src/main/java/modules/admin/ReportManager/ReportManagerExtension.java
+++ b/skyve-war/src/main/java/modules/admin/ReportManager/ReportManagerExtension.java
@@ -16,11 +16,15 @@ import org.skyve.domain.types.DateTime;
 import org.skyve.util.FileUtil;
 import org.skyve.util.JSON;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import modules.admin.domain.ReportManager;
 import modules.admin.domain.ReportTemplate;
 
 public class ReportManagerExtension extends ReportManager {
+
+    private static final Logger SLOGGER = LoggerFactory.getLogger(ReportManagerExtension.class);
 
 	/**
 	 * 
@@ -92,8 +96,7 @@ public class ReportManagerExtension extends ReportManager {
 		try {
 			FileUtil.delete(new File(getBasePath()));
 		} catch (IOException e) {
-			Util.LOGGER.info("FAILED to clean up temporary files at " + getBasePath());
-			e.printStackTrace();
+			SLOGGER.info("FAILED to clean up temporary files at {}", getBasePath(), e);
 		}
 	}
 

--- a/skyve-war/src/main/java/modules/admin/SelfRegistrationActivation/SelfRegistrationActivationExtension.java
+++ b/skyve-war/src/main/java/modules/admin/SelfRegistrationActivation/SelfRegistrationActivationExtension.java
@@ -23,12 +23,12 @@ public class SelfRegistrationActivationExtension extends SelfRegistrationActivat
 
 			UserExtension result = userQuery.beanResult();
 			if (result == null) {
-				Util.LOGGER.warning("No user exists for activation code=" + activationCode);
+				LOGGER.warn("No user exists for activation code=" + activationCode);
 				setResult(Result.FAILURE);
 			}
 			else if (Boolean.TRUE.equals(result.getActivated())) {
 				// User already activated, prompt them to login
-				Util.LOGGER.warning("User=" + result.getUserName() + " already activated");
+				LOGGER.warn("User=" + result.getUserName() + " already activated");
 				setUser(result);
 				setResult(Result.ALREADYACTIVATED);
 			}

--- a/skyve-war/src/main/java/modules/admin/Startup/StartupExtension.java
+++ b/skyve-war/src/main/java/modules/admin/Startup/StartupExtension.java
@@ -23,7 +23,6 @@ import org.skyve.impl.geoip.GeoIPServiceStaticSingleton;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.util.JSON;
-import org.skyve.util.Util;
 
 import jakarta.inject.Inject;
 import modules.admin.Country.CountryExtension;
@@ -585,7 +584,7 @@ public class StartupExtension extends Startup {
 			}
 		}
 
-		Util.LOGGER.info("No startup properties were modified, nothing to marshall.");
+		LOGGER.info("No startup properties were modified, nothing to marshall.");
 		return null;
 	}
 
@@ -625,7 +624,7 @@ public class StartupExtension extends Startup {
 		String json = this.marshall(properties);
 		if (StringUtils.isNotBlank(json)) {
 			this.writeConfiguration(json);
-			Util.LOGGER.info("Wrote updated properties to override json");
+			LOGGER.info("Wrote updated properties to override json");
 		}
 	}
 }

--- a/skyve-war/src/main/java/modules/admin/User/UserBizlet.java
+++ b/skyve-war/src/main/java/modules/admin/User/UserBizlet.java
@@ -281,8 +281,7 @@ public class UserBizlet extends Bizlet<UserExtension> {
 				final JobMetaData passwordChangeNotificationJobMetadata = module.getJob("jPasswordChangeNotification");
 				EXT.getJobScheduler().runOneShotJob(passwordChangeNotificationJobMetadata, bean, user);
 			} catch (Exception e) {
-				Util.LOGGER.warning("Failed to kick off password change notification job");
-				e.printStackTrace();
+				LOGGER.warn("Failed to kick off password change notification job", e);
 			}
 
 			// Record security event in security log

--- a/skyve-war/src/main/java/modules/admin/User/UserExtension.java
+++ b/skyve-war/src/main/java/modules/admin/User/UserExtension.java
@@ -156,7 +156,7 @@ public class UserExtension extends User {
 	 * @throws Exception
 	 */
 	public void sendUserRegistrationEmail() throws Exception {
-		Util.LOGGER.info("Sending registration email to " + this.getContact().getEmail1());
+		LOGGER.info("Sending registration email to " + this.getContact().getEmail1());
 		CommunicationUtil.sendFailSafeSystemCommunication(SELF_REGISTRATION_COMMUNICATION,
 															"{contact.email1}",
 															null,

--- a/skyve-war/src/main/java/modules/admin/UserDashboard/UserDashboardExtension.java
+++ b/skyve-war/src/main/java/modules/admin/UserDashboard/UserDashboardExtension.java
@@ -213,7 +213,7 @@ public class UserDashboardExtension extends UserDashboard {
 			}
 		} catch (@SuppressWarnings("unused") Exception e) {
 			// TODO: handle exception
-			Util.LOGGER.warning("Failed to create " + reason + " tile.");
+			LOGGER.warn("Failed to create " + reason + " tile.", e);
 		}
 	}
 

--- a/skyve-war/src/main/java/modules/admin/UserLoginRecord/UserLoginRecordBizlet.java
+++ b/skyve-war/src/main/java/modules/admin/UserLoginRecord/UserLoginRecordBizlet.java
@@ -5,7 +5,6 @@ import java.util.Objects;
 import org.skyve.CORE;
 import org.skyve.EXT;
 import org.skyve.domain.app.AppConstants;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.SortDirection;
 import org.skyve.metadata.model.document.Bizlet;
 import org.skyve.metadata.module.JobMetaData;
@@ -49,9 +48,9 @@ public class UserLoginRecordBizlet extends Bizlet<UserLoginRecordExtension> {
 			if (ipAddress != null) {
 				countryCode = geoIPService.geolocate(ipAddress).countryCode();
 				if(countryCode == null) {
-					UtilImpl.LOGGER.info(userName + " has logged in from IP Address " + ipAddress);
+					LOGGER.info(userName + " has logged in from IP Address " + ipAddress);
 				}else {
-					UtilImpl.LOGGER.info(userName + " has logged in from IP Address " + ipAddress + " in country: " + countryCode);
+					LOGGER.info(userName + " has logged in from IP Address " + ipAddress + " in country: " + countryCode);
 				}
 				bean.setCountryCode(countryCode);
 			}

--- a/skyve-war/src/main/java/modules/admin/UserLoginRecord/jobs/DifferentCountryLoginNotificationJob.java
+++ b/skyve-war/src/main/java/modules/admin/UserLoginRecord/jobs/DifferentCountryLoginNotificationJob.java
@@ -2,10 +2,8 @@ package modules.admin.UserLoginRecord.jobs;
 
 import java.util.List;
 
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.job.Job;
 import org.skyve.util.CommunicationUtil;
-import org.skyve.util.Util;
 
 import modules.admin.ModulesUtil;
 import modules.admin.domain.Contact;
@@ -61,7 +59,7 @@ public class DifferentCountryLoginNotificationJob extends Job {
 				if (startup.getEnvironmentSupportEmail() == null) {
 					String warningMessage = "There is no environment support email specified. Failed to send different country login notification.";
 					log.add(warningMessage);
-					Util.LOGGER.warning(warningMessage);
+					LOGGER.warn(warningMessage);
 					return;
 				}
 
@@ -71,12 +69,12 @@ public class DifferentCountryLoginNotificationJob extends Job {
 
 				String successMessage = String.format("Successfully sent email warning of unusual login activity to %s", userEmail);
 				log.add(successMessage);
-				UtilImpl.LOGGER.info(successMessage);
+				LOGGER.info(successMessage);
 			} catch (Exception e) {
 				String errorMessage = String.format(
 						"Failed to send security alert email to %s at %s regarding a login from a different country. Exception: %s", userName, userEmail, e.getMessage());
 				log.add(errorMessage);
-				UtilImpl.LOGGER.warning(errorMessage);
+				LOGGER.warn(errorMessage);
 				e.printStackTrace();
 			}
 		}

--- a/skyve-war/src/main/java/router/DefaultUxUiSelector.java
+++ b/skyve-war/src/main/java/router/DefaultUxUiSelector.java
@@ -5,18 +5,22 @@ import java.util.TreeMap;
 
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.AbstractWebContext;
-import org.skyve.web.UserAgentType;
 import org.skyve.metadata.router.UxUi;
 import org.skyve.metadata.router.UxUiSelector;
 import org.skyve.metadata.user.User;
-import org.skyve.util.Util;
+import org.skyve.web.UserAgentType;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import modules.admin.domain.Startup;
 
 public class DefaultUxUiSelector implements UxUiSelector {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultUxUiSelector.class);
+
 	public static final String DISMISS_STARTUP = "DISMISS_STARTUP";
 
 	private static final Map<String, UxUi> uxuis = new TreeMap<>();
@@ -43,7 +47,7 @@ public class DefaultUxUiSelector implements UxUiSelector {
 			// check the user has not already dismissed the startup page this session
 			Object dismissed = session != null ? session.getAttribute(DISMISS_STARTUP) : null;
 			if (! Boolean.TRUE.equals(dismissed)) {
-				Util.LOGGER.info("ROUTING TO STARTUP");
+				LOGGER.info("ROUTING TO STARTUP");
 				return UxUis.STARTUP;
 			}
 		}

--- a/skyve-war/src/main/webapp/device.jsp
+++ b/skyve-war/src/main/webapp/device.jsp
@@ -2,6 +2,10 @@
 <%@ page import="org.skyve.impl.web.AbstractWebContext"%>
 <%@ page import="org.skyve.util.Util"%>
 <%@ page import="org.skyve.web.UserAgentType"%>
+<%@ page import="org.slf4j.LoggerFactory"%>
+<%@ page import="org.slf4j.Logger"%>
+
+<%! static final Logger logger = LoggerFactory.getLogger("org.skyve.jsp.device"); %>
 
 <%
 	UserAgentType type = UserAgentType.valueOf(request.getParameter("ua"));
@@ -13,6 +17,7 @@
 	if (queryString != null) {
 		outcomeUrl += '?' + queryString;
 	}
-	Util.LOGGER.info("Server-side forward to " + outcomeUrl);
+
+	logger.info("Server-side forward to " + outcomeUrl);
 	request.getRequestDispatcher(outcomeUrl).forward(request, response);
 %>

--- a/skyve-war/src/main/webapp/home.jsp
+++ b/skyve-war/src/main/webapp/home.jsp
@@ -20,6 +20,12 @@
 <%@ page import="org.skyve.web.UserAgentType"%>
 <%@ page import="org.skyve.impl.web.WebUtil"%>
 <%@ page import="org.skyve.impl.util.UtilImpl"%>
+<%@ page import="org.slf4j.LoggerFactory"%>
+<%@ page import="org.slf4j.Logger"%>
+<%@ page import="org.skyve.util.logging.Category"%>
+
+<%! static final Logger logger = LoggerFactory.getLogger("org.skyve.jsp.home"); %>
+<%! static final Logger COMMAND_LOGGER = Category.COMMAND.logger(); %>
 
 <%
 	// Stop cookie/request header injection by checking the valid customer name
@@ -94,7 +100,7 @@
 		// Now determine if the outcome URL is unsecured or not.
 		String outcomeUrl = router.selectOutcomeUrl(uxuiName, criteria);
 		if (outcomeUrl == null) {
-			UtilImpl.LOGGER.severe("The route criteria " + criteria + " for uxui " + uxuiName + " did not produce an outcome URL");
+		    logger.error("The route criteria " + criteria + " for uxui " + uxuiName + " did not produce an outcome URL");
 			throw new ServletException("The route criteria " + criteria + " for uxui " + uxuiName + " did not produce an outcome URL");
 		}
 		if (router.isUnsecured(outcomeUrl)) {
@@ -190,7 +196,7 @@
 		// Determine the route
 		String outcomeUrl = router.selectOutcomeUrl(uxuiName, criteria);
 		if (UtilImpl.COMMAND_TRACE) {
-			UtilImpl.LOGGER.info(String.format("home.jsp - Route uxui=%s,c=%s,dg=%s,d=%s,m=%s,q=%s,a=%s to %s",
+		    COMMAND_LOGGER.info(String.format("home.jsp - Route uxui=%s,c=%s,dg=%s,d=%s,m=%s,q=%s,a=%s to %s",
 													uxuiName,
 													criteria.getCustomerName(),
 													criteria.getDataGroupId(),
@@ -201,7 +207,7 @@
 													outcomeUrl));
 		}
 		if (outcomeUrl == null) {
-			UtilImpl.LOGGER.severe("The route criteria " + criteria + " for uxui " + uxuiName + " did not produce an outcome URL");
+			logger.error("The route criteria " + criteria + " for uxui " + uxuiName + " did not produce an outcome URL");
 			throw new ServletException("The route criteria " + criteria + " for uxui " + uxuiName + " did not produce an outcome URL");
 		}
 			

--- a/skyve-war/src/main/webapp/loggedIn.jsp
+++ b/skyve-war/src/main/webapp/loggedIn.jsp
@@ -1,5 +1,9 @@
 <%@ page session="false" language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ page import="org.skyve.util.Util"%>
+<%@ page import="org.slf4j.LoggerFactory"%>
+<%@ page import="org.slf4j.Logger"%>
+
+<%! static final Logger logger = LoggerFactory.getLogger("org.skyve.jsp.loggedIn"); %>
 
 <%
 	String queryString = request.getQueryString();
@@ -7,6 +11,6 @@
 	if (queryString != null) {
 		outcomeUrl += '?' + queryString;
 	}
-	Util.LOGGER.info("Server-side forward to " + outcomeUrl);
+	logger.info("Server-side forward to " + outcomeUrl);
 	request.getRequestDispatcher(outcomeUrl).forward(request, response);
 %>

--- a/skyve-war/src/main/webapp/pages/requestPasswordReset.jsp
+++ b/skyve-war/src/main/webapp/pages/requestPasswordReset.jsp
@@ -12,7 +12,13 @@
 <%@page import="org.skyve.impl.web.WebUtil"%>
 <%@page import="org.skyve.metadata.user.User"%>
 <%@page import="org.skyve.util.Util"%>
+<%@page import="org.slf4j.LoggerFactory"%>
+<%@page import="org.slf4j.Logger"%>
+
+<%! static final Logger logger = LoggerFactory.getLogger("org.skyve.jsp.requestPasswordReset"); %>
+
 <%
+
 	String basePath = Util.getSkyveContextUrl() + "/";
 	String customer = WebUtil.determineCustomerWithoutSession(request);
 	boolean mobile = UserAgent.getType(request).isMobile();
@@ -41,13 +47,11 @@
 			}
 			catch (Exception e) {
 				// don't stop - we need to give nothing away
-				UtilImpl.LOGGER.log(Level.SEVERE, 
-										String.format("Password Reset Request Failed for customer=%s and email=%s", customerValue, emailValue),
-										e);
+				logger.error("Password Reset Request Failed for customer={} and email={}", customerValue, emailValue, e);
 			}
 		}
 		else {
-			UtilImpl.LOGGER.severe("Recaptcha failed validation");
+		    logger.error("Recaptcha failed validation");
 		}
 	}
 %>

--- a/skyve-war/src/main/webapp/pages/resendRegistrationEmail.jsp
+++ b/skyve-war/src/main/webapp/pages/resendRegistrationEmail.jsp
@@ -12,6 +12,11 @@
 <%@page import="org.skyve.impl.web.WebUtil"%>
 <%@page import="org.skyve.metadata.user.User"%>
 <%@page import="org.skyve.util.Util"%>
+<%@page import="org.slf4j.LoggerFactory"%>
+<%@page import="org.slf4j.Logger"%>
+
+<%! static final Logger logger = LoggerFactory.getLogger("org.skyve.jsp.resendRegistrationEmail"); %>
+
 <%
 	String basePath = Util.getSkyveContextUrl() + "/";
 	String customer = WebUtil.determineCustomerWithoutSession(request);
@@ -31,9 +36,7 @@
 		}
 		catch (Exception e) {
 			// don't stop - we need to give nothing away
-			UtilImpl.LOGGER.log(Level.SEVERE, 
-									String.format("Send Registration Email failed for customer=%s and userId=%s", customerValue, userIdValue),
-									e);
+			logger.error("Send Registration Email failed for customer={} and userId={}", customerValue, userIdValue, e);
 		}
 	}
 %>

--- a/skyve-war/src/main/webapp/pages/resetPassword.jsp
+++ b/skyve-war/src/main/webapp/pages/resetPassword.jsp
@@ -14,6 +14,10 @@
 <%@ page import="org.skyve.util.OWASP"%>
 <%@ page import="org.skyve.util.Util"%>
 <%@ page import="org.skyve.web.WebContext"%>
+<%@page import="org.slf4j.LoggerFactory"%>
+<%@page import="org.slf4j.Logger"%>
+
+<%! static final Logger logger = LoggerFactory.getLogger("org.skyve.jsp.resendRegistrationEmail"); %>
 
 <%
 	final String newPasswordFieldName = "newPassword";
@@ -93,7 +97,7 @@
 			}
 		}
 		else {
-			UtilImpl.LOGGER.severe("Recaptcha failed validation");
+		    logger.error("Recaptcha failed validation");
 		}
 	}
 %>

--- a/skyve-war/src/test/java/util/AbstractDomainTest.java
+++ b/skyve-war/src/test/java/util/AbstractDomainTest.java
@@ -27,10 +27,13 @@ import org.skyve.metadata.model.document.Bizlet;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
 import org.skyve.util.test.TestUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractDomainTest<T extends PersistentBean> extends AbstractH2Test {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDomainTest.class);
 
 	protected abstract T getBean() throws Exception;
 
@@ -239,7 +242,7 @@ public abstract class AbstractDomainTest<T extends PersistentBean> extends Abstr
 			
 			if (Objects.equals(Binder.get(result, attributeToUpdate.getName()), originalValue)) {
 				// skip this test if we couldn't generate a new value to save
-				Util.LOGGER.warning(String.format("Skipping testUpdate() for attribute %s, original and updated values were the same", attributeToUpdate.getName()));
+				LOGGER.warn("Skipping testUpdate() for attribute {}, original and updated values were the same", attributeToUpdate.getName());
 				return;
 			}
 			
@@ -249,7 +252,7 @@ public abstract class AbstractDomainTest<T extends PersistentBean> extends Abstr
 			assertThat("Error updating " + attributeToUpdate.getName(), Binder.get(uResult, attributeToUpdate.getName()),
 						is(not(originalValue)));
 		} else {
-			Util.LOGGER.fine(String.format("Skipping update test for %s, no scalar attribute found", bean.getBizDocument()));
+			LOGGER.debug("Skipping update test for {}, no scalar attribute found", bean.getBizDocument());
 		}
 	}
 

--- a/skyve-web/pom.xml
+++ b/skyve-web/pom.xml
@@ -88,6 +88,11 @@
 			<artifactId>all-themes</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>compile</scope>
+		</dependency>
 
 		<!-- test dependencies -->
 		<dependency>

--- a/skyve-web/src/main/java/org/skyve/impl/sail/execution/TestDataEnterViewVisitor.java
+++ b/skyve-web/src/main/java/org/skyve/impl/sail/execution/TestDataEnterViewVisitor.java
@@ -35,7 +35,6 @@ import org.skyve.metadata.sail.language.step.Comment;
 import org.skyve.metadata.sail.language.step.interaction.DataEnter;
 import org.skyve.metadata.sail.language.step.interaction.TabSelect;
 import org.skyve.metadata.view.widget.bound.Bound;
-import org.skyve.util.Util;
 
 import jakarta.faces.model.SelectItem;
 
@@ -199,7 +198,7 @@ public class TestDataEnterViewVisitor extends NoOpViewVisitor {
 														binding,
 														bean.getBizModule(),
 														bean.getBizDocument());
-						Util.LOGGER.warning(message);
+						LOGGER.warn(message);
 						Comment comment = new Comment();
 						comment.setComment(message);
 						scalarSteps.add(comment);
@@ -214,7 +213,7 @@ public class TestDataEnterViewVisitor extends NoOpViewVisitor {
 														binding,
 														bean.getBizModule(),
 														bean.getBizDocument());
-						Util.LOGGER.warning(message);
+						LOGGER.warn(message);
 						Comment comment = new Comment();
 						comment.setComment(message);
 						scalarSteps.add(comment);

--- a/skyve-web/src/main/java/org/skyve/impl/web/CustomerResourceServlet.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/CustomerResourceServlet.java
@@ -27,6 +27,8 @@ import org.skyve.util.Binder.TargetMetaData;
 import org.skyve.util.Thumbnail;
 import org.skyve.util.Util;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -37,6 +39,8 @@ import jakarta.servlet.http.HttpSession;
 		
 public class CustomerResourceServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CustomerResourceServlet.class);
 
 	protected final class Resource {
 		private ContentManager cm;
@@ -164,7 +168,7 @@ public class CustomerResourceServlet extends HttpServlet {
 			if (documentName != null) {
 				int dotIndex = documentName.indexOf('.');
 				if (dotIndex < 0) {
-					Util.LOGGER.severe("Module/Document is malformed in the URL");
+					LOGGER.error("Module/Document is malformed in the URL");
 				}
 				else {
 					moduleName = documentName.substring(0, dotIndex);
@@ -187,11 +191,11 @@ public class CustomerResourceServlet extends HttpServlet {
 			catch (@SuppressWarnings("unused") NumberFormatException e) {
 				imageWidth = 0;
 				imageHeight = 0;
-				Util.LOGGER.severe("Width/Height is malformed in the URL");
+				LOGGER.error("Width/Height is malformed in the URL");
 			}
 			
 			if (resourceFileName == null) {
-				Util.LOGGER.severe("No resource file name or data file name in the URL");
+				LOGGER.error("No resource file name or data file name in the URL");
 			}
 			else {
 				HttpSession session = request.getSession(false);
@@ -225,7 +229,7 @@ public class CustomerResourceServlet extends HttpServlet {
 
 				if (DownloadAreaType.content.toString().equals(resourceArea)) {
 					if ((moduleName == null) || (documentName == null)) {
-						Util.LOGGER.severe("No _doc parameter in the URL");
+						LOGGER.error("No _doc parameter in the URL");
 					}
 					if ((user != null) && 
 							(customer != null) && 
@@ -239,7 +243,7 @@ public class CustomerResourceServlet extends HttpServlet {
 						}
 					}
 					else {
-						Util.LOGGER.severe("No skyve user or customer or the contentId is not valid");
+						LOGGER.error("No skyve user or customer or the contentId is not valid");
 					}
 				} 
 				else if (DownloadAreaType.resources.toString().equals(resourceArea)) {
@@ -289,8 +293,7 @@ public class CustomerResourceServlet extends HttpServlet {
 					resource.dispose();
 				}
 				catch (Exception e) {
-					UtilImpl.LOGGER.severe("Could not dispose of the thread-local content resource properly.  It has been removed from the thread local storage.");
-					e.printStackTrace();
+					LOGGER.error("Could not dispose of the thread-local content resource properly. It has been removed from the thread local storage.", e);
 				}
 				finally {
 					RESOURCES.remove();
@@ -311,8 +314,7 @@ public class CustomerResourceServlet extends HttpServlet {
 			return resource.getLastModified();
 		} 
 		catch (Exception e) {
-			Util.LOGGER.severe("Problem getting the customer resource - " + e.toString());
-			e.printStackTrace();
+			LOGGER.error("Problem getting the customer resource - {}", e.toString(), e);
 			return -1;
 		}
 	}
@@ -348,7 +350,7 @@ public class CustomerResourceServlet extends HttpServlet {
 			byte[] bytes = resource.getBytes();
 			if (bytes == null) {
 				response.sendError(HttpServletResponse.SC_NOT_FOUND);
-				Util.LOGGER.severe(String.format("Problem getting the customer resource - %s was not found.", resource.getFileName()));
+				LOGGER.error("Problem getting the customer resource - {} was not found.", resource.getFileName());
 				return;
 			}
 	
@@ -370,13 +372,11 @@ public class CustomerResourceServlet extends HttpServlet {
 		} 
 		catch (SecurityException e) {
 			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-			Util.LOGGER.severe("Problem getting the customer resource - " + e.toString());
-			e.printStackTrace();
+			LOGGER.error("Problem getting the customer resource - ", e.toString(), e);
 		}
 		catch (Exception e) {
 			response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-			Util.LOGGER.severe("Problem getting the customer resource - " + e.toString());
-			e.printStackTrace();
+			LOGGER.error("Problem getting the customer resource - {}", e.toString(), e);
 		}
 	}
 	

--- a/skyve-web/src/main/java/org/skyve/impl/web/ReportServlet.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/ReportServlet.java
@@ -50,6 +50,8 @@ import org.skyve.report.ReportFormat;
 import org.skyve.util.JSON;
 import org.skyve.util.OWASP;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
@@ -65,6 +67,9 @@ import net.sf.jasperreports.engine.design.JRValidationException;
 import net.sf.jasperreports.j2ee.servlets.BaseHttpServlet;
 
 public class ReportServlet extends HttpServlet {
+
+    private static final Logger HTTP_LOGGER = Category.HTTP.logger();
+
 	private static final long serialVersionUID = 1L;
 
 	public static final String REPORT_PATH = "/report";
@@ -213,7 +218,7 @@ public class ReportServlet extends HttpServlet {
 					AbstractWebContext.DOCUMENT_NAME.equals(paramName) ||
 					AbstractWebContext.REPORT_NAME.equals(paramName))) {
 				params.put(paramName, OWASP.sanitise(Sanitisation.text, Util.processStringValue(paramValue)));
-				if (UtilImpl.HTTP_TRACE) UtilImpl.LOGGER.info("ReportServlet: Report Parameter " + paramName + " = " + paramValue);
+				if (UtilImpl.HTTP_TRACE) HTTP_LOGGER.info("ReportServlet: Report Parameter {} = {}", paramName, paramValue);
 			}
 		}
 
@@ -320,7 +325,7 @@ public class ReportServlet extends HttpServlet {
 				Customer customer = user.getCustomer();
 
 				String valuesParam = request.getParameter("values");
-				if (UtilImpl.HTTP_TRACE) UtilImpl.LOGGER.info(valuesParam);
+				if (UtilImpl.HTTP_TRACE) HTTP_LOGGER.info(valuesParam);
 				if (valuesParam == null) {
 					response.setContentType(MimeType.html.toString());
 					response.setCharacterEncoding(Util.UTF8);

--- a/skyve-web/src/main/java/org/skyve/impl/web/SkyveContextListener.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/SkyveContextListener.java
@@ -62,6 +62,8 @@ import org.skyve.persistence.DataStore;
 import org.skyve.persistence.DynamicPersistence;
 import org.skyve.util.GeoIPService;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.faces.FacesException;
 import jakarta.servlet.FilterRegistration;
@@ -75,6 +77,8 @@ import jakarta.websocket.server.ServerEndpointConfig;
 public class SkyveContextListener implements ServletContextListener {
 	private static final String DEV_LOGIN_FILTER_CLASS_NAME = DevLoginFilter.class.getName();
 	private static final String RESPONSE_HEADER_FILTER_CLASS_NAME = ResponseHeaderFilter.class.getName();
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkyveContextListener.class);
 
 	@Override
 	public void contextInitialized(ServletContextEvent evt) {
@@ -188,7 +192,7 @@ public class SkyveContextListener implements ServletContextListener {
 		}
 		String archiveName = null;
 		if (UtilImpl.PROPERTIES_FILE_PATH == null) {
-			UtilImpl.LOGGER.info("SKYVE CONTEXT REAL PATH = " + UtilImpl.SKYVE_CONTEXT_REAL_PATH);
+			LOGGER.info("SKYVE CONTEXT REAL PATH = " + UtilImpl.SKYVE_CONTEXT_REAL_PATH);
 			File archive = new File(UtilImpl.SKYVE_CONTEXT_REAL_PATH);
 			if (archive.getParentFile().getName().endsWith("ear")) {
 				archive = archive.getParentFile();
@@ -210,9 +214,9 @@ public class SkyveContextListener implements ServletContextListener {
 			String className = reg.getClassName();
 			if (DEV_LOGIN_FILTER_CLASS_NAME.equals(className)) {
 				UtilImpl.DEV_LOGIN_FILTER_USED = true;
-				UtilImpl.LOGGER.warning("****************************************************************************************************");
-				UtilImpl.LOGGER.warning("DevLoginFilter is in use - Skyve will opening services that should not be open in a legit deployment");
-				UtilImpl.LOGGER.warning("****************************************************************************************************");
+				LOGGER.warn("****************************************************************************************************");
+				LOGGER.warn("DevLoginFilter is in use - Skyve will opening services that should not be open in a legit deployment");
+				LOGGER.warn("****************************************************************************************************");
 			}
 			else if (RESPONSE_HEADER_FILTER_CLASS_NAME.equals(className)) {
 				if (ResponseHeaderFilter.SECURITY_HEADERS_FILTER_NAME.equals(reg.getName())) {
@@ -561,11 +565,11 @@ public class SkyveContextListener implements ServletContextListener {
 		UtilImpl.SKYVE_REPOSITORY_CLASS = getString("factories", "repositoryClass", factories, false);
 		if (ProvidedRepositoryFactory.get() == null) {
 			if (UtilImpl.SKYVE_REPOSITORY_CLASS == null) {
-				UtilImpl.LOGGER.info("SET SKYVE REPOSITORY CLASS TO DEFAULT");
+				LOGGER.info("SET SKYVE REPOSITORY CLASS TO DEFAULT");
 				ProvidedRepositoryFactory.set(new DefaultRepository());
 			}
 			else {
-				UtilImpl.LOGGER.info("SET SKYVE REPOSITORY CLASS TO " + UtilImpl.SKYVE_REPOSITORY_CLASS);
+				LOGGER.info("SET SKYVE REPOSITORY CLASS TO " + UtilImpl.SKYVE_REPOSITORY_CLASS);
 				try {
 					Class<?> loadedClass = Thread.currentThread().getContextClassLoader().loadClass(UtilImpl.SKYVE_REPOSITORY_CLASS);
 					ProvidedRepository providedRepository = (ProvidedRepository) loadedClass.getDeclaredConstructor().newInstance();
@@ -580,11 +584,11 @@ public class SkyveContextListener implements ServletContextListener {
 		UtilImpl.SKYVE_PERSISTENCE_CLASS = getString("factories", "persistenceClass", factories, false);
 		if (AbstractPersistence.IMPLEMENTATION_CLASS == null) {
 			if (UtilImpl.SKYVE_PERSISTENCE_CLASS == null) {
-				UtilImpl.LOGGER.info("SET SKYVE PERSISTENCE CLASS TO DEFAULT (HibernateContentPersistence)");
+				LOGGER.info("SET SKYVE PERSISTENCE CLASS TO DEFAULT (HibernateContentPersistence)");
 				AbstractPersistence.IMPLEMENTATION_CLASS = HibernateContentPersistence.class;
 			}
 			else {
-				UtilImpl.LOGGER.info("SET SKYVE PERSISTENCE CLASS TO " + UtilImpl.SKYVE_PERSISTENCE_CLASS);
+				LOGGER.info("SET SKYVE PERSISTENCE CLASS TO " + UtilImpl.SKYVE_PERSISTENCE_CLASS);
 				try {
 					AbstractPersistence.IMPLEMENTATION_CLASS = (Class<? extends AbstractPersistence>) Thread.currentThread().getContextClassLoader().loadClass(UtilImpl.SKYVE_PERSISTENCE_CLASS);
 				}
@@ -597,11 +601,11 @@ public class SkyveContextListener implements ServletContextListener {
 		UtilImpl.SKYVE_DYNAMIC_PERSISTENCE_CLASS = getString("factories", "dynamicPersistenceClass", factories, false);
 		if (AbstractPersistence.DYNAMIC_IMPLEMENTATION_CLASS == null) {
 			if (UtilImpl.SKYVE_DYNAMIC_PERSISTENCE_CLASS == null) {
-				UtilImpl.LOGGER.info("SET SKYVE DYNAMIC PERSISTENCE CLASS TO DEFAULT (RDBMSDynamicPersistence)");
+				LOGGER.info("SET SKYVE DYNAMIC PERSISTENCE CLASS TO DEFAULT (RDBMSDynamicPersistence)");
 				AbstractPersistence.DYNAMIC_IMPLEMENTATION_CLASS = RDBMSDynamicPersistence.class;
 			}
 			else {
-				UtilImpl.LOGGER.info("SET SKYVE DYNAMIC PERSISTENCE CLASS TO " + UtilImpl.SKYVE_DYNAMIC_PERSISTENCE_CLASS);
+				LOGGER.info("SET SKYVE DYNAMIC PERSISTENCE CLASS TO " + UtilImpl.SKYVE_DYNAMIC_PERSISTENCE_CLASS);
 				try {
 					AbstractPersistence.DYNAMIC_IMPLEMENTATION_CLASS = (Class<? extends DynamicPersistence>) Thread.currentThread().getContextClassLoader().loadClass(UtilImpl.SKYVE_DYNAMIC_PERSISTENCE_CLASS);
 				}
@@ -1010,7 +1014,7 @@ public class SkyveContextListener implements ServletContextListener {
 						cm.shutdown();
 					}
 					catch (Exception e) {
-						UtilImpl.LOGGER.info("Could not close or shutdown of the content manager - this is probably OK although resources may be left hanging or locked");
+						LOGGER.info("Could not close or shutdown of the content manager - this is probably OK although resources may be left hanging or locked", e);
 						e.printStackTrace();
 					}
 				}

--- a/skyve-web/src/main/java/org/skyve/impl/web/SkyveSessionListener.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/SkyveSessionListener.java
@@ -4,10 +4,11 @@ import org.skyve.impl.cache.StateUtil;
 import org.skyve.impl.metadata.customer.CustomerImpl;
 import org.skyve.impl.metadata.repository.DefaultRepository;
 import org.skyve.impl.metadata.repository.ProvidedRepositoryFactory;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.metadata.user.User;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpSessionEvent;
@@ -22,6 +23,9 @@ import jakarta.servlet.http.HttpSessionListener;
  * @author mike
  */
 public class SkyveSessionListener implements HttpSessionListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkyveSessionListener.class);
+
 	/**
 	 * Increment the session count
 	 */
@@ -57,7 +61,7 @@ public class SkyveSessionListener implements HttpSessionListener {
 						customer = (CustomerImpl) user.getCustomer();
 					}
 					catch (Exception e) {
-						UtilImpl.LOGGER.warning("Could not get the user customer " + customerName + " from the repository to call notifyLogout() on session destroyed.");
+						LOGGER.warn("Could not get the user customer " + customerName + " from the repository to call notifyLogout() on session destroyed.");
 						e.printStackTrace();
 					}
 					if (customer != null) {
@@ -65,7 +69,7 @@ public class SkyveSessionListener implements HttpSessionListener {
 					}
 				}
 				else {
-					UtilImpl.LOGGER.warning("Could not get the user customer as it is null so cannot call notifyLogout() on session destroyed.");
+					LOGGER.warn("Could not get the user customer as it is null so cannot call notifyLogout() on session destroyed.");
 				}
 			}
 			// Remove the session repository if it exists

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/FacesAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/FacesAction.java
@@ -18,8 +18,9 @@ import org.skyve.domain.messages.MessageException;
 import org.skyve.domain.messages.SecurityException;
 import org.skyve.domain.messages.SessionEndedException;
 import org.skyve.impl.persistence.AbstractPersistence;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.el.ValueExpression;
 import jakarta.faces.application.FacesMessage;
@@ -45,6 +46,9 @@ import jakarta.servlet.http.HttpServletRequest;
  * @param <T>
  */
 public abstract class FacesAction<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FacesAction.class);
+
 	public final T execute() {
 		T result = null;
 		
@@ -341,7 +345,7 @@ public abstract class FacesAction<T> {
 								gridSize = value.size();
 							}
 							else {
-				            	UtilImpl.LOGGER.warning("FacesAction.findAllMessageComponentClientIds: ClientID " + clientId + " points to a data grid that has a data table value of null");
+				            	LOGGER.warn("FacesAction.findAllMessageComponentClientIds: ClientID " + clientId + " points to a data grid that has a data table value of null");
 							}
 							break;
 						}

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/SkyveFacesFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/SkyveFacesFilter.java
@@ -2,7 +2,6 @@ package org.skyve.impl.web.faces;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.logging.Level;
 
 import org.skyve.CORE;
 import org.skyve.content.MimeType;
@@ -13,6 +12,9 @@ import org.skyve.impl.metadata.repository.router.Router;
 import org.skyve.impl.persistence.AbstractPersistence;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.faces.application.ViewExpiredException;
 import jakarta.servlet.Filter;
@@ -25,6 +27,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public class SkyveFacesFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkyveFacesFilter.class);
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	// This is used when the principal is not (or no longer) logged in.
 	// This must be a protected resource so that the login page is displayed
 	private String forwardURI;
@@ -128,7 +134,7 @@ public class SkyveFacesFilter implements Filter {
 		catch (Exception e) {
 			Throwable c = e.getCause();
 
-			Util.LOGGER.log(Level.SEVERE, "SkyveFacesFilter.doFilter", e);
+			LOGGER.error("SkyveFacesFilter.doFilter", e);
 			e.printStackTrace();
 
 			// redirect to appropriate page
@@ -157,7 +163,7 @@ public class SkyveFacesFilter implements Filter {
 			}
 		}
 		finally {
-			if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("SkyveFacesFilter - DISCONNECT PERSISTENCE");
+			if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("SkyveFacesFilter - DISCONNECT PERSISTENCE");
 			AbstractPersistence persistence = AbstractPersistence.get();
 			persistence.commit(true);
 			if (UtilImpl.FACES_TRACE) StateUtil.logStateStats();

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ActionUtil.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ActionUtil.java
@@ -7,7 +7,6 @@ import org.primefaces.PrimeFaces;
 import org.skyve.CORE;
 import org.skyve.domain.Bean;
 import org.skyve.impl.cache.StateUtil;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.AbstractWebContext;
 import org.skyve.impl.web.faces.FacesUtil;
 import org.skyve.impl.web.faces.views.FacesView;
@@ -17,11 +16,16 @@ import org.skyve.metadata.module.Module;
 import org.skyve.metadata.module.query.MetaDataQueryDefinition;
 import org.skyve.metadata.user.User;
 import org.skyve.util.Binder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 
 public class ActionUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActionUtil.class);
+
 	/**
 	 * Disallow instantiation
 	 */
@@ -61,7 +65,7 @@ public class ActionUtil {
 			}
     	}
     	else {
-    		UtilImpl.LOGGER.warning("ActionUtil.getTargetBeanForViewAndReferenceBinding: FacesView.getBean() yields null");
+    		LOGGER.warn("ActionUtil.getTargetBeanForViewAndReferenceBinding: FacesView.getBean() yields null");
     	}
     	
     	return result;
@@ -91,7 +95,7 @@ public class ActionUtil {
 	    	}
     	}
     	else {
-    		UtilImpl.LOGGER.warning("ActionUtil.setTargetBeanForViewAndCollectionBinding: FacesView.getBean() yields null");
+    		LOGGER.warn("ActionUtil.setTargetBeanForViewAndCollectionBinding: FacesView.getBean() yields null");
     	}
     }
     

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/AddAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/AddAction.java
@@ -105,9 +105,9 @@ public class AddAction extends FacesAction<Void> {
 		if (! vetoed) {
 			Bizlet<Bean> bizlet = ((DocumentImpl) relationDocument).getBizlet(customer);
 			if (bizlet != null) {
-				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Add + ", " + newBean + ", " + facesView.getBean() + ", " + webContext);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Add + ", " + newBean + ", " + facesView.getBean() + ", " + webContext);
 				newBean = bizlet.preExecute(ImplicitActionName.Add, newBean, parentBean, webContext);
-				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + newBean);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preExecute: " + newBean);
 			}
 			internalCustomer.interceptAfterPreExecute(ImplicitActionName.Add, newBean, parentBean, webContext);
 

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/AddAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/AddAction.java
@@ -1,7 +1,6 @@
 package org.skyve.impl.web.faces.actions;
 
 import java.util.List;
-import java.util.logging.Level;
 
 import org.skyve.CORE;
 import org.skyve.domain.Bean;
@@ -21,14 +20,19 @@ import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
 import org.skyve.util.Binder;
 import org.skyve.util.Binder.TargetMetaData;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 /**
  * Adds an element to an array.
  * The onAddedHandlers event actions is not implemented since the grid cannot be inlined.
  */
 public class AddAction extends FacesAction<Void> {
+    
+    private static Logger FACES_LOGGER = Category.FACES.logger();
+    private static Logger BIZLET_LOGGER = Category.BIZLET.logger();
+    
 	private FacesView facesView;
 	private String dataWidgetBinding;
 	private boolean inline;
@@ -41,7 +45,7 @@ public class AddAction extends FacesAction<Void> {
 	@Override
 	public Void callback() throws Exception {
 		String viewBinding = facesView.getViewBinding();
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("AddAction - dataWidgetBinding=" + dataWidgetBinding + 
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("AddAction - dataWidgetBinding=" + dataWidgetBinding + 
 													" : facesView.viewBinding=" + viewBinding + 
 													" : facesView.inline=" + inline);
 		if ((! inline) && (! FacesAction.validateRequiredFields())) {
@@ -101,9 +105,9 @@ public class AddAction extends FacesAction<Void> {
 		if (! vetoed) {
 			Bizlet<Bean> bizlet = ((DocumentImpl) relationDocument).getBizlet(customer);
 			if (bizlet != null) {
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Add + ", " + newBean + ", " + facesView.getBean() + ", " + webContext);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Add + ", " + newBean + ", " + facesView.getBean() + ", " + webContext);
 				newBean = bizlet.preExecute(ImplicitActionName.Add, newBean, parentBean, webContext);
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + newBean);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + newBean);
 			}
 			internalCustomer.interceptAfterPreExecute(ImplicitActionName.Add, newBean, parentBean, webContext);
 
@@ -120,8 +124,8 @@ public class AddAction extends FacesAction<Void> {
 				facesView.setViewBinding(newViewBinding.toString());
 		    	facesView.getZoomInBindings().push(zoomInBinding.toString());
 				if (UtilImpl.FACES_TRACE) { 
-					Util.LOGGER.info("Push ZoomInBinding " + zoomInBinding.toString());
-					Util.LOGGER.info("Set ViewBinding " + newViewBinding.toString());
+					FACES_LOGGER.info("Push ZoomInBinding " + zoomInBinding.toString());
+					FACES_LOGGER.info("Set ViewBinding " + newViewBinding.toString());
 				}
 
 		    	ActionUtil.redirectViewScopedConversation(facesView, true);

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ChartAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ChartAction.java
@@ -41,11 +41,16 @@ import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.model.chart.MetaDataChartModel;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 /**
  * Create a PF chart model from a Skyve model.
  */
 public class ChartAction extends FacesAction<ChartModel> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private FacesView facesView;
 	private Object model;
 	private ChartType type;
@@ -58,7 +63,7 @@ public class ChartAction extends FacesAction<ChartModel> {
 
 	@Override
 	public ChartModel callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("ChartAction - CHART " + model);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("ChartAction - CHART " + model);
 
 		AbstractPersistence persistence = AbstractPersistence.get();
 		Bean targetBean = ActionUtil.getTargetBeanForView(facesView);

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/CompleteAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/CompleteAction.java
@@ -3,7 +3,6 @@ package org.skyve.impl.web.faces.actions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 
 import org.skyve.EXT;
 import org.skyve.domain.Bean;
@@ -27,8 +26,14 @@ import org.skyve.metadata.user.UserAccess;
 import org.skyve.persistence.DocumentQuery;
 import org.skyve.util.Binder.TargetMetaData;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public class CompleteAction extends FacesAction<List<String>> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
+
 	private FacesView facesView;
 	private String query;
 	private String binding;
@@ -46,7 +51,7 @@ public class CompleteAction extends FacesAction<List<String>> {
 
 	@Override
 	public List<String> callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("CompleteAction - EXECUTE complete " + query + " for binding " + binding);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("CompleteAction - EXECUTE complete " + query + " for binding " + binding);
 		AbstractPersistence persistence = AbstractPersistence.get();
 		Bean bean = ActionUtil.getTargetBeanForView(facesView);
 		final String formModuleName = bean.getBizModule();
@@ -128,9 +133,9 @@ public class CompleteAction extends FacesAction<List<String>> {
 			if (! vetoed) {
 				Bizlet<Bean> bizlet = ((DocumentImpl) document).getBizlet(customer);
 				if (bizlet != null) {
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "complete", "Entering " + bizlet.getClass().getName() + ".complete: " + attributeName + ", " + query + ", " + bean);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".complete: " + attributeName + ", " + query + ", " + bean);
 					result = bizlet.complete(attributeName, query, bean);
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "complete", "Exiting " + bizlet.getClass().getName() + ".complete: " + attributeName + ", " + query + ", " + bean);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".complete: " + attributeName + ", " + query + ", " + bean);
 				}
 				internalCustomer.interceptAfterComplete(attributeName, query, bean, result);
 			}

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/DeleteAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/DeleteAction.java
@@ -1,12 +1,10 @@
 package org.skyve.impl.web.faces.actions;
 
-import java.util.logging.Level;
-
 import org.skyve.domain.PersistentBean;
 import org.skyve.domain.messages.Message;
 import org.skyve.domain.messages.OptimisticLockException;
-import org.skyve.domain.messages.SecurityException;
 import org.skyve.domain.messages.OptimisticLockException.OperationType;
+import org.skyve.domain.messages.SecurityException;
 import org.skyve.domain.messages.ValidationException;
 import org.skyve.impl.metadata.customer.CustomerImpl;
 import org.skyve.impl.metadata.model.document.DocumentImpl;
@@ -20,10 +18,15 @@ import org.skyve.metadata.model.document.Bizlet;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 public class DeleteAction extends FacesAction<Void> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
+
 	private FacesView facesView;
 	public DeleteAction(FacesView facesView) {
 		this.facesView = facesView;
@@ -31,7 +34,7 @@ public class DeleteAction extends FacesAction<Void> {
 
 	@Override
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("DeleteAction");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("DeleteAction");
 
 		AbstractPersistence persistence = AbstractPersistence.get();
 		PersistentBean beanToDelete = (PersistentBean) ActionUtil.getTargetBeanForView(facesView);
@@ -75,9 +78,9 @@ public class DeleteAction extends FacesAction<Void> {
 		if (! vetoed) {
 			Bizlet<PersistentBean> bizlet = ((DocumentImpl) document).getBizlet(customer);
 			if (bizlet != null) {
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Delete + ", " + persistentBeanToDelete + ", null, " + ", " + webContext);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Delete + ", " + persistentBeanToDelete + ", null, " + ", " + webContext);
 				persistentBeanToDelete = bizlet.preExecute(ImplicitActionName.Delete, persistentBeanToDelete, null, webContext);
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + persistentBeanToDelete);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preExecute: " + persistentBeanToDelete);
 			}
 			internalCustomer.interceptAfterPreExecute(ImplicitActionName.Delete, persistentBeanToDelete, null, webContext);
 

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/EditAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/EditAction.java
@@ -3,7 +3,6 @@ package org.skyve.impl.web.faces.actions;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.Stack;
-import java.util.logging.Level;
 
 import org.apache.commons.lang3.StringUtils;
 import org.skyve.CORE;
@@ -29,13 +28,20 @@ import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
 import org.skyve.metadata.user.UserAccess;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 import jakarta.servlet.http.HttpServletRequest;
 
 public class EditAction extends FacesAction<Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EditAction.class);
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
+
 	private FacesView facesView = null;
 	public EditAction(FacesView facesView) {
 		this.facesView = facesView;
@@ -43,7 +49,7 @@ public class EditAction extends FacesAction<Void> {
 
 	@Override
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("EditAction");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("EditAction");
 
 		Bean bean = null;
 		AbstractWebContext webContext = null;
@@ -125,9 +131,9 @@ public class EditAction extends FacesAction<Void> {
 						if (! vetoed) {
 							Bizlet<Bean> bizlet = ((DocumentImpl) document).getBizlet(customer);
 							if (bizlet != null) {
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.New + ", " + bean + ", null, " + ", " + webContext);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.New + ", " + bean + ", null, " + ", " + webContext);
 				    			bean = bizlet.preExecute(ImplicitActionName.New, bean, null, webContext);
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + bean);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preExecute: " + bean);
 							}
 							internalCustomer.interceptAfterPreExecute(ImplicitActionName.New, bean, null, webContext);
 							
@@ -161,9 +167,9 @@ public class EditAction extends FacesAction<Void> {
 						if (! vetoed) {
 							Bizlet<Bean> bizlet = ((DocumentImpl) document).getBizlet(customer);
 							if (bizlet != null) {
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Edit + ", " + bean + ", null, " + ", " + webContext);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Edit + ", " + bean + ", null, " + ", " + webContext);
 				    			bean = bizlet.preExecute(ImplicitActionName.Edit, bean, null, webContext);
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + bean);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preExecute: " + bean);
 							}
 							internalCustomer.interceptAfterPreExecute(ImplicitActionName.Edit, bean, null, webContext);
 							
@@ -198,7 +204,7 @@ public class EditAction extends FacesAction<Void> {
 		}
 		catch (Exception e) {
 			// Failed to get the current bean - current is null
-			UtilImpl.LOGGER.info("EditAction:- Could not get binding " + viewBinding + " in bean " + bean + " : " + e.getMessage());
+			LOGGER.info("EditAction:- Could not get binding {} in bean {} : {}", viewBinding, bean, e.getMessage(), e);
 		}
 		if (current != null) { // successful binding get
 			Stack<String> zoomInBindings = facesView.getZoomInBindings();

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ExecuteActionAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ExecuteActionAction.java
@@ -17,9 +17,14 @@ import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.Action;
 import org.skyve.metadata.view.View;
 import org.skyve.metadata.view.View.ViewType;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 public class ExecuteActionAction extends FacesAction<Void> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private FacesView facesView;
 	private String actionName;
 	
@@ -39,7 +44,7 @@ public class ExecuteActionAction extends FacesAction<Void> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("ExecuteActionAction - EXECUTE ACTION " + actionName + ((collectionName != null) ? (" for grid " + collectionName + " with selected row " + elementBizId) : ""));
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("ExecuteActionAction - EXECUTE ACTION " + actionName + ((collectionName != null) ? (" for grid " + collectionName + " with selected row " + elementBizId) : ""));
 
 		AbstractPersistence persistence = AbstractPersistence.get();
 		Bean targetBean = ActionUtil.getTargetBeanForViewAndReferenceBinding(facesView, collectionName, elementBizId);
@@ -52,7 +57,7 @@ public class ExecuteActionAction extends FacesAction<Void> {
 											targetBean.isCreated() ? ViewType.edit.toString() : ViewType.create.toString());
     	Action action = view.getAction(actionName);
     	Boolean clientValidation = action.getClientValidation();
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("ExecuteActionAction - client validation = " + (! Boolean.FALSE.equals(clientValidation)));
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("ExecuteActionAction - client validation = " + (! Boolean.FALSE.equals(clientValidation)));
     	String resourceName = action.getResourceName();
     	
 		if (! user.canExecuteAction(targetDocument, resourceName)) {

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ExecuteDownloadAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ExecuteDownloadAction.java
@@ -16,12 +16,17 @@ import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.Action;
 import org.skyve.metadata.view.View;
 import org.skyve.metadata.view.View.ViewType;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 /**
  * /download?_n=<action>&_doc=<module.document>&_c=<webId>&_ctim=<millis> and optionally &_b=<view binding>
  */
 public class ExecuteDownloadAction extends FacesAction<Void> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private FacesView facesView;
 	private String actionName;
 	private String dataWidgetBinding;
@@ -39,7 +44,7 @@ public class ExecuteDownloadAction extends FacesAction<Void> {
 
 	@Override
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("ExecuteDownloadAction - EXECUTE ACTION " + actionName + ((dataWidgetBinding != null) ? (" for data widget " + dataWidgetBinding + " with selected row " + elementBizId) : ""));
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("ExecuteDownloadAction - EXECUTE ACTION " + actionName + ((dataWidgetBinding != null) ? (" for data widget " + dataWidgetBinding + " with selected row " + elementBizId) : ""));
 
 		AbstractPersistence persistence = AbstractPersistence.get();
 		Bean targetBean = ActionUtil.getTargetBeanForViewAndReferenceBinding(facesView, dataWidgetBinding, elementBizId);
@@ -52,7 +57,7 @@ public class ExecuteDownloadAction extends FacesAction<Void> {
 											targetBean.isCreated() ? ViewType.edit.toString() : ViewType.create.toString());
     	Action action = view.getAction(actionName);
     	Boolean clientValidation = action.getClientValidation();
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("ExecuteActionAction - client validation = " + (! Boolean.FALSE.equals(clientValidation)));
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("ExecuteActionAction - client validation = " + (! Boolean.FALSE.equals(clientValidation)));
     	String resourceName = action.getResourceName();
     	
 		if (! user.canExecuteAction(targetDocument, resourceName)) {

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/GetBeansAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/GetBeansAction.java
@@ -9,9 +9,13 @@ import org.skyve.impl.web.faces.models.SkyveLazyDataModel;
 import org.skyve.impl.web.faces.views.FacesView;
 import org.skyve.metadata.view.widget.FilterParameter;
 import org.skyve.metadata.view.widget.bound.Parameter;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public class GetBeansAction extends FacesAction<List<BeanMapAdapter>> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private FacesView facesView;
 	private String bizModule;
 	private String bizDocument;
@@ -41,7 +45,7 @@ public class GetBeansAction extends FacesAction<List<BeanMapAdapter>> {
 	
 	@Override
 	public List<BeanMapAdapter> callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("GetBeansAction - bizModule=" + bizModule + 
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("GetBeansAction - bizModule=" + bizModule + 
 														" : bizDocument=" + bizDocument + 
 														" : queryName=" + queryName + 
 														" : modelName=" + modelName);

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/GetContentFileNameAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/GetContentFileNameAction.java
@@ -7,9 +7,13 @@ import org.skyve.domain.Bean;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.faces.FacesAction;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public class GetContentFileNameAction extends FacesAction<String> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private Bean bean;
 	private String binding;
 	public GetContentFileNameAction(Bean bean, String binding) {
@@ -19,7 +23,7 @@ public class GetContentFileNameAction extends FacesAction<String> {
 	
 	@Override
 	public String callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("GetContentFileNameAction - binding=" + binding);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("GetContentFileNameAction - binding=" + binding);
 
 		String contentId = (String) Binder.get(bean, binding);
 		String fileName = "&lt;Empty&gt;";

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/GetContentURLAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/GetContentURLAction.java
@@ -5,9 +5,13 @@ import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.AbstractWebContext;
 import org.skyve.impl.web.faces.FacesAction;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 public class GetContentURLAction extends FacesAction<String> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private Bean bean;
 	private String binding;
 	private boolean image;
@@ -19,7 +23,7 @@ public class GetContentURLAction extends FacesAction<String> {
 	
 	@Override
 	public String callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("GetContentURLAction - binding=" + binding);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("GetContentURLAction - binding=" + binding);
 
 		String contentId = (String) Binder.get(bean, binding);
 		if (contentId == null) {

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/GetSelectItemsAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/GetSelectItemsAction.java
@@ -23,12 +23,18 @@ import org.skyve.metadata.module.Module;
 import org.skyve.persistence.Persistence;
 import org.skyve.util.Binder;
 import org.skyve.util.Binder.TargetMetaData;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.faces.model.SelectItem;
 
 public class GetSelectItemsAction extends FacesAction<List<SelectItem>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetSelectItemsAction.class);
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private Bean bean;
 	private WebContext webContext;
 	private String binding;
@@ -68,7 +74,7 @@ public class GetSelectItemsAction extends FacesAction<List<SelectItem>> {
 
 	@Override
 	public List<SelectItem> callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("GetSelectItemsAction - binding=" + binding + " : includeEmptyItem=" + includeEmptyItem);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("GetSelectItemsAction - binding=" + binding + " : includeEmptyItem=" + includeEmptyItem);
 
     	Customer customer = CORE.getUser().getCustomer();
         Module module = customer.getModule(moduleName);
@@ -91,7 +97,7 @@ public class GetSelectItemsAction extends FacesAction<List<SelectItem>> {
             
             List<DomainValue> domainValues = null;
             if ((domainType == DomainType.dynamic) && (owningBean == null)) {
-            	UtilImpl.LOGGER.warning("GetSelectItemsAction: Dynamic domain values called on binding " + binding + " but this binding evaluates to null");
+                LOGGER.warn("GetSelectItemsAction: Dynamic domain values called on binding " + binding + " but this binding evaluates to null");
             	domainValues = Collections.emptyList();
             }
             else {

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/PopulateAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/PopulateAction.java
@@ -10,12 +10,16 @@ import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.module.query.MetaDataQueryDefinition;
 import org.skyve.metadata.view.model.list.ListModel;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 /**
  * Just set the state of the list bean up - but do not load any data
  */
 public class PopulateAction extends FacesAction<Void> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private FacesView facesView;
 	public PopulateAction(FacesView facesView) {
 		this.facesView = facesView;
@@ -23,7 +27,7 @@ public class PopulateAction extends FacesAction<Void> {
 	
 	@Override
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("PopulateAction");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("PopulateAction");
 
 		String bizModule = facesView.getBizModuleParameter();
 		String bizDocument = facesView.getBizDocumentParameter();

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/PreRenderColdHitAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/PreRenderColdHitAction.java
@@ -6,13 +6,19 @@ import org.skyve.impl.web.UserAgent;
 import org.skyve.impl.web.faces.FacesAction;
 import org.skyve.impl.web.faces.views.FacesView;
 import org.skyve.metadata.user.User;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.faces.context.FacesContext;
 import jakarta.servlet.http.HttpServletRequest;
 
 public class PreRenderColdHitAction extends FacesAction<Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PreRenderColdHitAction.class);
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private FacesView facesView;
 	public PreRenderColdHitAction(FacesView facesView) {
 		this.facesView = facesView;
@@ -20,7 +26,7 @@ public class PreRenderColdHitAction extends FacesAction<Void> {
 
 	@Override
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("PreRenderColdHitAction");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("PreRenderColdHitAction");
 
 		// Set the UX/UI and user agent type
 		HttpServletRequest request = (HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest();
@@ -45,7 +51,7 @@ public class PreRenderColdHitAction extends FacesAction<Void> {
 		log.append(" : d=").append(facesView.getBizDocumentParameter());
 		log.append(" : q=").append(facesView.getQueryNameParameter());
 		log.append(" : i=").append(facesView.getBizIdParameter());
-		Util.LOGGER.info(log.toString());
+		LOGGER.info(log.toString());
 		switch (webAction) {
 		case e:
 			new EditAction(facesView).callback(); // execute without error trapping

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/RemoveAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/RemoveAction.java
@@ -1,7 +1,6 @@
 package org.skyve.impl.web.faces.actions;
 
 import java.util.List;
-import java.util.logging.Level;
 
 import org.skyve.CORE;
 import org.skyve.domain.Bean;
@@ -15,14 +14,19 @@ import org.skyve.metadata.controller.ImplicitActionName;
 import org.skyve.metadata.model.document.Bizlet;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 /**
  * Remove an element from an array.
  * The onRemovedHandlers event actions are processed here also.
  */
 public class RemoveAction extends FacesAction<Void> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
+
 	private FacesView facesView;
 	private String collectionName;
 	private String elementBizId;
@@ -40,7 +44,7 @@ public class RemoveAction extends FacesAction<Void> {
 
 	@Override
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("RemoveAction - collectionName=" + collectionName + " : elementBizId=" + elementBizId);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("RemoveAction - collectionName=" + collectionName + " : elementBizId=" + elementBizId);
 
 		Bean bean = facesView.getBean();
 		String viewBinding = facesView.getViewBinding();
@@ -58,15 +62,15 @@ public class RemoveAction extends FacesAction<Void> {
 			if (removedHandlerActionNames != null) {
 				for (String removedHandlerActionName : removedHandlerActionNames) {
 					if (Boolean.TRUE.toString().equals(removedHandlerActionName)) {
-						if (UtilImpl.FACES_TRACE) Util.LOGGER.info("RemoveAction - execute removed handler rerender with client validation");
+						if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("RemoveAction - execute removed handler rerender with client validation");
 						new RerenderAction(facesView, collectionName, true).execute();
 					}
 					else if (Boolean.FALSE.toString().equals(removedHandlerActionName)) {
-						if (UtilImpl.FACES_TRACE) Util.LOGGER.info("RemoveAction - execute removed handler rerender with no client validation");
+						if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("RemoveAction - execute removed handler rerender with no client validation");
 						new RerenderAction(facesView, collectionName, false).execute();
 					}
 					else {
-						if (UtilImpl.FACES_TRACE) Util.LOGGER.info(String.format("RemoveAction - execute removed handler [%s] action", removedHandlerActionName));
+						if (UtilImpl.FACES_TRACE) FACES_LOGGER.info(String.format("RemoveAction - execute removed handler [%s] action", removedHandlerActionName));
 						new ExecuteActionAction(facesView, removedHandlerActionName, null, null).execute();
 					}
 				}
@@ -91,9 +95,9 @@ public class RemoveAction extends FacesAction<Void> {
 			if (! vetoed) {
 				Bizlet<Bean> bizlet = ((DocumentImpl) document).getBizlet(internalCustomer);
 				if (bizlet != null) {
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Remove + ", " + beanToRemove + ", null, " + ", " + webContext);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Remove + ", " + beanToRemove + ", null, " + ", " + webContext);
 					beanToRemove = bizlet.preExecute(ImplicitActionName.Remove, beanToRemove, null, webContext);
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + beanToRemove);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preExecute: " + beanToRemove);
 				}
 				internalCustomer.interceptAfterPreExecute(ImplicitActionName.Remove, beanToRemove, null, webContext);
 

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/RerenderAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/RerenderAction.java
@@ -1,7 +1,5 @@
 package org.skyve.impl.web.faces.actions;
 
-import java.util.logging.Level;
-
 import org.skyve.domain.Bean;
 import org.skyve.impl.metadata.customer.CustomerImpl;
 import org.skyve.impl.metadata.model.document.DocumentImpl;
@@ -13,9 +11,17 @@ import org.skyve.metadata.model.document.Bizlet;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RerenderAction extends FacesAction<Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RerenderAction.class);
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
+
 	private FacesView facesView;
 	private String source;
 	private boolean validate;
@@ -28,7 +34,7 @@ public class RerenderAction extends FacesAction<Void> {
 
 	@Override
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("RerenderAction - EXECUTE RERENDER with source " + source + (validate ? " with" : " without") + " validation ");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("RerenderAction - EXECUTE RERENDER with source " + source + (validate ? " with" : " without") + " validation ");
 
 		AbstractPersistence persistence = AbstractPersistence.get();
 		Bean targetBean = ActionUtil.getTargetBeanForView(facesView);
@@ -49,9 +55,9 @@ public class RerenderAction extends FacesAction<Void> {
 				boolean vetoed = customer.interceptBeforePreRerender(source, targetBean, webContext);
 				if (! vetoed) {
 					if (targetBizlet != null) {
-						if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, targetBizlet.getClass().getName(), "preRerender", "Entering " + targetBizlet.getClass().getName() + ".preRerender: " + source + ", " + targetBean + ", " + webContext);
+						if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + targetBizlet.getClass().getName() + ".preRerender: " + source + ", " + targetBean + ", " + webContext);
 		    			targetBizlet.preRerender(source, targetBean, webContext);
-		    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, targetBizlet.getClass().getName(), "preRerender", "Exiting " + targetBizlet.getClass().getName() + ".preRerender: " + targetBean);
+		    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + targetBizlet.getClass().getName() + ".preRerender: " + targetBean);
 					}
 					customer.interceptAfterPreRerender(source, targetBean, webContext);
 					
@@ -61,7 +67,7 @@ public class RerenderAction extends FacesAction<Void> {
 		    }
 		}
 		else {
-        	UtilImpl.LOGGER.warning("RerenderAction: Target Bean is null");
+        	LOGGER.warn("RerenderAction: Target Bean is null");
 		}
 		
 	    return null;

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/SaveAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/SaveAction.java
@@ -1,7 +1,5 @@
 package org.skyve.impl.web.faces.actions;
 
-import java.util.logging.Level;
-
 import org.skyve.domain.PersistentBean;
 import org.skyve.domain.messages.SecurityException;
 import org.skyve.impl.metadata.customer.CustomerImpl;
@@ -19,10 +17,15 @@ import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.Action;
 import org.skyve.metadata.view.View;
 import org.skyve.metadata.view.View.ViewType;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 public class SaveAction extends FacesAction<Void> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
+
 	private FacesView facesView; 
 	private boolean ok;
 	public SaveAction(FacesView facesView, boolean ok) {
@@ -32,7 +35,7 @@ public class SaveAction extends FacesAction<Void> {
 
 	@Override
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("SaveAction - ok=" + ok);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("SaveAction - ok=" + ok);
 
 		AbstractPersistence persistence = AbstractPersistence.get();
 		PersistentBean targetBean = (PersistentBean) ActionUtil.getTargetBeanForView(facesView);
@@ -49,7 +52,7 @@ public class SaveAction extends FacesAction<Void> {
     	if (action != null) { // could be Defaults action
     		clientValidation = action.getClientValidation();
     	}
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("SaveAction - client validation = " + (! Boolean.FALSE.equals(clientValidation)));
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("SaveAction - client validation = " + (! Boolean.FALSE.equals(clientValidation)));
 
 		if (Boolean.FALSE.equals(clientValidation) || FacesAction.validateRequiredFields()) {
 			// Run the bizlet
@@ -59,9 +62,9 @@ public class SaveAction extends FacesAction<Void> {
 			if (! vetoed) {
 				Bizlet<PersistentBean> bizlet = ((DocumentImpl) targetDocument).getBizlet(customer);
 				if (bizlet != null) {
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ian + ", " + targetBean + ", null, " + ", " + webContext);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preExecute: " + ian + ", " + targetBean + ", null, " + ", " + webContext);
 					targetBean = bizlet.preExecute(ian, targetBean, null, webContext);
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + targetBean);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preExecute: " + targetBean);
 				}
 				internalCustomer.interceptAfterPreExecute(ian, targetBean, null, webContext);
 

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/SetTitleAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/SetTitleAction.java
@@ -12,9 +12,15 @@ import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.View;
 import org.skyve.metadata.view.View.ViewType;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SetTitleAction extends FacesAction<Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SetTitleAction.class);
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	private FacesView facesView;
 	public SetTitleAction(FacesView facesView) {
 		this.facesView = facesView;
@@ -22,7 +28,7 @@ public class SetTitleAction extends FacesAction<Void> {
 	
 	@Override
 	public Void callback() throws Exception {
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("SetTitleAction");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("SetTitleAction");
 
 		if (facesView.getBean() != null) {
 			User user = CORE.getUser();
@@ -38,7 +44,7 @@ public class SetTitleAction extends FacesAction<Void> {
 			facesView.setTitle(Binder.formatMessage(view.getLocalisedTitle(), targetBean));
 	    }
 		else {
-        	UtilImpl.LOGGER.warning("SetTitleAction: FacesView.getBean() yields null");
+        	LOGGER.warn("SetTitleAction: FacesView.getBean() yields null");
 		}
 		
 		return null;

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ZoomInAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ZoomInAction.java
@@ -1,7 +1,5 @@
 package org.skyve.impl.web.faces.actions;
 
-import java.util.logging.Level;
-
 import org.skyve.CORE;
 import org.skyve.domain.Bean;
 import org.skyve.impl.bind.BindUtil;
@@ -16,10 +14,15 @@ import org.skyve.metadata.model.document.Bizlet;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 public class ZoomInAction extends FacesAction<Void> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
+
 	private FacesView facesView;
 	private String binding;
 	private String bizId;
@@ -38,7 +41,7 @@ public class ZoomInAction extends FacesAction<Void> {
 	public Void callback() throws Exception {
 		StringBuilder sb = new StringBuilder(64);
 		sb.append("ZoomInAction - binding=").append(binding).append(" : bizId=").append(bizId);
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info(sb.toString());
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info(sb.toString());
 
 		// We can't check for update privilege here as we don't know if the zoom in is read-only or not.
 		// Its up to the app coder to disable the UI if appropriate.
@@ -52,12 +55,12 @@ public class ZoomInAction extends FacesAction<Void> {
 				sb.append("ElementById(").append(bizId).append(')');
 			}
 			facesView.getZoomInBindings().push(sb.toString());
-			if (UtilImpl.FACES_TRACE) Util.LOGGER.info("Push ZoomInBinding " + sb.toString());
+			if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("Push ZoomInBinding " + sb.toString());
 			if (viewBinding != null) {
 				sb.insert(0, '.').insert(0, viewBinding);
 			}
 			facesView.setViewBinding(sb.toString());
-			if (UtilImpl.FACES_TRACE) Util.LOGGER.info("Set ViewBinding " + sb.toString());
+			if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("Set ViewBinding " + sb.toString());
 	
 			Bean currentBean = ActionUtil.getTargetBeanForView(facesView);
 			if (currentBean == null) { // instantiate one
@@ -84,9 +87,9 @@ public class ZoomInAction extends FacesAction<Void> {
 			if (! vetoed) {
 				Bizlet<Bean> bizlet = ((DocumentImpl) referenceDocument).getBizlet(customer);
 				if (bizlet != null) {
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Edit + ", " + currentBean + ", " + facesView.getBean() + ", " + webContext);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Edit + ", " + currentBean + ", " + facesView.getBean() + ", " + webContext);
 					currentBean = bizlet.preExecute(ImplicitActionName.Edit, currentBean, parentBean, webContext);
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + currentBean);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preExecute: " + currentBean);
 				}
 				internalCustomer.interceptAfterPreExecute(ImplicitActionName.Edit, currentBean, parentBean, webContext);
 

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ZoomOutAction.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/actions/ZoomOutAction.java
@@ -1,7 +1,6 @@
 package org.skyve.impl.web.faces.actions;
 
 import java.util.Stack;
-import java.util.logging.Level;
 
 import org.skyve.CORE;
 import org.skyve.domain.Bean;
@@ -18,13 +17,18 @@ import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 /**
  * Strip the last term off the view binding
  */
 public class ZoomOutAction extends FacesAction<Void> {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
+
 	private FacesView facesView;
 	public ZoomOutAction(FacesView facesView) {
 		this.facesView = facesView;
@@ -33,7 +37,7 @@ public class ZoomOutAction extends FacesAction<Void> {
 	@Override
 	public Void callback() throws Exception {
 		Stack<String> zoomInBindings = facesView.getZoomInBindings();
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info(String.format("ZoomOutAction by zoom in binding of %s with view binding of %s",
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info(String.format("ZoomOutAction by zoom in binding of %s with view binding of %s",
 																	zoomInBindings.isEmpty() ? "null" : zoomInBindings.peek(),
 																	facesView.getViewBinding()));
 		// We cannot do security tests at this point because ZoomOut is the only way out of the UI.
@@ -54,9 +58,9 @@ public class ZoomOutAction extends FacesAction<Void> {
 			boolean vetoed = internalCustomer.interceptBeforePreExecute(ImplicitActionName.ZoomOut, referenceBean, null, webContext);
 			if (! vetoed) {
 				if (bizlet != null) {
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.ZoomOut + ", " + referenceBean + ", null, " + webContext);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.ZoomOut + ", " + referenceBean + ", null, " + webContext);
 					referenceBean = bizlet.preExecute(ImplicitActionName.ZoomOut, referenceBean, null, webContext);
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + referenceBean);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preExecute: " + referenceBean);
 				}
 				internalCustomer.interceptAfterPreExecute(ImplicitActionName.ZoomOut, referenceBean, null, webContext);
 
@@ -98,7 +102,7 @@ public class ZoomOutAction extends FacesAction<Void> {
 		String zoomInBinding = zoomInBindings.isEmpty() ? null : zoomInBindings.pop();
 		String newViewBinding = null;
 
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info(String.format("zoomOut - popped zoomInBinding = %s, viewBinding = %s",
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info(String.format("zoomOut - popped zoomInBinding = %s, viewBinding = %s",
 																	zoomInBinding,
 																	viewBinding));
 
@@ -127,7 +131,7 @@ public class ZoomOutAction extends FacesAction<Void> {
     			// otherwise leave the new view binding null as we are at the outer-most level.
     		}
     	}
-		if (UtilImpl.FACES_TRACE) Util.LOGGER.info("zoomOut - newViewBinding = " + newViewBinding);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("zoomOut - newViewBinding = " + newViewBinding);
 		facesView.setViewBinding(newViewBinding);
 
 		Bean currentBean = ActionUtil.getTargetBeanForView(facesView);

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/components/Conversation.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/components/Conversation.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.faces.FacesUtil;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.faces.component.FacesComponent;
 import jakarta.faces.component.UIComponentBase;
@@ -13,6 +15,8 @@ import jakarta.faces.context.FacesContext;
 @FacesComponent(Conversation.COMPONENT_TYPE)
 public class Conversation extends UIComponentBase {
 	public static final String COMPONENT_TYPE = "org.skyve.impl.web.faces.components.Conversation";
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
 
 	@Override
 	public String getFamily() {
@@ -24,7 +28,7 @@ public class Conversation extends UIComponentBase {
 		Map<String, Object> attributes = getAttributes();
 		final String managedBeanName = (String) attributes.get("managedBean");
 
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("Conversation - " + managedBeanName + " is the subject of the conversation.");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("Conversation - " + managedBeanName + " is the subject of the conversation.");
 
 		FacesContext.getCurrentInstance().getViewRoot().getAttributes().put(FacesUtil.MANAGED_BEAN_NAME_KEY, managedBeanName);
 	}

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/components/ListGrid.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/components/ListGrid.java
@@ -26,7 +26,8 @@ import org.skyve.metadata.module.query.MetaDataQueryDefinition;
 import org.skyve.metadata.router.UxUi;
 import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.model.list.ListModel;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -38,6 +39,9 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @FacesComponent(ListGrid.COMPONENT_TYPE)
 public class ListGrid extends HtmlPanelGroup {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	@SuppressWarnings("hiding")
 	public static final String COMPONENT_TYPE = "org.skyve.impl.web.faces.components.ListGrid";
 
@@ -93,7 +97,7 @@ public class ListGrid extends HtmlPanelGroup {
 			}.execute();
 		}
 
-		if ((UtilImpl.FACES_TRACE) && (! context.isPostback())) Util.LOGGER.info(new ComponentRenderer(this).toString());
+		if ((UtilImpl.FACES_TRACE) && (! context.isPostback())) FACES_LOGGER.info(new ComponentRenderer(this).toString());
 
 		super.encodeBegin(context);
 	}

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/components/Map.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/components/Map.java
@@ -9,7 +9,8 @@ import org.skyve.impl.web.faces.FacesAction;
 import org.skyve.impl.web.faces.pipeline.component.ComponentBuilder;
 import org.skyve.impl.web.faces.pipeline.component.ComponentRenderer;
 import org.skyve.impl.web.faces.pipeline.component.SkyveComponentBuilderChain;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.faces.component.FacesComponent;
 import jakarta.faces.component.UIComponent;
@@ -19,6 +20,9 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @FacesComponent(Map.COMPONENT_TYPE)
 public class Map extends HtmlPanelGroup {
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	@SuppressWarnings("hiding")
 	public static final String COMPONENT_TYPE = "org.skyve.impl.web.faces.components.Map";
 
@@ -65,7 +69,7 @@ public class Map extends HtmlPanelGroup {
 			}.execute();
 		}
 
-		if ((UtilImpl.FACES_TRACE) && (! context.isPostback())) Util.LOGGER.info(new ComponentRenderer(this).toString());
+		if ((UtilImpl.FACES_TRACE) && (! context.isPostback())) FACES_LOGGER.info(new ComponentRenderer(this).toString());
 
 		super.encodeBegin(context);
 	}		

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/components/ResetMenuState.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/components/ResetMenuState.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.WebUtil;
 import org.skyve.impl.web.faces.views.MenuView;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
 
 import jakarta.el.ELContext;
 import jakarta.faces.component.FacesComponent;
@@ -18,6 +20,8 @@ import jakarta.servlet.http.HttpServletResponse;
 public class ResetMenuState extends UIComponentBase {
 	public static final String COMPONENT_TYPE = "org.skyve.impl.web.faces.components.ResetMenuState";
 
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	@Override
 	public String getFamily() {
 		return "resetMenuState";
@@ -25,7 +29,7 @@ public class ResetMenuState extends UIComponentBase {
 
 	@Override
 	public void encodeBegin(FacesContext context) throws IOException {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("Menu State Cookies deleted...");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("Menu State Cookies deleted...");
 
 		ELContext elc = context.getELContext();
 		MenuView menu = (MenuView) elc.getELResolver().getValue(elc, null, "menu");

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/components/View.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/components/View.java
@@ -24,8 +24,10 @@ import org.skyve.metadata.router.UxUi;
 import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.View.ViewType;
 import org.skyve.util.Binder;
-import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.UserAgentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.faces.component.FacesComponent;
 import jakarta.faces.component.UIComponent;
@@ -34,6 +36,10 @@ import jakarta.faces.context.FacesContext;
 
 @FacesComponent(View.COMPONENT_TYPE) 
 public class View extends HtmlPanelGroup {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(View.class);
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
     @SuppressWarnings("hiding")
     public static final String COMPONENT_TYPE = "org.skyve.impl.web.faces.components.View";
 
@@ -86,7 +92,7 @@ public class View extends HtmlPanelGroup {
 	    	final LayoutBuilder layoutBuilder = tempLayoutBuilder;
 	    	
 	    	if (UtilImpl.FACES_TRACE) {
-	   			UtilImpl.LOGGER.info(String.format("View - GENERATE moduleName=%s : documentName=%s : " + 
+	    	    FACES_LOGGER.info(String.format("View - GENERATE moduleName=%s : documentName=%s : " + 
 	   													"managedBeanName=%s : widgetId=%s" +
 	   													" : process=%s : update=%s : managedBeanName=%s : " + 
 	   													"componentBuilderClass=%s : layoutBuilderClass=%s",
@@ -137,7 +143,7 @@ public class View extends HtmlPanelGroup {
 								Binder.set(view, "style", childStyle);
 							}
 							catch (@SuppressWarnings("unused") Exception e) {
-								UtilImpl.LOGGER.warning("Can't set the style attribute on this UIComponent - " + view);
+								LOGGER.warn("Can't set the style attribute on this UIComponent - " + view);
 							}
 						}
 						if (childStyleClass != null) {
@@ -145,7 +151,7 @@ public class View extends HtmlPanelGroup {
 								Binder.set(view, "styleClass", childStyleClass);
 							}
 							catch (@SuppressWarnings("unused") Exception e) {
-								UtilImpl.LOGGER.warning("Can't set the styleClass attribute on this UIComponent - " + view);
+								LOGGER.warn("Can't set the styleClass attribute on this UIComponent - " + view);
 							}
 						}
 					}
@@ -155,7 +161,7 @@ public class View extends HtmlPanelGroup {
 				}
 			}.execute();
 			
-			if ((UtilImpl.FACES_TRACE) && (! context.isPostback())) Util.LOGGER.info(new ComponentRenderer(this).toString());
+			if ((UtilImpl.FACES_TRACE) && (! context.isPostback())) FACES_LOGGER.info(new ComponentRenderer(this).toString());
 		}
 
 		super.encodeBegin(context);

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/models/BeanMapAdapter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/models/BeanMapAdapter.java
@@ -17,12 +17,16 @@ import org.skyve.impl.web.faces.actions.GetSelectItemsAction;
 import org.skyve.metadata.view.TextOutput.Sanitisation;
 import org.skyve.util.Binder;
 import org.skyve.util.OWASP;
+import org.skyve.util.logging.Category;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 import jakarta.faces.model.SelectItem;
 
 public final class BeanMapAdapter implements Map<String, Object>, Serializable {
 	private static final long serialVersionUID = 3398758718683866619L;
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
 
 	private Bean bean;
 	private WebContext webContext;
@@ -34,14 +38,14 @@ public final class BeanMapAdapter implements Map<String, Object>, Serializable {
 	}
 	
 	public Bean getBean() {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.finest("BeanMapAdapter.getBean " + bean);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.trace("BeanMapAdapter.getBean {}", bean);
 		return bean;
 	}
 	
 	public void setBean(Bean bean) {
 		this.bean = bean;
 		delegate.clear();
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.finest("BeanMapAdapter.setBean " + bean);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.trace("BeanMapAdapter.setBean {}", bean);
 	}
 	
 	@Override
@@ -56,13 +60,13 @@ public final class BeanMapAdapter implements Map<String, Object>, Serializable {
 
 	@Override
 	public boolean containsKey(Object key) {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.finest("BeanMapAdapter.containsKey " + key);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.trace("BeanMapAdapter.containsKey {}", key);
 		return delegate.containsKey(key);
 	}
 
 	@Override
 	public boolean containsValue(Object value) {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.finest("BeanMapAdapter.containsValue " + value);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.trace("BeanMapAdapter.containsValue {}", value);
 		return delegate.containsValue(value);
 	}
 
@@ -131,7 +135,7 @@ public final class BeanMapAdapter implements Map<String, Object>, Serializable {
 				}
 				delegate.put(binding, result);
 
-				if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.finest("BeanMapAdapter.get " + key + " = " + result);
+				if (UtilImpl.FACES_TRACE) FACES_LOGGER.trace("BeanMapAdapter.get {} = {}", key, result);
 				return result;
 			}
 		}.execute();
@@ -139,7 +143,7 @@ public final class BeanMapAdapter implements Map<String, Object>, Serializable {
 
 	@Override
 	public Object put(String key, Object value) {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.finest("BeanMapAdapter.put " + key + " to " + value);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.trace("BeanMapAdapter.put {} = {}", key, value);
 		set(key, value);
 		return delegate.put(key, value);
 	}
@@ -178,7 +182,7 @@ public final class BeanMapAdapter implements Map<String, Object>, Serializable {
 		String bizModule = bean.getBizModule();
 		String bizDocument = bean.getBizDocument();
 		final String key = String.format("%s.%s.%s", bizModule, bizDocument, binding);
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.finest("BeanMapAdapter.getSelectItems - key = " + key);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.trace("BeanMapAdapter.getSelectItems - key = {}", key);
 		return new GetSelectItemsAction(bean, webContext, binding, includeEmptyItem).execute();
 	}
 	

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/models/SkyveLazyDataModel.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/models/SkyveLazyDataModel.java
@@ -44,12 +44,18 @@ import org.skyve.metadata.view.widget.bound.Parameter;
 import org.skyve.util.Binder.TargetMetaData;
 import org.skyve.util.OWASP;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.SortParameter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
 
 public class SkyveLazyDataModel extends LazyDataModel<BeanMapAdapter> {
 	private static final long serialVersionUID = -2161288261538038204L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkyveLazyDataModel.class);
+    private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
 
 	private FacesView view;
 	private String moduleName;
@@ -149,11 +155,11 @@ public class SkyveLazyDataModel extends LazyDataModel<BeanMapAdapter> {
 		d = model.getDrivingDocument();
 		
 		if (! u.canReadDocument(d)) {
-			UtilImpl.LOGGER.info("User " + u.getName() + " cannot read document " + d.getOwningModuleName() + '.' + d.getName());
+			LOGGER.info("User " + u.getName() + " cannot read document " + d.getOwningModuleName() + '.' + d.getName());
 			throw new SecurityException(d.getName() + " in module " + d.getOwningModuleName(), u.getName());
 		}
-		
-		if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(String.format("LOAD %s : %s", String.valueOf(first), String.valueOf(pageSize)));
+
+        if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("LOAD {} : {}", first, pageSize);
 		model.setStartRow(first);
 		model.setEndRow(first + pageSize);
 
@@ -216,7 +222,7 @@ public class SkyveLazyDataModel extends LazyDataModel<BeanMapAdapter> {
 		SortParameter[] sortParameters = new SortParameter[l];
 		int i = 0;
 		for (SortMeta sm : multiSortMeta.values()) {
-			if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(String.format("    SORT by %s %s", sm.getField(), sm.getOrder()));
+			if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(String.format("    SORT by %s %s", sm.getField(), sm.getOrder()));
 			SortParameter sp = new SortParameterImpl();
 			sp.setBy(sm.getField());
 			sp.setDirection((SortOrder.DESCENDING.equals(sm.getOrder())) ? SortDirection.descending : null);
@@ -277,8 +283,8 @@ public class SkyveLazyDataModel extends LazyDataModel<BeanMapAdapter> {
 								value = BindUtil.fromString(customer, converter, implementingType, (String) value);
 							}
 							catch (@SuppressWarnings("unused") Exception e) {
-								UtilImpl.LOGGER.info("Could not coerce the String value [" + value + 
-														"] for filter parameter [" + key + "] to the required type, so just ignore...");
+                                LOGGER.info("Could not coerce the String value [" + value +
+                                        "] for filter parameter [" + key + "] to the required type, so just ignore...");
 								continue;
 							}
 						}
@@ -291,7 +297,7 @@ public class SkyveLazyDataModel extends LazyDataModel<BeanMapAdapter> {
 				contains = true;
 			}
 
-			if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(String.format("    FILTER %s %s %s", key, contains ? "contains" : "=", value));
+			if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(String.format("    FILTER %s %s %s", key, contains ? "contains" : "=", value));
 			if (contains) {
 				modelFilter.addContains(key, (String) value);
 			}

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/views/AbstractUploadView.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/views/AbstractUploadView.java
@@ -77,7 +77,7 @@ public abstract class AbstractUploadView extends LocalisableView {
 	protected boolean validFile(UploadedFile file, FacesContext fc) {
 		long size = file.getSize();
 		if (size > maximumSizeInBytes) {
-			UtilImpl.LOGGER.warning("FileUpload - File size of " + size + " > maximumSizeInBytes of " + maximumSizeInBytes);
+			LOGGER.warn("FileUpload - File size of " + size + " > maximumSizeInBytes of " + maximumSizeInBytes);
 			FacesMessage msg = new FacesMessage("Failure", "File is too large");
 			fc.addMessage(null, msg);
 			return false;
@@ -91,7 +91,7 @@ public abstract class AbstractUploadView extends LocalisableView {
 					(! Pattern.compile(whitelistRegex, Pattern.CASE_INSENSITIVE | Pattern.MULTILINE).matcher(name).matches())) ||
 					// Always disallow files starting with .
 					name.matches("^((.*\\/)+\\..*|\\..*|(.*\\\\)+\\..*)$")) {
-				UtilImpl.LOGGER.warning("FileUpload - Filename " + name + " does not match " + whitelistRegex);
+				LOGGER.warn("FileUpload - Filename " + name + " does not match " + whitelistRegex);
 				FacesMessage msg = new FacesMessage("Failure", "Filename " + name + " is not allowed");
 				fc.addMessage(null, msg);
 				return false;

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/views/BizportImportView.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/views/BizportImportView.java
@@ -98,7 +98,7 @@ public class BizportImportView extends AbstractUploadView {
 		
 		String context = getContext();
 		if ((context == null) || (action == null)) {
-			UtilImpl.LOGGER.warning("FileUpload - Malformed URL on Upload Action - context, binding, or action is null");
+			LOGGER.warn("FileUpload - Malformed URL on Upload Action - context, binding, or action is null");
 			FacesMessage msg = new FacesMessage("Failure", "Malformed URL");
 			fc.addMessage(null, msg);
 			return;
@@ -109,7 +109,7 @@ public class BizportImportView extends AbstractUploadView {
 
 		AbstractWebContext webContext = StateUtil.getCachedConversation(context, request);
 		if (webContext == null) {
-			UtilImpl.LOGGER.warning("FileUpload - Malformed URL on Upload Action - context does not exist");
+			LOGGER.warn("FileUpload - Malformed URL on Upload Action - context does not exist");
 			FacesMessage msg = new FacesMessage("Failure", "Malformed URL");
 			FacesContext.getCurrentInstance().addMessage(null, msg);
 			return;

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/views/ContentUploadView.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/views/ContentUploadView.java
@@ -129,7 +129,7 @@ public class ContentUploadView extends AbstractUploadView {
 
 		String context = getContext();
 		if ((context == null) || (contentBinding == null)) {
-			UtilImpl.LOGGER.warning("FileUpload - Malformed URL on Upload Action - context or contentBinding is null");
+			LOGGER.warn("FileUpload - Malformed URL on Upload Action - context or contentBinding is null");
 			FacesMessage msg = new FacesMessage("Failure", "Malformed URL");
 			fc.addMessage(null, msg);
 			return;
@@ -140,7 +140,7 @@ public class ContentUploadView extends AbstractUploadView {
 
 		AbstractWebContext webContext = StateUtil.getCachedConversation(context, request);
 		if (webContext == null) {
-			UtilImpl.LOGGER.warning("FileUpload - Malformed URL on Content Upload - context does not exist");
+			LOGGER.warn("FileUpload - Malformed URL on Content Upload - context does not exist");
 			FacesMessage msg = new FacesMessage("Failure", "Malformed URL");
 			FacesContext.getCurrentInstance().addMessage(null, msg);
 			return;

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/views/FacesView.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/views/FacesView.java
@@ -72,7 +72,9 @@ import org.skyve.metadata.view.widget.FilterParameter;
 import org.skyve.metadata.view.widget.bound.Parameter;
 import org.skyve.util.OWASP;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.UserAgentType;
+import org.slf4j.Logger;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.faces.FacesException;
@@ -88,7 +90,9 @@ import jakarta.inject.Named;
 @Named("skyve")
 public class FacesView extends HarnessView {
 	private static final long serialVersionUID = 3331890232012703780L;
-	
+
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
+
 	// NB whatever state is added here needs to be handled by hydrate/dehydrate
 
 	// This is set from a request attribute (the attribute is set in home.jsp)
@@ -152,7 +156,7 @@ public class FacesView extends HarnessView {
 			csrfToken = StateUtil.createToken().toString();
 			csrfTokenChecked = false;
 		}
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("getCsrfToken() = " + csrfToken);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("getCsrfToken() = " + csrfToken);
 		return csrfToken;
 	}
 
@@ -168,13 +172,13 @@ public class FacesView extends HarnessView {
 			return;
 		}
 		
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("setCsrfToken() = " + csrfToken);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("setCsrfToken() = " + csrfToken);
 		String currentCsrfToken = OWASP.sanitise(Sanitisation.text, Util.processStringValue(csrfToken));
 		csrfTokenChecked = true; // indicate we have checked the token
 		if (this.csrfToken != null) { // there needs to be a token to check first
 			
 			if (! this.csrfToken.equals(currentCsrfToken)) {
-				Util.LOGGER.severe("CSRF attack detected");
+				LOGGER.error("CSRF attack detected");
 				try {
 					FacesContext.getCurrentInstance().getExternalContext().redirect(Util.getLoggedOutUrl());
 				}
@@ -214,7 +218,7 @@ public class FacesView extends HarnessView {
 		log.append(" : d=").append(getBizDocumentParameter());
 		log.append(" : q=").append(getQueryNameParameter());
 		log.append(" : i=").append(getBizIdParameter());
-		UtilImpl.LOGGER.info(log.toString());
+		LOGGER.info(log.toString());
 
 		if (! csrfTokenChecked) {
 			if (! FacesUtil.isIgnoreAutoUpdate()) {
@@ -225,7 +229,7 @@ public class FacesView extends HarnessView {
 				}
 				else {
 					try {
-						Util.LOGGER.severe("No CSRF token detected");
+						LOGGER.error("No CSRF token detected");
 						ec.redirect(Util.getLoggedOutUrl());
 					}
 					catch (IOException e) {
@@ -329,7 +333,7 @@ public class FacesView extends HarnessView {
 	}
 
 	public void ok() {
-		UtilImpl.LOGGER.info("FacesView - ok");
+		LOGGER.info("FacesView - ok");
 		new SaveAction(this, true).execute();
 		
 		FacesContext c = FacesContext.getCurrentInstance();
@@ -339,7 +343,7 @@ public class FacesView extends HarnessView {
 	}
 
 	public void save() {
-		UtilImpl.LOGGER.info("FacesView - save");
+		LOGGER.info("FacesView - save");
 		Bean contextBean = getBean();
 		boolean notPersistedBefore = contextBean.isNotPersisted();
 
@@ -361,7 +365,7 @@ public class FacesView extends HarnessView {
 	}
 	
 	public void delete() {
-		UtilImpl.LOGGER.info("FacesView - delete");
+		LOGGER.info("FacesView - delete");
 		new DeleteAction(this).execute();
 
 		FacesContext c = FacesContext.getCurrentInstance();
@@ -374,9 +378,9 @@ public class FacesView extends HarnessView {
 	public void navigate(String dataWidgetBinding, String bizId) {
 		StringBuilder log = new StringBuilder(128);
 		log.append("FacesView - zoom in to ").append(dataWidgetBinding).append('(').append(bizId).append(')');
-		UtilImpl.LOGGER.info(log.toString());
+		LOGGER.info(log.toString());
 		new ZoomInAction(this, dataWidgetBinding, bizId).execute();
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("FacesView - view binding now " + viewBinding);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("FacesView - view binding now " + viewBinding);
 	}
 	
 	// for navigate-on-select in data grids
@@ -393,21 +397,21 @@ public class FacesView extends HarnessView {
 	
 	// Called by ZoomIn widget
 	public void navigate(String referenceBinding) {
-		UtilImpl.LOGGER.info("FacesView - zoom in to " + referenceBinding);
+		LOGGER.info("FacesView - zoom in to " + referenceBinding);
 		new ZoomInAction(this, referenceBinding).execute();
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("FacesView - view binding now " + viewBinding);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("FacesView - view binding now " + viewBinding);
 	}
 	
 	public void add(String dataWidgetBinding, boolean inline) {
 		StringBuilder log = new StringBuilder(128);
 		log.append("FacesView - add to ").append(dataWidgetBinding).append((inline ? " inline" : " with zoom"));
-		UtilImpl.LOGGER.info(log.toString());
+		LOGGER.info(log.toString());
 		new AddAction(this, dataWidgetBinding, inline).execute();
-		if (inline && UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("FacesView - view binding now " + viewBinding);
+		if (inline && UtilImpl.FACES_TRACE) LOGGER.info("FacesView - view binding now " + viewBinding);
 	}
 	
 	public void zoomout() {
-		UtilImpl.LOGGER.info("FacesView - zoomout");
+		LOGGER.info("FacesView - zoomout");
 		new ZoomOutAction(this).execute();
 	}
 
@@ -416,7 +420,7 @@ public class FacesView extends HarnessView {
 	 * removedHandlerActionNames uses "true/false" to indicate rerender action with/without client validation.
 	 */
 	public void remove(String dataWidgetBinding, String bizId, List<String> removedHandlerActionNames) {
-		UtilImpl.LOGGER.info("FacesView - remove " + viewBinding);
+		LOGGER.info("FacesView - remove " + viewBinding);
 		new RemoveAction(this, dataWidgetBinding, bizId, removedHandlerActionNames).execute();
 	}
 
@@ -429,7 +433,7 @@ public class FacesView extends HarnessView {
 			log.append(" for grid ").append(collectionBinding);
 			log.append(" with selected row ").append(elementBizId);
 		}
-		UtilImpl.LOGGER.info(log.toString());
+		LOGGER.info(log.toString());
 		new ExecuteActionAction(this, actionName, collectionBinding, elementBizId).execute();
 		new SetTitleAction(this).execute();
 	}
@@ -442,7 +446,7 @@ public class FacesView extends HarnessView {
 		StringBuilder log = new StringBuilder(128);
 		log.append("FacesView - rerender from source ").append(source);
 		log.append(validate ? " with" : " without").append(" validation");
-		UtilImpl.LOGGER.info(log.toString());
+		LOGGER.info(log.toString());
 		new RerenderAction(this, source, validate).execute();
 		new SetTitleAction(this).execute();
 	}
@@ -479,7 +483,7 @@ public class FacesView extends HarnessView {
 						StringBuilder log = new StringBuilder(128);
 						log.append("FacesView - selectGridRow set ").append(selectedIdBinding);
 						log.append(" to ").append(bizId);
-						UtilImpl.LOGGER.info(log.toString());
+						LOGGER.info(log.toString());
 						BindUtil.set(getCurrentBean().getBean(), selectedIdBinding, bizId);
 					}
 				}
@@ -554,7 +558,7 @@ public class FacesView extends HarnessView {
 			StringBuilder log = new StringBuilder(128);
 			log.append("FacesView - reorderGridRow ").append(collectionBinding);
 			log.append(" from ").append(fromIndex).append(" to ").append(toIndex);
-			UtilImpl.LOGGER.info(log.toString());
+			LOGGER.info(log.toString());
 			if (collectionBinding != null) {
 				@SuppressWarnings("unchecked")
 				final List<Bean> list = (List<Bean>) BindUtil.get(getCurrentBean().getBean(), collectionBinding);
@@ -643,7 +647,7 @@ public class FacesView extends HarnessView {
 			log.append(" for data widget ").append(collectionBinding);
 			log.append(" with selected row ").append(elementBizId);
 		}
-		UtilImpl.LOGGER.info(log.toString());
+		LOGGER.info(log.toString());
 		new ExecuteDownloadAction(this, 
 									actionName, 
 									collectionBinding,
@@ -750,7 +754,7 @@ public class FacesView extends HarnessView {
 											String binding,
 											boolean includeEmptyItem) {
 		final String key = new StringBuilder(64).append(moduleName).append('.').append(documentName).append('.').append(binding).toString();
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.finest("BeanMapAdapter.getSelectItems - key = " + key);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.trace("BeanMapAdapter.getSelectItems - key = {}", key);
 		return new GetSelectItemsAction(moduleName, documentName, binding, includeEmptyItem).execute();
 	}
 
@@ -762,7 +766,7 @@ public class FacesView extends HarnessView {
 		StringBuilder log = new StringBuilder(128);
 		log.append("FacesView - complete for query '").append(query);
 		log.append("' and binding ").append(binding);
-		UtilImpl.LOGGER.info(log.toString());
+		LOGGER.info(log.toString());
 
 		return new CompleteAction(this, query, binding, complete).execute();
 	}
@@ -800,7 +804,7 @@ public class FacesView extends HarnessView {
 		@SuppressWarnings("unchecked")
 		List<Parameter> parameters = (List<Parameter>) attributes.get("parameters");
 
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("FacesView - COMPLETE = " + completeModule + "." + completeQuery + " : " + query);
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("FacesView - COMPLETE = " + completeModule + "." + completeQuery + " : " + query);
 
  		List<BeanMapAdapter> result = null;
  		
@@ -826,7 +830,7 @@ public class FacesView extends HarnessView {
 	 				key.append('.').append(parameter.getName()).append(valueOrBinding);
 	 			}
 	 		}
-	 		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("FacesView - LIST KEY = " + key);
+	 		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("FacesView - LIST KEY = " + key);
 			result = beans.get(key.toString());
 			if (result == null) {
 				result = new GetBeansAction(this, completeModule, completeDocument, completeQuery, modelName, filterParameters, parameters, false).execute();
@@ -941,7 +945,7 @@ public class FacesView extends HarnessView {
 						int height,
 						String rgbHexBackgroundColour,
 						String rgbHexForegroundColour) {
-		UtilImpl.LOGGER.info("FacesView - sign for binding " + binding);
+		LOGGER.info("FacesView - sign for binding " + binding);
 		new FacesAction<Void>() {
 			@Override
 			public Void callback() throws Exception {
@@ -985,7 +989,7 @@ public class FacesView extends HarnessView {
 	 * Clear a signature content
 	 */
 	public void clear(String binding) {
-		UtilImpl.LOGGER.info("FacesView - clear signnature for binding " + binding);
+		LOGGER.info("FacesView - clear signnature for binding " + binding);
 		BindUtil.set(getCurrentBean().getBean(), binding, null);
 	}
 	
@@ -999,7 +1003,7 @@ public class FacesView extends HarnessView {
  	// restore the webContext and current bean etc
 	public void hydrate(AbstractWebContext newWebContext)
 	throws Exception {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("FacesView - hydrate");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("FacesView - hydrate");
 		webContext = newWebContext;
 		dehydratedWebId = null;
 		setBean(getBean());
@@ -1007,10 +1011,10 @@ public class FacesView extends HarnessView {
 
 	// remove the webContext and current bean etc leaving only the webId
 	public void dehydrate() {
-		if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("FacesView - dehydrate");
+		if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("FacesView - dehydrate");
 		if (webContext != null) {
 			dehydratedWebId = webContext.getWebId();
-			if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.info("FacesView - dehydratedWebId=" + dehydratedWebId);
+			if (UtilImpl.FACES_TRACE) FACES_LOGGER.info("FacesView - dehydratedWebId=" + dehydratedWebId);
 		}
 		webContext = null;
 		lazyDataModels.clear();

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/views/FileUploadView.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/views/FileUploadView.java
@@ -103,7 +103,7 @@ public class FileUploadView extends AbstractUploadView {
 
 		String context = getContext();
 		if ((context == null) || (action == null)) {
-			UtilImpl.LOGGER.warning("FileUpload - Malformed URL on Upload Action - context, binding, or action is null");
+			LOGGER.warn("FileUpload - Malformed URL on Upload Action - context, binding, or action is null");
 			FacesMessage msg = new FacesMessage("Failure", "Malformed URL");
 			fc.addMessage(null, msg);
 			return;
@@ -114,7 +114,7 @@ public class FileUploadView extends AbstractUploadView {
 
 		AbstractWebContext webContext = StateUtil.getCachedConversation(context, request);
 		if (webContext == null) {
-			UtilImpl.LOGGER.warning("FileUpload - Malformed URL on Upload Action - context does not exist");
+			LOGGER.warn("FileUpload - Malformed URL on Upload Action - context does not exist");
 			FacesMessage msg = new FacesMessage("Failure", "Malformed URL");
 			FacesContext.getCurrentInstance().addMessage(null, msg);
 			return;

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/views/ImageMarkupView.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/views/ImageMarkupView.java
@@ -193,7 +193,7 @@ public class ImageMarkupView extends LocalisableView {
 
 		FacesContext fc = FacesContext.getCurrentInstance();
 		if ((contextParameter == null) || (contentBindingParameter == null)) {
-			UtilImpl.LOGGER.warning("FileUpload - Malformed URL on Upload Action - context or contentBinding is null");
+			LOGGER.warn("FileUpload - Malformed URL on Upload Action - context or contentBinding is null");
 			FacesMessage msg = new FacesMessage("Failure", "Malformed URL");
 			fc.addMessage(null, msg);
 			return;
@@ -204,7 +204,7 @@ public class ImageMarkupView extends LocalisableView {
 
 		AbstractWebContext webContext = StateUtil.getCachedConversation(contextParameter, request);
 		if (webContext == null) {
-			UtilImpl.LOGGER.warning("FileUpload - Malformed URL on Content Upload - context does not exist");
+			LOGGER.warn("FileUpload - Malformed URL on Content Upload - context does not exist");
 			FacesMessage msg = new FacesMessage("Failure", "Malformed URL");
 			FacesContext.getCurrentInstance().addMessage(null, msg);
 			return;
@@ -288,13 +288,12 @@ public class ImageMarkupView extends LocalisableView {
 								index = (IndexType.textual.equals(indexType) || IndexType.both.equals(indexType));
 							}
 							else {
-								UtilImpl.LOGGER.warning("Could not determine whether to index the new marked up content as the attribute " + 
+								LOGGER.warn("Could not determine whether to index the new marked up content as the attribute " + 
 															contentBizModule + '.' + contentBizDocument + '.' + contentAttributeName + " is not a content attribute.");
 							}
 						}
 						catch (Exception e) {
-							UtilImpl.LOGGER.warning("Could not determine whether to index the new marked up content.");
-							e.printStackTrace();
+							LOGGER.warn("Could not determine whether to index the new marked up content.", e);
 						}
 						
 						// Put the new context

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/views/LocalisableView.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/views/LocalisableView.java
@@ -11,6 +11,9 @@ import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.faces.FacesAction;
 import org.skyve.metadata.user.User;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.faces.context.FacesContext;
 
@@ -20,6 +23,9 @@ import jakarta.faces.context.FacesContext;
  */
 public abstract class LocalisableView implements Serializable {
 	private static final long serialVersionUID = 2440700208785488690L;
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+    private static final Logger FACES_LOGGER = Category.FACES.logger();
 
 	public static final class I18nMapAdapter implements Map<String, String>, Serializable {
 		private static final long serialVersionUID = 4290123391587825685L;
@@ -56,7 +62,7 @@ public abstract class LocalisableView implements Serializable {
 				@Override
 				public String callback() throws Exception {
 					String result = Util.nullSafeI18n((String) key, locale);
-					if (UtilImpl.FACES_TRACE) UtilImpl.LOGGER.finest("I18nMapAdapter.get " + key + " = " + result);
+					if (UtilImpl.FACES_TRACE) FACES_LOGGER.trace("I18nMapAdapter.get {} = {}", key, result);
 					return result;
 				}
 			}.execute();

--- a/skyve-web/src/main/java/org/skyve/impl/web/filter/RequestLoggingAndStatisticsFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/filter/RequestLoggingAndStatisticsFilter.java
@@ -11,8 +11,10 @@ import org.skyve.impl.util.WebStatsUtil;
 import org.skyve.impl.web.UserAgent;
 import org.skyve.impl.web.WebContainer;
 import org.skyve.util.Monitoring;
+import org.skyve.util.logging.Category;
 import org.skyve.web.UserAgentType;
 import org.skyve.web.WebContext;
+import org.slf4j.Logger;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -26,6 +28,10 @@ import jakarta.servlet.http.HttpSession;
  * Log and collect stats on requests, if this is not a static resource.
  */
 public class RequestLoggingAndStatisticsFilter extends ExcludeStaticFilter {
+
+    private static final Logger HTTP_LOGGER = Category.HTTP.logger();
+    private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
+
     @Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
 	throws IOException, ServletException {
@@ -40,36 +46,36 @@ public class RequestLoggingAndStatisticsFilter extends ExcludeStaticFilter {
 			WebContainer.setHttpServletRequestResponse((HttpServletRequest) request, (HttpServletResponse) response);
 
 			if (UtilImpl.HTTP_TRACE) {
-				UtilImpl.LOGGER.info("*********************************** REQUEST ************************************");
-				UtilImpl.LOGGER.info("ContextPath=" + httpRequest.getContextPath());
-				UtilImpl.LOGGER.info("LocalAddr=" + request.getLocalAddr());
-				UtilImpl.LOGGER.info("LocalName=" + request.getLocalName());
-				UtilImpl.LOGGER.info("LocalPort=" + request.getLocalPort());
-				UtilImpl.LOGGER.info("Method=" + httpRequest.getMethod());
-				UtilImpl.LOGGER.info("PathInfo=" + httpRequest.getPathInfo());
-				UtilImpl.LOGGER.info("PathTranslated=" + httpRequest.getPathTranslated());
-				UtilImpl.LOGGER.info("Protocol=" + request.getProtocol());
-				UtilImpl.LOGGER.info("QueryString=" + httpRequest.getQueryString());
-				UtilImpl.LOGGER.info("RemoteAddr=" + request.getRemoteAddr());
-				UtilImpl.LOGGER.info("RemoteHost=" + request.getRemoteHost());
-				UtilImpl.LOGGER.info("RemotePort=" + request.getRemotePort());
-				UtilImpl.LOGGER.info("RemoteUser=" + httpRequest.getRemoteUser());
-				UtilImpl.LOGGER.info("RequestedSessionId=" + httpRequest.getRequestedSessionId());
-				UtilImpl.LOGGER.info("RequestURI=" + httpRequest.getRequestURI());
-				UtilImpl.LOGGER.info("RequestURL=" + httpRequest.getRequestURL().toString());
-				UtilImpl.LOGGER.info("Scheme=" + request.getScheme());
-				UtilImpl.LOGGER.info("ServerName=" + request.getServerName());
-				UtilImpl.LOGGER.info("ServerPort=" + request.getServerPort());
-				UtilImpl.LOGGER.info("ServletPath=" + httpRequest.getServletPath());
+				HTTP_LOGGER.info("*********************************** REQUEST ************************************");
+				HTTP_LOGGER.info("ContextPath=" + httpRequest.getContextPath());
+				HTTP_LOGGER.info("LocalAddr=" + request.getLocalAddr());
+				HTTP_LOGGER.info("LocalName=" + request.getLocalName());
+				HTTP_LOGGER.info("LocalPort=" + request.getLocalPort());
+				HTTP_LOGGER.info("Method=" + httpRequest.getMethod());
+				HTTP_LOGGER.info("PathInfo=" + httpRequest.getPathInfo());
+				HTTP_LOGGER.info("PathTranslated=" + httpRequest.getPathTranslated());
+				HTTP_LOGGER.info("Protocol=" + request.getProtocol());
+				HTTP_LOGGER.info("QueryString=" + httpRequest.getQueryString());
+				HTTP_LOGGER.info("RemoteAddr=" + request.getRemoteAddr());
+				HTTP_LOGGER.info("RemoteHost=" + request.getRemoteHost());
+				HTTP_LOGGER.info("RemotePort=" + request.getRemotePort());
+				HTTP_LOGGER.info("RemoteUser=" + httpRequest.getRemoteUser());
+				HTTP_LOGGER.info("RequestedSessionId=" + httpRequest.getRequestedSessionId());
+				HTTP_LOGGER.info("RequestURI=" + httpRequest.getRequestURI());
+				HTTP_LOGGER.info("RequestURL=" + httpRequest.getRequestURL().toString());
+				HTTP_LOGGER.info("Scheme=" + request.getScheme());
+				HTTP_LOGGER.info("ServerName=" + request.getServerName());
+				HTTP_LOGGER.info("ServerPort=" + request.getServerPort());
+				HTTP_LOGGER.info("ServletPath=" + httpRequest.getServletPath());
 				Principal principal = httpRequest.getUserPrincipal();
-				UtilImpl.LOGGER.info("UserPrincipal=" + ((principal == null) ? "<null>" : principal.getName()));
-				UtilImpl.LOGGER.info("********************************** PARAMETERS **********************************");
+				HTTP_LOGGER.info("UserPrincipal=" + ((principal == null) ? "<null>" : principal.getName()));
+				HTTP_LOGGER.info("********************************** PARAMETERS **********************************");
 				Enumeration<String> parameterNames = request.getParameterNames();
 				while (parameterNames.hasMoreElements()) {
 					String parameterName = parameterNames.nextElement();
 					if (parameterName != null) {
 						if (parameterName.toLowerCase().contains("password")) {
-							UtilImpl.LOGGER.info(parameterName + "=***PASSWORD***");
+							HTTP_LOGGER.info(parameterName + "=***PASSWORD***");
 						}
 						else {
 							String[] parameterValues = request.getParameterValues(parameterName);
@@ -77,26 +83,26 @@ public class RequestLoggingAndStatisticsFilter extends ExcludeStaticFilter {
 								for (String parameterValue : parameterValues) {
 									int parameterValueLength = parameterValue.length();
 									if (parameterValueLength > 51200) { // 50K
-										UtilImpl.LOGGER.info(parameterName + "=***LENGTH " + (parameterValueLength / 1024) + "K***");
+										HTTP_LOGGER.info(parameterName + "=***LENGTH " + (parameterValueLength / 1024) + "K***");
 									}
 									else if (parameterValue.toLowerCase().contains("password")) {
-										UtilImpl.LOGGER.info(parameterName + "=***CONTAINS PASSWORD***");
+										HTTP_LOGGER.info(parameterName + "=***CONTAINS PASSWORD***");
 									}
 									else {
-										UtilImpl.LOGGER.info(String.format("%s=%s", parameterName, parameterValue));
+										HTTP_LOGGER.info(String.format("%s=%s", parameterName, parameterValue));
 									}
 								}
 							}
 						}
 					}
 				}
-				UtilImpl.LOGGER.info("*********************************** HEADERS ************************************");
+				HTTP_LOGGER.info("*********************************** HEADERS ************************************");
 				Enumeration<String> headerNames = httpRequest.getHeaderNames();
 				while (headerNames.hasMoreElements()) {
 					String headerName = headerNames.nextElement();
-					UtilImpl.LOGGER.info(headerName + "=" + httpRequest.getHeader(headerName));
+					HTTP_LOGGER.info(headerName + "=" + httpRequest.getHeader(headerName));
 				}
-				UtilImpl.LOGGER.info("***************************** SESSION/CONVERSATION *****************************");
+				HTTP_LOGGER.info("***************************** SESSION/CONVERSATION *****************************");
 				StateUtil.logStateStats();
 			}
 
@@ -113,7 +119,7 @@ public class RequestLoggingAndStatisticsFilter extends ExcludeStaticFilter {
 					WebStatsUtil.recordHit(user, userAgentHeader, userAgentType);
 				}
 				else {
-					if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("DIDNT RECORD HIT AS WE ARE NOT LOGGED IN");
+					if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("DIDNT RECORD HIT AS WE ARE NOT LOGGED IN");
 				}
 			}
 			catch (Exception e) {
@@ -132,13 +138,13 @@ public class RequestLoggingAndStatisticsFilter extends ExcludeStaticFilter {
 				double loadPost = Monitoring.systemLoadAverage();
 				int memPctPost = Monitoring.percentageUsedMomory();
 
-				UtilImpl.LOGGER.info("******************************* TIMING/RESOURCES *******************************");
-				UtilImpl.LOGGER.info(String.format("TIME=%,d PRE/POST(DELTA) CPU=%.2f/%.2f(%.2f) MEM=%d%%/%d%%(%d%%)",
+				HTTP_LOGGER.info("******************************* TIMING/RESOURCES *******************************");
+				HTTP_LOGGER.info(String.format("TIME=%,d PRE/POST(DELTA) CPU=%.2f/%.2f(%.2f) MEM=%d%%/%d%%(%d%%)",
 						Long.valueOf(System.currentTimeMillis() - millis),
 						Double.valueOf(loadPre), Double.valueOf(loadPost), Double.valueOf(loadPost - loadPre),
 						Integer.valueOf(memPctPre), Integer.valueOf(memPctPost), Integer.valueOf(memPctPost - memPctPre)));
 				if (UtilImpl.HTTP_TRACE)
-					UtilImpl.LOGGER.info("********************************************************************************");
+				    HTTP_LOGGER.info("********************************************************************************");
 			}
 		} finally {
 			// Clear the request/response in WebContainer

--- a/skyve-web/src/main/java/org/skyve/impl/web/filter/gzip/CompressionFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/filter/gzip/CompressionFilter.java
@@ -20,7 +20,8 @@ package org.skyve.impl.web.filter.gzip;
 import java.io.IOException;
 import java.util.Enumeration;
 
-import org.skyve.impl.util.UtilImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -41,6 +42,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 
 public class CompressionFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompressionFilter.class);
 
     /**
      * The filter configuration object we are associated with.  If this value
@@ -86,8 +89,8 @@ public class CompressionFilter implements Filter {
                 compressionThreshold = Integer.parseInt(str);
                 if (compressionThreshold != 0 && compressionThreshold < minThreshold) {
                     if (debug > 0) {
-                    	UtilImpl.LOGGER.info("compressionThreshold should be either 0 - no compression or >= " + minThreshold);
-                    	UtilImpl.LOGGER.info("compressionThreshold set to " + minThreshold);
+                    	LOGGER.info("compressionThreshold should be either 0 - no compression or >= " + minThreshold);
+                    	LOGGER.info("compressionThreshold set to " + minThreshold);
                     }
                     compressionThreshold = minThreshold;
                 }
@@ -134,12 +137,12 @@ public class CompressionFilter implements Filter {
 							FilterChain chain)
 	throws IOException, ServletException {
         if (debug > 0) {
-        	UtilImpl.LOGGER.info("@doFilter");
+        	LOGGER.info("@doFilter");
         }
 
         if (compressionThreshold == 0) {
             if (debug > 0) {
-            	UtilImpl.LOGGER.info("doFilter gets called, but compressionTreshold is set to 0 - no compression");
+            	LOGGER.info("doFilter gets called, but compressionTreshold is set to 0 - no compression");
             }
             chain.doFilter(request, response);
             return;
@@ -148,14 +151,14 @@ public class CompressionFilter implements Filter {
         boolean supportCompression = false;
         if (request instanceof HttpServletRequest) {
             if (debug > 1) {
-            	UtilImpl.LOGGER.info("requestURI = " + ((HttpServletRequest) request).getRequestURI());
+            	LOGGER.info("requestURI = " + ((HttpServletRequest) request).getRequestURI());
             }
 
             // Are we allowed to compress ?
             String s = ((HttpServletRequest)request).getParameter("gzip");
             if ("false".equals(s)) {
                 if (debug > 0) {
-                	UtilImpl.LOGGER.info("got parameter gzip=false --> don't compress, just chain filter");
+                	LOGGER.info("got parameter gzip=false --> don't compress, just chain filter");
                 }
                 chain.doFilter(request, response);
                 return;
@@ -167,12 +170,12 @@ public class CompressionFilter implements Filter {
                 String name = (String)e.nextElement();
                 if (name.indexOf("gzip") != -1) {
                     if (debug > 0) {
-                    	UtilImpl.LOGGER.info("supports compression");
+                    	LOGGER.info("supports compression");
                     }
                     supportCompression = true;
                 } else {
                     if (debug > 0) {
-                    	UtilImpl.LOGGER.info("no support for compresion");
+                    	LOGGER.info("no support for compresion");
                     }
                 }
             }
@@ -180,7 +183,7 @@ public class CompressionFilter implements Filter {
 
         if (!supportCompression) {
             if (debug > 0) {
-            	UtilImpl.LOGGER.info("doFilter gets called wo compression");
+            	LOGGER.info("doFilter gets called wo compression");
             }
             chain.doFilter(request, response);
             return;
@@ -192,7 +195,7 @@ public class CompressionFilter implements Filter {
             wrappedResponse.setDebugLevel(debug);
             wrappedResponse.setCompressionThreshold(compressionThreshold);
             if (debug > 0) {
-            	UtilImpl.LOGGER.info("doFilter gets called with compression");
+            	LOGGER.info("doFilter gets called with compression");
             }
             try {
                 chain.doFilter(request, wrappedResponse);

--- a/skyve-web/src/main/java/org/skyve/impl/web/filter/gzip/CompressionResponseStream.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/filter/gzip/CompressionResponseStream.java
@@ -20,7 +20,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.zip.GZIPOutputStream;
 
-import org.skyve.impl.util.UtilImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
@@ -38,6 +39,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public class CompressionResponseStream
     extends ServletOutputStream {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompressionResponseStream.class);
 
     // ----------------------------------------------------------- Constructors
 
@@ -125,7 +127,7 @@ public class CompressionResponseStream
         compressionThreshold = threshold;
         buffer = new byte[compressionThreshold];
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("buffer is set to "+compressionThreshold);
+        	LOGGER.info("buffer is set to "+compressionThreshold);
         }
     }
 
@@ -137,7 +139,7 @@ public class CompressionResponseStream
 	public void close() throws IOException {
 
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("close() @ CompressionResponseStream");
+        	LOGGER.info("close() @ CompressionResponseStream");
         }
         if (closed)
             throw new IOException("This output stream has already been closed");
@@ -167,7 +169,7 @@ public class CompressionResponseStream
 	public void flush() throws IOException {
 
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("flush() @ CompressionResponseStream");
+        	LOGGER.info("flush() @ CompressionResponseStream");
         }
         if (closed) {
             throw new IOException("Cannot flush a closed output stream");
@@ -182,11 +184,11 @@ public class CompressionResponseStream
     public void flushToGZip() throws IOException {
 
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("flushToGZip() @ CompressionResponseStream");
+        	LOGGER.info("flushToGZip() @ CompressionResponseStream");
         }
         if (bufferCount > 0) {
             if (debug > 1) {
-            	UtilImpl.LOGGER.info("flushing out to GZipStream, bufferCount = " + bufferCount);
+            	LOGGER.info("flushing out to GZipStream, bufferCount = " + bufferCount);
             }
             writeToGZip(buffer, 0, bufferCount);
             bufferCount = 0;
@@ -245,7 +247,7 @@ public class CompressionResponseStream
 	public void write(byte b[], int off, int len) throws IOException {
 
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("write, bufferCount = " + bufferCount + " len = " + len + " off = " + off);
+        	LOGGER.info("write, bufferCount = " + bufferCount + " len = " + len + " off = " + off);
         }
 
         if (closed)
@@ -278,15 +280,15 @@ public class CompressionResponseStream
     public void writeToGZip(byte b[], int off, int len) throws IOException {
 
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("writeToGZip, len = " + len);
+        	LOGGER.info("writeToGZip, len = " + len);
         }
         if (gzipstream == null) {
             if (debug > 1) {
-            	UtilImpl.LOGGER.info("new GZIPOutputStream");
+            	LOGGER.info("new GZIPOutputStream");
             }
             if (response.isCommitted()) {
                 if (debug > 1)
-                	UtilImpl.LOGGER.info("Response already committed. Using original output stream");
+                	LOGGER.info("Response already committed. Using original output stream");
                 gzipstream = output;
             } else {
                 response.addHeader("Content-Encoding", "gzip");

--- a/skyve-web/src/main/java/org/skyve/impl/web/filter/gzip/CompressionServletResponseWrapper.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/filter/gzip/CompressionServletResponseWrapper.java
@@ -20,7 +20,8 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
-import org.skyve.impl.util.UtilImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
@@ -37,6 +38,8 @@ import jakarta.servlet.http.HttpServletResponseWrapper;
 
 public class CompressionServletResponseWrapper extends HttpServletResponseWrapper {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompressionServletResponseWrapper.class);
+
     // ----------------------------------------------------- Constructor
 
     /**
@@ -48,7 +51,7 @@ public class CompressionServletResponseWrapper extends HttpServletResponseWrappe
         super(response);
         origResponse = response;
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("CompressionServletResponseWrapper constructor gets called");
+        	LOGGER.info("CompressionServletResponseWrapper constructor gets called");
         }
     }
 
@@ -106,7 +109,7 @@ public class CompressionServletResponseWrapper extends HttpServletResponseWrappe
     @Override
 	public void setContentType(String contentType) {
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("setContentType to "+contentType);
+        	LOGGER.info("setContentType to "+contentType);
         }
         this.contentType = contentType;
         origResponse.setContentType(contentType);
@@ -118,7 +121,7 @@ public class CompressionServletResponseWrapper extends HttpServletResponseWrappe
      */
     public void setCompressionThreshold(int threshold) {
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("setCompressionThreshold to " + threshold);
+        	LOGGER.info("setCompressionThreshold to " + threshold);
         }
         this.threshold = threshold;
     }
@@ -140,7 +143,7 @@ public class CompressionServletResponseWrapper extends HttpServletResponseWrappe
      */
     public ServletOutputStream createOutputStream() throws IOException {
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("createOutputStream gets called");
+        	LOGGER.info("createOutputStream gets called");
         }
 
         @SuppressWarnings("hiding")
@@ -181,7 +184,7 @@ public class CompressionServletResponseWrapper extends HttpServletResponseWrappe
     @Override
 	public void flushBuffer() throws IOException {
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("flush buffer @ CompressionServletResponseWrapper");
+        	LOGGER.info("flush buffer @ CompressionServletResponseWrapper");
         }
         ((CompressionResponseStream)stream).flush();
 
@@ -203,7 +206,7 @@ public class CompressionServletResponseWrapper extends HttpServletResponseWrappe
         if (stream == null)
             stream = createOutputStream();
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("stream is set to "+stream+" in getOutputStream");
+        	LOGGER.info("stream is set to "+stream+" in getOutputStream");
         }
 
         return (stream);
@@ -228,12 +231,12 @@ public class CompressionServletResponseWrapper extends HttpServletResponseWrappe
 
         stream = createOutputStream();
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("stream is set to "+stream+" in getWriter");
+        	LOGGER.info("stream is set to "+stream+" in getWriter");
         }
         //String charset = getCharsetFromContentType(contentType);
         String charEnc = origResponse.getCharacterEncoding();
         if (debug > 1) {
-        	UtilImpl.LOGGER.info("character encoding is " + charEnc);
+        	LOGGER.info("character encoding is " + charEnc);
         }
         // HttpServletResponse.getCharacterEncoding() shouldn't return null
         // according the spec, so feel free to remove that "if"

--- a/skyve-web/src/main/java/org/skyve/impl/web/filter/rest/AbstractRestFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/filter/rest/AbstractRestFilter.java
@@ -1,11 +1,13 @@
 package org.skyve.impl.web.filter.rest;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.persistence.Persistence;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -21,6 +23,9 @@ import jakarta.ws.rs.core.MediaType;
 public abstract class AbstractRestFilter implements Filter {
 	protected static final String REALM_INIT_PARAMETER = "realm";
 	protected static final String UNSECURED_INIT_PARAMETER = "unsecured";
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRestFilter.class);
+	private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
 	
 	protected String realm = "Skyve";
 	protected String[] unsecuredURLPrefixes;
@@ -55,7 +60,7 @@ public abstract class AbstractRestFilter implements Filter {
         if (unsecuredURLPrefixes != null) {
 	        for (String unsecuredURLPrefix : unsecuredURLPrefixes) {
 	        	if (pathToTest.startsWith(unsecuredURLPrefix)) {
-	        		if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(String.format("%s is unsecured", pathToTest));
+	        		if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(String.format("%s is unsecured", pathToTest));
 	        		chain.doFilter(request, response);
 	        		return true;
 	        	}
@@ -117,7 +122,7 @@ public abstract class AbstractRestFilter implements Filter {
 		}
 		catch (IOException e) {
 			// can only log it and move on at this stage
-			UtilImpl.LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
+			LOGGER.warn(e.getLocalizedMessage(), e);
 		}
 	}
 }

--- a/skyve-web/src/main/java/org/skyve/impl/web/filter/rest/BasicAuthFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/filter/rest/BasicAuthFilter.java
@@ -3,7 +3,6 @@ package org.skyve.impl.web.filter.rest;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Base64;
-import java.util.logging.Level;
 
 import org.skyve.EXT;
 import org.skyve.domain.Bean;
@@ -19,6 +18,9 @@ import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.persistence.Persistence;
 import org.skyve.persistence.SQL;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -28,6 +30,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public class BasicAuthFilter extends AbstractRestFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BasicAuthFilter.class);
+    private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
+
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
 	throws IOException, ServletException {
@@ -58,8 +64,8 @@ public class BasicAuthFilter extends AbstractRestFilter {
 			error(null, httpResponse, HttpServletResponse.SC_UNAUTHORIZED, realm, "Unable to authenticate with the provided credentials");
 			return;
 		}
-		
-		if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(String.format("Basic Auth for username: %s URI: %s", username, httpRequest.getRequestURI()));
+
+		if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("Basic Auth for username: {} URI: {}", username, httpRequest.getRequestURI());
 
 		AbstractPersistence persistence = null;
 		try {
@@ -91,7 +97,7 @@ public class BasicAuthFilter extends AbstractRestFilter {
 		}
 		catch (Throwable t) {
 			t.printStackTrace();
-			UtilImpl.LOGGER.log(Level.SEVERE, t.getLocalizedMessage(), t);
+			LOGGER.error(t.getLocalizedMessage(), t);
 			error(persistence, httpResponse, t.getLocalizedMessage());
 		}
 		finally {

--- a/skyve-web/src/main/java/org/skyve/impl/web/filter/rest/SessionFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/filter/rest/SessionFilter.java
@@ -3,13 +3,13 @@ package org.skyve.impl.web.filter.rest;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.security.Principal;
-import java.util.logging.Level;
 
 import org.skyve.domain.messages.SessionEndedException;
 import org.skyve.impl.persistence.AbstractPersistence;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.WebUtil;
 import org.skyve.metadata.user.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -19,6 +19,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public class SessionFilter extends AbstractRestFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SessionFilter.class);
+
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
 	throws IOException, ServletException {
@@ -52,8 +55,7 @@ public class SessionFilter extends AbstractRestFilter {
 			}
 		}
 		catch (Throwable t) {
-			t.printStackTrace();
-			UtilImpl.LOGGER.log(Level.SEVERE, t.getLocalizedMessage(), t);
+			LOGGER.error(t.getLocalizedMessage(), t);
 			error(persistence, httpResponse, t.getLocalizedMessage());
 		}
 		finally {

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/ChartServlet.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/ChartServlet.java
@@ -20,7 +20,6 @@ import org.skyve.impl.metadata.view.widget.Chart.ChartType;
 import org.skyve.impl.persistence.AbstractPersistence;
 import org.skyve.impl.snapshot.CompoundFilterOperator;
 import org.skyve.impl.snapshot.SmartClientFilterOperator;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.AbstractWebContext;
 import org.skyve.impl.web.UserAgent;
 import org.skyve.impl.web.WebUtil;
@@ -54,6 +53,8 @@ import org.skyve.persistence.DocumentQuery.AggregateFunction;
 import org.skyve.util.JSON;
 import org.skyve.util.OWASP;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -80,7 +81,9 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class ChartServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
-	
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChartServlet.class);
+
 	private static final String CHART_TYPE_NAME = "t";
 	private static final String DATA_SOURCE_NAME = "ds";
 	private static final String BUILDER_NAME = "b";
@@ -152,7 +155,7 @@ public class ChartServlet extends HttpServlet {
 		Customer customer = CORE.getCustomer();
 		Module module = customer.getModule(moduleName);
 		Document document = module.getDocument(customer, documentName);
-		UtilImpl.LOGGER.info("UX/UI = " + uxuiName);
+		LOGGER.info("UX/UI = " + uxuiName);
 
 		View view = document.getView(uxuiName,
 										customer,

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/HealthServlet.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/HealthServlet.java
@@ -24,6 +24,8 @@ import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.persistence.DataStore;
 import org.skyve.util.Monitoring;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -44,6 +46,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class HealthServlet extends HttpServlet {
 	private static final long serialVersionUID = -509208309881530817L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HealthServlet.class);
 
 	// The thread-safe cached response
 	private static AtomicReference<String> cachedResponse = new AtomicReference<>();
@@ -72,14 +76,14 @@ public class HealthServlet extends HttpServlet {
 			try (PrintWriter pw = response.getWriter()) {
 				pw.append(payload);
 			}
-			Util.LOGGER.info("Health Check Response = " + payload);
+			LOGGER.info("Health Check Response = " + payload);
 		}
 		else { // cached response can be used
 			String payload = cachedResponse.get();
 			try (PrintWriter pw = response.getWriter()) {
 				pw.append(payload);
 			}
-			Util.LOGGER.info("Cached Response = " + payload);
+			LOGGER.info("Cached Response = " + payload);
 		}
 		response.setStatus(HttpServletResponse.SC_OK);
 	}

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/rest/RestService.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/rest/RestService.java
@@ -13,7 +13,6 @@ import org.skyve.domain.PersistentBean;
 import org.skyve.domain.messages.NoResultsException;
 import org.skyve.domain.messages.SecurityException;
 import org.skyve.impl.bind.BindUtil;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.filter.rest.AbstractRestFilter;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.document.Document;
@@ -27,6 +26,8 @@ import org.skyve.util.Binder;
 import org.skyve.util.JSON;
 import org.skyve.util.Thumbnail;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.servlet.http.HttpServletRequest;
@@ -46,6 +47,9 @@ import jakarta.ws.rs.core.MediaType;
 @Path("/api")
 @RequestScoped
 public class RestService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestService.class);
+
 	@Context
 	private HttpServletRequest request;
 	@Context
@@ -353,7 +357,7 @@ public class RestService {
 				AttachmentContent content = cm.getAttachment(contentId);
 				
 				if (content == null) {
-					UtilImpl.LOGGER.info(request.getRequestURI() + " not found");
+					LOGGER.info(request.getRequestURI() + " not found");
 					response.setStatus(HttpServletResponse.SC_NOT_FOUND);
 					return result;
 				}
@@ -384,7 +388,7 @@ public class RestService {
 									String.format("attachment; filename=\"%s\"", fileName));
 				// The following allows partial requests which are useful for large media or downloading files with pause and resume functions.
 				response.setHeader("Accept-Ranges", "bytes");
-				UtilImpl.LOGGER.info(request.getRequestURI() + " served as binary");
+				LOGGER.info(request.getRequestURI() + " served as binary");
 			}				
 		}
 		catch (Throwable t) {

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientCompleteServlet.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientCompleteServlet.java
@@ -6,7 +6,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 
 import org.skyve.EXT;
 import org.skyve.content.MimeType;
@@ -35,6 +34,9 @@ import org.skyve.metadata.user.UserAccess;
 import org.skyve.persistence.DocumentQuery;
 import org.skyve.util.Binder.TargetMetaData;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -46,18 +48,21 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class SmartClientCompleteServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(SmartClientCompleteServlet.class);
+	private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
 
 	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response)
 	throws ServletException, IOException {
-		UtilImpl.LOGGER.info("SmartClientComplete - get....");
+		LOGGER.info("SmartClientComplete - get....");
 		processRequest(request, response);
 	}
 
 	@Override
 	protected void doPost(HttpServletRequest request, HttpServletResponse response)
 	throws ServletException, IOException {
-		UtilImpl.LOGGER.info("SmartClientComplete - post....");
+		LOGGER.info("SmartClientComplete - post....");
 		processRequest(request, response);
 	}
 
@@ -232,9 +237,9 @@ public class SmartClientCompleteServlet extends HttpServlet {
 						if (! vetoed) {
 							Bizlet<Bean> bizlet = ((DocumentImpl) document).getBizlet(customer);
 							if (bizlet != null) {
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "complete", "Entering " + bizlet.getClass().getName() + ".complete: " + attributeName + ", " + value + ", " + bean);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".complete: " + attributeName + ", " + value + ", " + bean);
 								result = bizlet.complete(attributeName, value, bean);
-								if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "complete", "Exiting " + bizlet.getClass().getName() + ".complete: " + attributeName + ", " + value + ", " + bean);
+								if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".complete: " + attributeName + ", " + value + ", " + bean);
 							}
 							internalCustomer.interceptAfterComplete(attributeName, value, bean, result);
 						}

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientEditServlet.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientEditServlet.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.logging.Level;
 
 import org.skyve.EXT;
 import org.skyve.content.MimeType;
@@ -60,6 +59,9 @@ import org.skyve.metadata.view.View.ViewType;
 import org.skyve.util.Binder.TargetMetaData;
 import org.skyve.util.OWASP;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
@@ -70,6 +72,9 @@ import jakarta.servlet.http.HttpSession;
 
 public class SmartClientEditServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SmartClientEditServlet.class);
+    private static final Logger BIZLET_LOGGER = Category.BIZLET.logger();
 
 	private static Class<? extends SmartClientViewRenderer> MANIPULATOR_CLASS = null;
 	
@@ -113,14 +118,14 @@ public class SmartClientEditServlet extends HttpServlet {
 	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) 
 	throws ServletException, IOException {
-		UtilImpl.LOGGER.info("SmartClientEdit - get....");
+		LOGGER.info("SmartClientEdit - get....");
 		processRequest(request, response);
 	}
 	
 	@Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) 
 	throws ServletException, IOException  {
-		UtilImpl.LOGGER.info("SmartClientEdit - post....");
+		LOGGER.info("SmartClientEdit - post....");
 		processRequest(request, response);
 	}
 	
@@ -166,7 +171,7 @@ public class SmartClientEditServlet extends HttpServlet {
 			        	if (webContext == null) {
 			        		throw new ConversationEndedException(request.getLocale());
 			        	}
-			        	UtilImpl.LOGGER.info("USE OLD CONVERSATION!!!!");
+			        	LOGGER.info("USE OLD CONVERSATION!!!!");
 			            persistence = webContext.getConversation();
 			            persistence.setForThread();
 			        }
@@ -174,7 +179,7 @@ public class SmartClientEditServlet extends HttpServlet {
 			            // Create and inject any dependencies
 						webContext = new SmartClientWebContext(UUID.randomUUID().toString(), request);
 
-			    		UtilImpl.LOGGER.info("START NEW CONVERSATION!!!!");
+			    		LOGGER.info("START NEW CONVERSATION!!!!");
 			            persistence = AbstractPersistence.get();
 			            persistence.evictAllCached();
 			            webContext.setConversation(persistence);
@@ -182,7 +187,7 @@ public class SmartClientEditServlet extends HttpServlet {
 			        webContext.setAction(OWASP.sanitise(Sanitisation.text, Util.processStringValue(request.getParameter(AbstractWebContext.ACTION_NAME))));
 			
 					UxUi uxui = UserAgent.getUxUi(request);
-					UtilImpl.LOGGER.info("UX/UI = " + uxui.getName());
+					LOGGER.info("UX/UI = " + uxui.getName());
 					
 			    	persistence.begin();
 			    	Principal userPrincipal = request.getUserPrincipal();
@@ -274,7 +279,7 @@ public class SmartClientEditServlet extends HttpServlet {
 							(! ImplicitActionName.Save.toString().equals(actionName)) &&
 							(! ImplicitActionName.ZoomOut.toString().equals(actionName)) &&
 							(! ImplicitActionName.Print.toString().equals(actionName))) {
-						UtilImpl.LOGGER.info("ACTION " + formBinding + " : " + gridBinding);
+						LOGGER.info("ACTION " + formBinding + " : " + gridBinding);
 						if ((editIdCounter == null) || (createIdCounter == null)) {
 							throw new ServletException("Request is malformed");
 						}
@@ -306,7 +311,7 @@ public class SmartClientEditServlet extends HttpServlet {
 						ImplicitActionName action = (actionName == null) ? null : ImplicitActionName.valueOf(actionName);
 						switch (operation) {
 						case fetch:
-							UtilImpl.LOGGER.info("FETCH with binding " + formBinding);
+							LOGGER.info("FETCH with binding " + formBinding);
 							if ((editIdCounter == null) || (createIdCounter == null)) {
 								throw new ServletException("Request is malformed");
 							}
@@ -329,7 +334,7 @@ public class SmartClientEditServlet extends HttpServlet {
 							break;
 						case add:
 						case update:
-							UtilImpl.LOGGER.info("ADD/UPDATE with binding " + formBinding + " : " + gridBinding);
+							LOGGER.info("ADD/UPDATE with binding " + formBinding + " : " + gridBinding);
 							if ((editIdCounter == null) || (createIdCounter == null)) {
 								throw new ServletException("Request is malformed");
 							}
@@ -357,7 +362,7 @@ public class SmartClientEditServlet extends HttpServlet {
 									pw);
 							break;
 						case remove:
-							UtilImpl.LOGGER.info("REMOVE with binding " + formBinding);
+							LOGGER.info("REMOVE with binding " + formBinding);
 
 							SmartClientListServlet.checkCsrfToken(session, request, response, currentCsrfToken);
 
@@ -521,9 +526,9 @@ public class SmartClientEditServlet extends HttpServlet {
 					boolean vetoed = internalCustomer.interceptBeforePreExecute(ImplicitActionName.New, processBean, null, webContext);
 					if (! vetoed) {
 						if (processBizlet != null) {
-							if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Entering " + processBizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.New + ", " + processBean + ", null, " + webContext);
+							if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.New + ", " + processBean + ", null, " + webContext);
 			    			processBean = processBizlet.preExecute(ImplicitActionName.New, processBean, null, webContext);
-			    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processBean);
+			    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processBean);
 						}
 						internalCustomer.interceptAfterPreExecute(ImplicitActionName.New, processBean, null, webContext);
 					}
@@ -532,9 +537,9 @@ public class SmartClientEditServlet extends HttpServlet {
 					boolean vetoed = internalCustomer.interceptBeforePreRerender(source, processBean, webContext);
 					if (! vetoed) {
 						if (processBizlet != null) {
-							if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processBean + ", " + webContext);
+							if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processBean + ", " + webContext);
 			    			processBizlet.preRerender(source, processBean, webContext);
-			    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processBean);
+			    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processBean);
 						}
 						internalCustomer.interceptAfterPreRerender(source, processBean, webContext);
 					}
@@ -559,9 +564,9 @@ public class SmartClientEditServlet extends HttpServlet {
 					boolean vetoed = internalCustomer.interceptBeforePreExecute(ImplicitActionName.Edit, processBean, null, webContext);
 					if (! vetoed) {
 						if (processBizlet != null) {
-							if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Entering " + processBizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Edit + ", " + processBean + ", null, " + webContext);
+							if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Edit + ", " + processBean + ", null, " + webContext);
 			    			processBean = processBizlet.preExecute(ImplicitActionName.Edit, processBean, null, webContext);
-			    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processBean);
+			    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processBean);
 						}
 						internalCustomer.interceptAfterPreExecute(ImplicitActionName.Edit, processBean, null, webContext);
 					}
@@ -570,9 +575,9 @@ public class SmartClientEditServlet extends HttpServlet {
 					boolean vetoed = internalCustomer.interceptBeforePreRerender(source, processBean, webContext);
 					if (! vetoed) {
 						if (processBizlet != null) {
-							if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processBean + ", " + webContext);
+							if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processBean + ", " + webContext);
 			    			processBizlet.preRerender(source, processBean, webContext);
-			    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processBean);
+			    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processBean);
 						}
 						internalCustomer.interceptAfterPreRerender(source, processBean, webContext);
 					}
@@ -622,9 +627,9 @@ public class SmartClientEditServlet extends HttpServlet {
 					boolean vetoed = internalCustomer.interceptBeforePreExecute(ImplicitActionName.Add, processBean, parentBean, webContext);
 					if (! vetoed) {
 						if (processBizlet != null) {
-							if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Entering " + processBizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Add + ", " + processBean + ", " + parentBean + ", " + webContext);
+							if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Add + ", " + processBean + ", " + parentBean + ", " + webContext);
 			    			processBean = processBizlet.preExecute(ImplicitActionName.Add, processBean, parentBean, webContext);
-			    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processBean);
+			    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processBean);
 						}
 						internalCustomer.interceptAfterPreExecute(ImplicitActionName.Add, processBean, parentBean, webContext);
 
@@ -649,9 +654,9 @@ public class SmartClientEditServlet extends HttpServlet {
 			    		}
 
 			    		if (processBizlet != null) {
-							if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processBean + ", " + webContext);
+							if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processBean + ", " + webContext);
 			    			processBizlet.preRerender(source, processBean, webContext);
-			    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processBean);
+			    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processBean);
 						}
 						internalCustomer.interceptAfterPreRerender(source, processBean, webContext);
 					}
@@ -681,9 +686,9 @@ public class SmartClientEditServlet extends HttpServlet {
 					boolean vetoed = internalCustomer.interceptBeforePreExecute(ImplicitActionName.Edit, processBean, parentBean, webContext);
 					if (! vetoed) {
 						if (processBizlet != null) {
-							if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Entering " + processBizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Edit + ", " + processBean + ", " + parentBean + ", " + webContext);
+							if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Edit + ", " + processBean + ", " + parentBean + ", " + webContext);
 			    			processBean = processBizlet.preExecute(ImplicitActionName.Edit, processBean, parentBean, webContext);
-			    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processBean);
+			    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processBean);
 						}
 						internalCustomer.interceptAfterPreExecute(ImplicitActionName.Edit, processBean, parentBean, webContext);
 					}
@@ -692,9 +697,9 @@ public class SmartClientEditServlet extends HttpServlet {
 					boolean vetoed = internalCustomer.interceptBeforePreRerender(source, processBean, webContext);
 					if (! vetoed) {
 		    			if (processBizlet != null) {
-							if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processBean + ", " + webContext);
+							if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processBean + ", " + webContext);
 			    			processBizlet.preRerender(source, processBean, webContext);
-			    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processBean);
+			    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processBean);
 		    			}
 						internalCustomer.interceptAfterPreRerender(source, processBean, webContext);
 					}
@@ -964,24 +969,24 @@ public class SmartClientEditServlet extends HttpServlet {
 				boolean vetoed = internalCustomer.interceptBeforePreRerender(source, processedBean, webContext);
 				if (! vetoed) {
 					if (processBizlet != null) {
-						if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processedBean + ", " + webContext);
+						if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preRerender: " + source + ", " + processedBean + ", " + webContext);
 						processBizlet.preRerender(source, processedBean, webContext);
-						if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preRerender", "Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processedBean);
+						if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preRerender: " + processedBean);
 					}
 					internalCustomer.interceptAfterPreRerender(source, processedBean, webContext);
 				}
 			}
 		}
 		else { // an implicit action
-			UtilImpl.LOGGER.info("PRE-EXECUTE on " + implicitAction);
+			LOGGER.info("PRE-EXECUTE on " + implicitAction);
 
 			// Process pre-execute
 			boolean vetoed = internalCustomer.interceptBeforePreExecute(implicitAction, processedBean, null, webContext);
 			if (! vetoed) {
 				if (processBizlet != null) {
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Entering " + processBizlet.getClass().getName() + ".preExecute: " + implicitAction + ", " + processedBean + ", null, " + webContext);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + processBizlet.getClass().getName() + ".preExecute: " + implicitAction + ", " + processedBean + ", null, " + webContext);
 					processedBean = processBizlet.preExecute(implicitAction, processedBean, null, webContext);
-					if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, processBizlet.getClass().getName(), "preExecute", "Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processedBean);
+					if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + processBizlet.getClass().getName() + ".preExecute: " + processedBean);
 				}
 				internalCustomer.interceptAfterPreExecute(implicitAction, processedBean, null, webContext);
 			}
@@ -1149,7 +1154,7 @@ public class SmartClientEditServlet extends HttpServlet {
 		}
 		
 		// Run preExecute after the copy is taken, in case we rollback
-		UtilImpl.LOGGER.info("PRE-EXECUTE on " + ImplicitActionName.Delete);
+		LOGGER.info("PRE-EXECUTE on " + ImplicitActionName.Delete);
 		CustomerImpl internalCustomer = (CustomerImpl) customer;
 		boolean vetoed = internalCustomer.interceptBeforePreExecute(ImplicitActionName.Delete, 
 																		persistentBeanToDelete, 
@@ -1157,12 +1162,12 @@ public class SmartClientEditServlet extends HttpServlet {
 																		webContext);
 		if (! vetoed) {
 			if (bizlet != null) {
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Delete + ", " + persistentBeanToDelete + ", null, " + webContext);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".preExecute: " + ImplicitActionName.Delete + ", " + persistentBeanToDelete + ", null, " + webContext);
 				persistentBeanToDelete = bizlet.preExecute(ImplicitActionName.Delete, 
 															persistentBeanToDelete, 
 															null,
 															webContext);
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "preExecute", "Exiting " + bizlet.getClass().getName() + ".preExecute: " + persistentBeanToDelete);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".preExecute: " + persistentBeanToDelete);
 			}
 			internalCustomer.interceptAfterPreExecute(ImplicitActionName.Delete, 
 														persistentBeanToDelete, 
@@ -1186,9 +1191,9 @@ public class SmartClientEditServlet extends HttpServlet {
 		boolean vetoed = internalCustomer.interceptBeforePostRender(bean, webContext);
 		if (! vetoed) {
 			if (bizlet != null) {
-				if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "postRender", "Entering " + bizlet.getClass().getName() + ".postRender: " + bean + ", " + webContext);
+				if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Entering " + bizlet.getClass().getName() + ".postRender: " + bean + ", " + webContext);
     			bizlet.postRender(bean, webContext);
-    			if (UtilImpl.BIZLET_TRACE) UtilImpl.LOGGER.logp(Level.INFO, bizlet.getClass().getName(), "postRender", "Exiting " + bizlet.getClass().getName() + ".postRender: " + bean + ", " + webContext);
+    			if (UtilImpl.BIZLET_TRACE) BIZLET_LOGGER.info("Exiting " + bizlet.getClass().getName() + ".postRender: " + bean + ", " + webContext);
 			}
 			internalCustomer.interceptAfterPostRender(bean, webContext);
 		}

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientGeneratorServlet.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientGeneratorServlet.java
@@ -10,7 +10,6 @@ import org.skyve.domain.messages.DomainException;
 import org.skyve.domain.messages.MessageException;
 import org.skyve.domain.messages.SessionEndedException;
 import org.skyve.impl.persistence.AbstractPersistence;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.AbstractWebContext;
 import org.skyve.impl.web.UserAgent;
 import org.skyve.impl.web.WebUtil;
@@ -25,6 +24,8 @@ import org.skyve.metadata.view.View;
 import org.skyve.metadata.view.View.ViewType;
 import org.skyve.util.OWASP;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
@@ -37,6 +38,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class SmartClientGeneratorServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SmartClientGeneratorServlet.class);
 
 	private static Class<? extends SmartClientViewRenderer> RENDERER_CLASS = null;
 	
@@ -73,7 +76,7 @@ public class SmartClientGeneratorServlet extends HttpServlet {
 	protected void doGet(HttpServletRequest request,
 							HttpServletResponse response)
 	throws ServletException, IOException {
-		UtilImpl.LOGGER.info("SmartClient Generate - get....");
+		LOGGER.info("SmartClient Generate - get....");
 		processRequest(request, response);
 	}
 
@@ -109,7 +112,7 @@ public class SmartClientGeneratorServlet extends HttpServlet {
 
 				UxUi uxui = UserAgent.getUxUi(request);
 				String uxuiName = uxui.getName();
-				UtilImpl.LOGGER.info("UX/UI = " + uxuiName);
+				LOGGER.info("UX/UI = " + uxuiName);
 
 				EXT.checkAccess(user, UserAccess.singular(moduleName, documentName), uxuiName);
 

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientListServlet.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientListServlet.java
@@ -72,7 +72,10 @@ import org.skyve.util.Binder.TargetMetaData;
 import org.skyve.util.JSON;
 import org.skyve.util.OWASP;
 import org.skyve.util.Util;
+import org.skyve.util.logging.Category;
 import org.skyve.web.SortParameter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -85,7 +88,10 @@ import jakarta.servlet.http.HttpSession;
  */
 public class SmartClientListServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
-	
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SmartClientListServlet.class);
+    private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
+
 	static final String ISC_META_DATA_PREFIX = "isc_metaDataPrefix";
 	static final String ISC_DATA_FORMAT = "isc_dataFormat";
 	static final String OLD_VALUES = "_oldValues";
@@ -96,14 +102,14 @@ public class SmartClientListServlet extends HttpServlet {
 	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) 
 	throws ServletException, IOException {
-		UtilImpl.LOGGER.info("SmartClientList - get....");
+		LOGGER.info("SmartClientList - get....");
 		processRequest(request, response);
 	}
 	
 	@Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) 
 	throws ServletException, IOException {
-		UtilImpl.LOGGER.info("SmartClientList - post....");
+		LOGGER.info("SmartClientList - post....");
 		processRequest(request, response);
 	}
 	
@@ -146,7 +152,7 @@ public class SmartClientListServlet extends HttpServlet {
 					AbstractWebContext webContext = StateUtil.getCachedConversation(webId, request);
 					if (webContext != null) {
 						if (request.getParameter(AbstractWebContext.CONTINUE_CONVERSATION) != null) {
-				        	UtilImpl.LOGGER.info("USE VIEW CONVERSATION!!!!");
+				        	LOGGER.info("USE VIEW CONVERSATION!!!!");
 				            persistence = webContext.getConversation();
 				            persistence.setForThread();
 						}
@@ -262,7 +268,7 @@ public class SmartClientListServlet extends HttpServlet {
 						}
 					}
 					for (String name : parameters.keySet()) {
-						UtilImpl.LOGGER.info(name + " = " + parameters.get(name));
+						LOGGER.info(name + " = " + parameters.get(name));
 					}
 
 					String tagId = OWASP.sanitise(Sanitisation.text, Util.processStringValue(request.getParameter("_tagId")));
@@ -459,7 +465,7 @@ public class SmartClientListServlet extends HttpServlet {
 			beans.add(summaryBean);
 		}
 		long totalRows = page.getTotalRows();
-		if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info(String.format("totalRows = %d, row size = %d", 
+		if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(String.format("totalRows = %d, row size = %d", 
 																		Long.valueOf(page.getTotalRows()), 
 																		Integer.valueOf(page.getRows().size())));
 
@@ -901,7 +907,7 @@ public class SmartClientListServlet extends HttpServlet {
 		if (criteria != null) {
 			boolean firstCriteriaIteration = true; // the first filter criteria encountered - not a bound parameter
 			for (Map<String, Object> criterion : criteria) {
-				if (UtilImpl.COMMAND_TRACE) UtilImpl.LOGGER.info("criterion = " + JSON.marshall(criterion));
+				if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info("criterion = " + JSON.marshall(criterion));
 				String binding = ((String) criterion.get("fieldName"));
 				binding = BindUtil.unsanitiseBinding(binding);
 				SmartClientFilterOperator filterOperator = SmartClientFilterOperator.valueOf((String) criterion.get("operator"));
@@ -1290,7 +1296,7 @@ public class SmartClientListServlet extends HttpServlet {
 					result = BindUtil.fromString(customer, converter, type, valueString);
 				}
 				catch (Exception e1) {
-					Util.LOGGER.warning("Could not format " + valueString + " as type " + type + " with converter " + converter + ". See the following stack traces below");
+					LOGGER.warn("Could not format {} as type {} with converter {}. See the following stack traces below", valueString, type, converter, e1);
 					e.printStackTrace();
 					e1.printStackTrace();
 					if (valueBinding == null) {

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientTextSearchServlet.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientTextSearchServlet.java
@@ -18,7 +18,6 @@ import org.skyve.domain.PersistentBean;
 import org.skyve.domain.messages.SecurityException;
 import org.skyve.domain.messages.SessionEndedException;
 import org.skyve.impl.persistence.AbstractPersistence;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.WebUtil;
 import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.document.Document;
@@ -26,6 +25,8 @@ import org.skyve.metadata.module.Module;
 import org.skyve.metadata.user.User;
 import org.skyve.util.JSON;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -35,6 +36,8 @@ import jakarta.servlet.http.HttpServletResponse;
 public class SmartClientTextSearchServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(SmartClientTextSearchServlet.class);
+
 	@Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) 
 	throws ServletException, IOException {
@@ -42,7 +45,7 @@ public class SmartClientTextSearchServlet extends HttpServlet {
 		while (parameterNames.hasMoreElements()) {
 			String name = parameterNames.nextElement();
 			String value = request.getParameter(name);
-			UtilImpl.LOGGER.info(name + " = " + value);
+			LOGGER.info(name + " = " + value);
 		}
 
 		String criteria = request.getParameter("query");

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientViewRenderer.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/SmartClientViewRenderer.java
@@ -156,7 +156,7 @@ public class SmartClientViewRenderer extends ViewRenderer {
 
 	@Override
 	public void renderView(String icon16x16Url, String icon32x32Url) {
-		UtilImpl.LOGGER.info("VIEW = " + view.getTitle() + " for " + document.getName());
+		LOGGER.info("VIEW = " + view.getTitle() + " for " + document.getName());
 		Sidebar sidebar = view.getSidebar();
 		if (noCreateView) {
 			if (sidebar == null) {

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/ViewJSONManipulator.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/smartclient/ViewJSONManipulator.java
@@ -368,9 +368,9 @@ public class ViewJSONManipulator extends ViewVisitor {
 			}
 			else {
 				if (value == null) {
-					UtilImpl.LOGGER.warning(String.format("Careful - the value of binding %s for %s yields null",
+					LOGGER.warn("Careful - the value of binding {} for {} yields null",
 															bindingPrefix, 
-															bean));
+															bean);
 				}
 				else {
 					Bean currentBean = (Bean) value;
@@ -720,7 +720,7 @@ public class ViewJSONManipulator extends ViewVisitor {
 		}
 		catch (MetaDataException e) {
 			// do nothing useful as the binding isn't an attribute
-			UtilImpl.LOGGER.warning(e.toString());
+			LOGGER.warn(e.toString());
 		}
 	}
 	

--- a/skyve-web/src/main/java/org/skyve/impl/web/spring/SecurityListener.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/spring/SecurityListener.java
@@ -14,6 +14,8 @@ import org.skyve.impl.util.TimeUtil;
 import org.skyve.impl.util.UUIDv7;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.MetaDataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
@@ -21,11 +23,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class SecurityListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityListener.class);
+
 	@EventListener
 	@SuppressWarnings("static-method")
 	public void onAuthenticationFailure(AuthenticationFailureBadCredentialsEvent evt) {
 		String userName = SkyveSpringSecurity.userNameFromPrincipal(evt.getAuthentication().getPrincipal());
-		UtilImpl.LOGGER.warning("Login Attempt failed for user " + userName);
+		LOGGER.warn("Login Attempt failed for user " + userName);
 		if (userName != null) {
 			recordLoginFailure(userName);
 		}
@@ -36,9 +41,9 @@ public class SecurityListener {
 	public void onAuthenticationSuccess(AuthenticationSuccessEvent evt) {
 		String userName = SkyveSpringSecurity.userNameFromPrincipal(evt.getAuthentication().getPrincipal());
 		if (userName == null) {
-			UtilImpl.LOGGER.warning("Cannot reset login failures in org.skyve.impl.web.spring.SecurityListener.onAuthenticationSuccess() as the principal type is not known. If you are using a Spring Security plugin, please override this class in your project and handle the principal yourself.");
+			LOGGER.warn("Cannot reset login failures in org.skyve.impl.web.spring.SecurityListener.onAuthenticationSuccess() as the principal type is not known. If you are using a Spring Security plugin, please override this class in your project and handle the principal yourself.");
 		}
-		UtilImpl.LOGGER.info("Login Attempt succeeded for user " + userName);
+		LOGGER.info("Login Attempt succeeded for user " + userName);
 		if (userName != null) {
 			resetLoginFailure(userName);
 		}
@@ -61,7 +66,7 @@ public class SecurityListener {
 			sql = "update ADM_SecurityUser set authenticationFailures = coalesce(authenticationFailures, 0) + 1, lastAuthenticationFailure = ? where bizId = ?";
 		}
 		else {
-			UtilImpl.LOGGER.warning("Login Failure for " + username + " was not recorded because " + rdbms + " is not suported in SecurityListener");
+			LOGGER.warn("Login Failure for " + username + " was not recorded because " + rdbms + " is not suported in SecurityListener");
 			return;
 		}
 

--- a/skyve-web/src/main/java/org/skyve/impl/web/spring/SkyveAuthenticationSuccessHandler.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/spring/SkyveAuthenticationSuccessHandler.java
@@ -3,8 +3,9 @@ package org.skyve.impl.web.spring;
 import java.io.IOException;
 
 import org.skyve.impl.util.TwoFactorAuthConfigurationSingleton;
-import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
@@ -25,6 +26,9 @@ import jakarta.servlet.http.HttpServletResponse;
  * @author mike
  */
 public class SkyveAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkyveAuthenticationSuccessHandler.class);
+
 	private UserDetailsManager userDetailsManager;
 	
 	public SkyveAuthenticationSuccessHandler(UserDetailsManager userDetailsManager) {
@@ -45,7 +49,7 @@ public class SkyveAuthenticationSuccessHandler extends SavedRequestAwareAuthenti
 		if (savedRequest != null) {
 			redirectUrl = savedRequest.getRedirectUrl();
 			if (redirectUrl != null) {
-				UtilImpl.LOGGER.info("Redirect after login requested to " + redirectUrl);
+				LOGGER.info("Redirect after login requested to " + redirectUrl);
 				// its http behind proxy server terminating TLS or some other edge case
 				if (Util.isSecureUrl() && redirectUrl.startsWith("http://")) { // could be https:// or ws:// or wss://
 					if (savedRequest instanceof DefaultSavedRequest) {
@@ -94,7 +98,7 @@ public class SkyveAuthenticationSuccessHandler extends SavedRequestAwareAuthenti
 			}
 		}
 		
-		UtilImpl.LOGGER.info("Redirected to " + redirectUrl);
+		LOGGER.info("Redirected to " + redirectUrl);
 		requestCache.removeRequest(request, response);
 		clearAuthenticationAttributes(request);
 		getRedirectStrategy().sendRedirect(request, response, redirectUrl);

--- a/skyve-web/src/main/java/org/skyve/impl/web/spring/SkyveSpringSecurity.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/spring/SkyveSpringSecurity.java
@@ -9,7 +9,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
@@ -26,6 +25,8 @@ import org.skyve.impl.util.TwoFactorAuthCustomerConfiguration;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.SecurityUtil;
 import org.skyve.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
@@ -50,7 +51,9 @@ import org.springframework.security.web.authentication.rememberme.PersistentToke
 
 public class SkyveSpringSecurity {
 	public static final String LOGIN_ATTEMPT_PATH = "/loginAttempt";
-	
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkyveSpringSecurity.class);
+
 	@SuppressWarnings("static-method")
 	public PasswordEncoder passwordEncoder() {
 		return SecurityUtil.createDelegatingPasswordEncoder();
@@ -87,7 +90,7 @@ public class SkyveSpringSecurity {
 						}
 						
 						@Override
-						public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+						public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
 							return null;
 						}
 						
@@ -293,7 +296,7 @@ public class SkyveSpringSecurity {
 												secondsRemaining++;
 											}
 											locked = true;
-											UtilImpl.LOGGER.warning("Account " + springUsername + " is locked for another " + secondsRemaining + " seconds");
+											LOGGER.warn("Account " + springUsername + " is locked for another " + secondsRemaining + " seconds");
 										}
 									}
 								}

--- a/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushEmailFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushEmailFilter.java
@@ -9,11 +9,15 @@ import org.skyve.EXT;
 import org.skyve.domain.messages.DomainException;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.util.Mail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.provisioning.UserDetailsManager;
 
 public class TwoFactorAuthPushEmailFilter extends TwoFactorAuthPushFilter {
 	private static final String TFA_CODE_KEY = "{tfaCode}"; 
-	
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TwoFactorAuthPushEmailFilter.class);
+
 	public static final String SYSTEM_TWO_FACTOR_CODE_SUBJECT = "Email verification security code";
 	public static final String SYSTEM_TWO_FACTOR_CODE_BODY = "Hi,<br />"
 			+ "Your verification code is: {tfaCode}<br />"
@@ -28,7 +32,7 @@ public class TwoFactorAuthPushEmailFilter extends TwoFactorAuthPushFilter {
 	protected void pushNotification(TwoFactorAuthUser user, String code) {
 		String emailAddress = user.getEmail();
 		if (emailAddress == null) {
-			UtilImpl.LOGGER.warning("No email found for user : " + user.getUsername()); 
+			LOGGER.warn("No email found for user : " + user.getUsername()); 
 			return;
 		}
 		


### PR DESCRIPTION
- Removed all references to Util/UtilImpl's LOGGER and replaced with
slf4j loggers with relevant categories.

Wherever the Util logger was used behind a "trace" flag (set via the
application config JSON) or the Instrumentation control panel the
logger category has been replaced by a shared category which reflects
the trace flag. See org.skyve.util.logging.Category.

Everywhere else the logger categories have been replaced updated to
match the class name of the class doing the logging.