### PR TITLE
Updated sensitivity obfuscation to handle short strings

### DIFF
--- a/skyve-ext/src/main/java/org/skyve/impl/backup/BackupField.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/BackupField.java
@@ -10,8 +10,8 @@ import org.skyve.metadata.model.Attribute.Sensitivity;
  */
 public class BackupField {
 
-	public AttributeType attributeType;
-	public Sensitivity sensitivity;
+	private final AttributeType attributeType;
+	private Sensitivity sensitivity;
 
 	/**
 	 * Constructs a new {@code BackupField} with the specified attribute type and sensitivity.
@@ -26,10 +26,6 @@ public class BackupField {
 
 	public AttributeType getAttributeType() {
 		return attributeType;
-	}
-
-	public void setAttributeType(AttributeType attributeType) {
-		this.attributeType = attributeType;
 	}
 
 	public Sensitivity getSensitivity() {

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/BackupField.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/BackupField.java
@@ -1,0 +1,42 @@
+package org.skyve.impl.backup;
+
+import org.skyve.metadata.model.Attribute.AttributeType;
+import org.skyve.metadata.model.Attribute.Sensitivity;
+
+/**
+ * Represents a field in the backup process, storing metadata about an attribute's type and sensitivity level.
+ * 
+ * @author simeonsolomou
+ */
+public class BackupField {
+
+	public AttributeType attributeType;
+	public Sensitivity sensitivity;
+
+	/**
+	 * Constructs a new {@code BackupField} with the specified attribute type and sensitivity.
+	 *
+	 * @param attributeType - the type of the attribute.
+	 * @param sensitivity - the sensitivity level of the attribute.
+	 */
+	public BackupField(AttributeType attributeType, Sensitivity sensitivity) {
+		this.attributeType = attributeType;
+		this.sensitivity = sensitivity;
+	}
+
+	public AttributeType getAttributeType() {
+		return attributeType;
+	}
+
+	public void setAttributeType(AttributeType attributeType) {
+		this.attributeType = attributeType;
+	}
+
+	public Sensitivity getSensitivity() {
+		return sensitivity;
+	}
+
+	public void setSensitivity(Sensitivity sensitivity) {
+		this.sensitivity = sensitivity;
+	}
+}

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/BackupJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/BackupJob.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.WKTWriter;
@@ -160,9 +159,9 @@ public class BackupJob extends CancellableJob {
 														values.clear();
 	
 														for (String name : table.fields.keySet()) {
-															Pair<AttributeType, Sensitivity> field = table.fields.get(name);
-															AttributeType attributeType = field.getLeft();
-															Sensitivity sensitivity = field.getRight();
+															BackupField field = table.fields.get(name);
+															AttributeType attributeType = field.getAttributeType();
+															Sensitivity sensitivity = field.getSensitivity();
 															boolean redact = (sensitivityLevel > 0) && (sensitivity.ordinal() >= sensitivityLevel);
 															Object value = null;
 	
@@ -210,7 +209,11 @@ public class BackupJob extends CancellableJob {
 																// Respect sensitivity
 																if (redact) {
 																	// Redact value
-																	value = BackupUtil.redactData(attributeType, value);
+																	if (field instanceof BackupLengthField lengthField) {
+																		value = BackupUtil.redactData(attributeType, value, lengthField.getMaxLength());
+																	} else {
+																		value = BackupUtil.redactData(attributeType, value);
+																	}
 																}
 															}
 															else if (AttributeType.geometry.equals(attributeType)) {

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/BackupLengthField.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/BackupLengthField.java
@@ -1,0 +1,35 @@
+package org.skyve.impl.backup;
+
+import org.skyve.metadata.model.Attribute.AttributeType;
+import org.skyve.metadata.model.Attribute.Sensitivity;
+
+/**
+ * Represents a length field in the backup process, storing metadata about an attribute's type, sensitivity level and maximum length.
+ * 
+ * @author simeonsolomou
+ */
+public class BackupLengthField extends BackupField {
+
+	public Integer maxLength;
+
+	/**
+	 * Constructs a new {@code BackupField} with the specified attribute type, sensitivity and maximum length.
+	 *
+	 * @param attributeType - the type of the attribute.
+	 * @param sensitivity - the sensitivity level of the attribute.
+	 * @param maxLength - the maximum length of the attribute.
+	 */
+	public BackupLengthField(AttributeType attributeType, Sensitivity sensitivity, Integer maxLength) {
+		super(attributeType, sensitivity);
+
+		this.maxLength = maxLength;
+	}
+
+	public Integer getMaxLength() {
+		return maxLength;
+	}
+
+	public void setMaxLength(Integer maxLength) {
+		this.maxLength = maxLength;
+	}
+}

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/BackupLengthField.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/BackupLengthField.java
@@ -13,7 +13,7 @@ public class BackupLengthField extends BackupField {
 	public Integer maxLength;
 
 	/**
-	 * Constructs a new {@code BackupField} with the specified attribute type, sensitivity and maximum length.
+	 * Constructs a new {@code BackupLengthField} with the specified attribute type, sensitivity and maximum length.
 	 *
 	 * @param attributeType - the type of the attribute.
 	 * @param sensitivity - the sensitivity level of the attribute.

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/BackupLengthField.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/BackupLengthField.java
@@ -10,7 +10,7 @@ import org.skyve.metadata.model.Attribute.Sensitivity;
  */
 public class BackupLengthField extends BackupField {
 
-	public Integer maxLength;
+	private final Integer maxLength;
 
 	/**
 	 * Constructs a new {@code BackupLengthField} with the specified attribute type, sensitivity and maximum length.
@@ -27,9 +27,5 @@ public class BackupLengthField extends BackupField {
 
 	public Integer getMaxLength() {
 		return maxLength;
-	}
-
-	public void setMaxLength(Integer maxLength) {
-		this.maxLength = maxLength;
 	}
 }

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/ContentChecker.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/ContentChecker.java
@@ -68,7 +68,7 @@ public class ContentChecker {
 
 							while (resultSet.next()) {
 								for (String name : table.fields.keySet()) {
-									AttributeType attributeType = table.fields.get(name).getLeft();
+									AttributeType attributeType = table.fields.get(name).getAttributeType();
 									if (AttributeType.content.equals(attributeType) || AttributeType.image.equals(attributeType)) {
 										String stringValue = resultSet.getString(name);
 										if (! resultSet.wasNull()) {
@@ -225,7 +225,7 @@ public class ContentChecker {
 			sql.setLength(0);
 
 			for (String name : table.fields.keySet()) {
-				AttributeType attributeType = table.fields.get(name).getLeft();
+				AttributeType attributeType = table.fields.get(name).getAttributeType();
 				if (AttributeType.content.equals(attributeType) || AttributeType.image.equals(attributeType)) {
 					if (sql.length() == 0) {
 						sql.append("select bizId from ").append(table.persistentIdentifier).append(" where ");
@@ -279,7 +279,7 @@ public class ContentChecker {
 	
 	private static boolean hasContent(@Nonnull Table table) {
 		for (String name : table.fields.keySet()) {
-			AttributeType attributeType = table.fields.get(name).getLeft();
+			AttributeType attributeType = table.fields.get(name).getAttributeType();
 			if (AttributeType.content.equals(attributeType) || AttributeType.image.equals(attributeType)) {
 				return true;
 			}

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/ReindexAttachmentsJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/ReindexAttachmentsJob.java
@@ -68,7 +68,7 @@ public class ReindexAttachmentsJob extends CancellableJob {
 									return;
 								}
 								for (String name : table.fields.keySet()) {
-									AttributeType attributeType = table.fields.get(name).getLeft();
+									AttributeType attributeType = table.fields.get(name).getAttributeType();
 									if (AttributeType.content.equals(attributeType) ||
 											AttributeType.image.equals(attributeType)) {
 										String stringValue = resultSet.getString(name);
@@ -115,7 +115,7 @@ public class ReindexAttachmentsJob extends CancellableJob {
 	
 	private static boolean hasContent(Table table) {
 		for (String name : table.fields.keySet()) {
-			AttributeType attributeType = table.fields.get(name).getLeft();
+			AttributeType attributeType = table.fields.get(name).getAttributeType();
 			if (AttributeType.content.equals(attributeType) ||
 					AttributeType.image.equals(attributeType)) {
 				return true;

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/RestoreJob.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/RestoreJob.java
@@ -18,7 +18,6 @@ import java.sql.Types;
 import java.util.Collection;
 import java.util.Map;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.WKTReader;
 import org.skyve.CORE;
@@ -39,7 +38,6 @@ import org.skyve.impl.persistence.hibernate.dialect.SkyveDialect;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.job.CancellableJob;
 import org.skyve.metadata.model.Attribute.AttributeType;
-import org.skyve.metadata.model.Attribute.Sensitivity;
 import org.skyve.util.FileUtil;
 import org.skyve.util.PushMessage;
 import org.skyve.util.Util;
@@ -329,8 +327,8 @@ public class RestoreJob extends CancellableJob {
 										continue;
 									}
 
-									Pair<AttributeType, Sensitivity> field = table.fields.get(header);
-									AttributeType attributeType = (field == null) ? null : field.getLeft();
+									BackupField field = table.fields.get(header);
+									AttributeType attributeType = (field == null) ? null : field.getAttributeType();
 
 									// foreign keys
 									if (header.endsWith("_id")) {

--- a/skyve-ext/src/main/java/org/skyve/impl/backup/Table.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/backup/Table.java
@@ -6,15 +6,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.MutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.skyve.domain.Bean;
 import org.skyve.domain.ChildBean;
 import org.skyve.domain.HierarchicalBean;
 import org.skyve.domain.PersistentBean;
 import org.skyve.impl.metadata.model.document.field.Field;
 import org.skyve.impl.metadata.model.document.field.Field.IndexType;
+import org.skyve.impl.metadata.model.document.field.LengthField;
 import org.skyve.impl.metadata.repository.ProvidedRepositoryFactory;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.customer.Customer;
@@ -32,15 +30,15 @@ import org.skyve.util.logging.Category;
 import org.slf4j.Logger;
 
 class Table {
-	static final ImmutablePair<AttributeType, Sensitivity> TEXT = ImmutablePair.of(AttributeType.text, Sensitivity.none);
-	static final ImmutablePair<AttributeType, Sensitivity> ASSOCIATION = ImmutablePair.of(AttributeType.association, Sensitivity.none);
-	static final ImmutablePair<AttributeType, Sensitivity> INTEGER = ImmutablePair.of(AttributeType.integer, Sensitivity.none);
+	static final BackupField TEXT = new BackupField(AttributeType.text, Sensitivity.none);
+	static final BackupField ASSOCIATION = new BackupField(AttributeType.association, Sensitivity.none);
+	static final BackupField INTEGER = new BackupField(AttributeType.integer, Sensitivity.none);
 
     private static final Logger COMMAND_LOGGER = Category.COMMAND.logger();
 
 	String agnosticIdentifier;
 	String persistentIdentifier;
-	LinkedHashMap<String, Pair<AttributeType, Sensitivity>> fields = new LinkedHashMap<>();
+	LinkedHashMap<String, BackupField> fields = new LinkedHashMap<>();
 	TreeMap<String, IndexType> indexes = new TreeMap<>();
 	
 	Table(String agnosticIdentifier, String persistentIdentifier) {
@@ -86,7 +84,7 @@ class Table {
 				fields.put(Bean.BIZ_KEY, TEXT);
 			}
 			else {
-				fields.put(Bean.BIZ_KEY, ImmutablePair.of(AttributeType.text, sensitivity));
+				fields.put(Bean.BIZ_KEY, new BackupField(AttributeType.text, sensitivity));
 			}
 			fields.put(Bean.CUSTOMER_NAME, TEXT);
 			fields.put(PersistentBean.FLAG_COMMENT_NAME, TEXT);
@@ -130,7 +128,7 @@ class Table {
 								fields.put(attributeName + "_type", TEXT);
 							}
 							
-							fields.put(attributeName + "_id", ImmutablePair.of(attributeType, Sensitivity.none));
+							fields.put(attributeName + "_id", new BackupField(attributeType, Sensitivity.none));
 							if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(agnosticIdentifier + " - Put " + attributeName + "_id -> " + attributeType);
 						}
 					}
@@ -155,15 +153,22 @@ class Table {
 						}
 
 						// Either add the field, or upgrade its sensitivity value as appropriate
-						Pair<AttributeType, Sensitivity> pair = fields.get(fieldName);
-						if (pair == null) {
-							fields.put(fieldName, MutablePair.of(attributeType, sensitivity));
+						BackupField field = fields.get(fieldName);
+						if (field == null) {
+							// If a length field, record the maximum length
+							if (attribute instanceof LengthField lengthField) {
+								Integer maxLength = Integer.valueOf(lengthField.getLength());
+								fields.put(fieldName, new BackupLengthField(attributeType, sensitivity, maxLength));
+							} else {
+								fields.put(fieldName, new BackupField(attributeType, sensitivity));
+							}
+
 							if (UtilImpl.COMMAND_TRACE) COMMAND_LOGGER.info(agnosticIdentifier + " - Put " + fieldName + " -> " + attributeType);
 						}
 						else {
-							Sensitivity existing = pair.getRight();
+							Sensitivity existing = field.getSensitivity();
 							if (sensitivity.ordinal() > existing.ordinal()) {
-								pair.setValue(sensitivity);
+								field.setSensitivity(sensitivity);
 							}
 						}
 					}
@@ -177,10 +182,10 @@ class Table {
 		result.put("name", agnosticIdentifier);
 		List<Map<String, Object>> fieldList = new ArrayList<>(fields.size());
 		for (String key : fields.keySet()) {
-			Pair<AttributeType, Sensitivity> pair = fields.get(key);
+			BackupField backupField = fields.get(key);
 			Map<String, Object> field = new TreeMap<>();
 			// Ignore data sensitivity in fields as this is just for restore
-			field.put(key, pair.getLeft());
+			field.put(key, backupField.getAttributeType());
 			fieldList.add(field);
 		}
 		result.put("fields", fieldList);
@@ -219,7 +224,7 @@ class Table {
 		for (Map<String, Object> field : fieldList) {
 			for (String key : field.keySet()) {
 				// Ignore data sensitivity in fields as this is just for restore
-				result.fields.put(key, ImmutablePair.of(AttributeType.valueOf((String) field.get(key)), Sensitivity.none));
+				result.fields.put(key, new BackupField(AttributeType.valueOf((String) field.get(key)), Sensitivity.none));
 			}
 		}
 		

--- a/skyve-ext/src/test/java/org/skyve/impl/backup/BackupUtilTest.java
+++ b/skyve-ext/src/test/java/org/skyve/impl/backup/BackupUtilTest.java
@@ -22,7 +22,7 @@ import org.skyve.metadata.model.Attribute.AttributeType;
 public class BackupUtilTest {
 	@Test
 	@SuppressWarnings("static-method")
-	public void testRedactSensitiveData() {
+	public void testRedactSegment() {
 		// setup the test data
 		String input1 = "Client 1",
 				input2 = "Cli2",
@@ -32,7 +32,11 @@ public class BackupUtilTest {
 				input6 = "",
 				input7 = null,
 				input8 = "Really long client name",
-				input9 = "client1@email.org";
+				input9 = "client1@email.org",
+				input10 = "Cli2",
+				input11 = "Cl3",
+				input12 = "C4",
+				input13 = "C";
 
 		// call the method under test
 		String result1 = (String) redactData(AttributeType.text, input1);
@@ -44,17 +48,25 @@ public class BackupUtilTest {
 		String result7 = (String) redactData(AttributeType.memo, input7);
 		String result8 = (String) redactData(AttributeType.id, input8);
 		String result9 = (String) redactData(AttributeType.text, input9);
+		String result10 = (String) redactData(AttributeType.text, input10, Integer.valueOf(4));
+		String result11 = (String) redactData(AttributeType.text, input11, Integer.valueOf(4));
+		String result12 = (String) redactData(AttributeType.text, input12, Integer.valueOf(3));
+		String result13 = (String) redactData(AttributeType.text, input13, Integer.valueOf(2));
 		
 		// verify the result
 		assertThat(result1, is("Cl****1"));
-		assertThat(result2, is("C**2"));
-		assertThat(result3, is("C*3"));
-		assertThat(result4, is("C*"));
-		assertThat(result5, is("*"));
+		assertThat(result2, is("C****2"));
+		assertThat(result3, is("C****3"));
+		assertThat(result4, is("C****"));
+		assertThat(result5, is("****"));
 		assertThat(result6, is(""));
 		assertThat(result7, is(nullValue()));
 		assertThat(result8, is("Re**********me"));
-		assertThat(result9, is("cl***t1@em*****rg"));
+		assertThat(result9, is("cl****t1@em*****rg"));
+		assertThat(result10, is("C**2"));
+		assertThat(result11, is("C**3"));
+		assertThat(result12, is("C**"));
+		assertThat(result13, is("**"));
 	}
 	
 	@Test


### PR DESCRIPTION
[Trello](https://trello.com/c/W8dtzqQV)

**Notes**
I had to alter the field the object iterated in the BackupJob so that I had access to the maximum length.
Let me know if you have any questions regarding this.

**Changes**
- Updated `BackupUtil.redactSegment` to pad asterisks in shorter strings (considering max length)
- Changed `Table.fields` from `HashMap<String, Pair<AttributeType, Sensitivity>>` to `BackupField`/`BackupLengthField`