### PR TITLE
Security log configurations

### DIFF
--- a/skyve-core/src/main/java/org/skyve/impl/util/UtilImpl.java
+++ b/skyve-core/src/main/java/org/skyve/impl/util/UtilImpl.java
@@ -375,6 +375,15 @@ public class UtilImpl {
 	public static String BOOTSTRAP_EMAIL = null;
 	public static String BOOTSTRAP_PASSWORD = null;
 	
+	// Security notifications configurations
+	public static String SECURITY_NOTIFICATIONS_EMAIL_ADDRESS = null;
+	public static boolean DISABLE_GEO_IP_BLOCK_NOTIFICATIONS = false;
+	public static boolean DISABLE_PASSWORD_CHANGE_NOTIFICATIONS = false;
+	public static boolean DISABLE_DIFFERENT_COUNTRY_LOGIN_NOTIFICATIONS = false;
+	public static boolean DISABLE_IP_ADDRESS_CHANGE_NOTIFICATIONS = false;
+	public static boolean DISABLE_ACCESS_EXCEPTION_NOTIFICATIONS = false;
+	public static boolean DISABLE_SECURITY_EXCEPTION_NOTIFICATIONS = false;
+
 	public static boolean PRIMEFLEX = false;
 	
 	public static Set<String> TWO_FACTOR_AUTH_CUSTOMERS = null;

--- a/skyve-core/src/test/resources/json/skyve.json
+++ b/skyve-core/src/test/resources/json/skyve.json
@@ -254,5 +254,17 @@
 		"user": "admin",
 		"email": "admin@yourdomain.com",
 		"password": "admin"
-	}
+	},
+  	// Security Settings
+  	"security": {
+    	// Email address for security notifications
+    	"securityNotificationsEmail": "security@yourdomain.com",
+    	// Disable notifications for certain event types
+    	"disableGeoIPBlockNotifications": false,
+    	"disablePasswordChangeNotifications": false,
+    	"disableDifferentCountryLoginNotifications": false,
+    	"disableIPAddressChangeNotifications": false,
+    	"disableAccessExceptionNotifications": false,
+    	"disableSecurityExceptionNotifications": false
+  	}
 }

--- a/skyve-war/config/skyve.json
+++ b/skyve-war/config/skyve.json
@@ -399,5 +399,17 @@
 		"user": "admin",
 		"email": "admin@yourdomain.com",
 		"password": "admin"
-	}
+	},
+  	// Security Settings
+  	"security": {
+    	// Email address for security notifications
+    	"securityNotificationsEmail": "security@yourdomain.com",
+    	// Disable notifications for certain event types
+    	"disableGeoIPBlockNotifications": false,
+    	"disablePasswordChangeNotifications": false,
+    	"disableDifferentCountryLoginNotifications": false,
+    	"disableIPAddressChangeNotifications": false,
+    	"disableAccessExceptionNotifications": false,
+    	"disableSecurityExceptionNotifications": false
+  	}
 }

--- a/skyve-war/src/generated/java/modules/admin/domain/Configuration.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Configuration.java
@@ -1244,6 +1244,25 @@ public abstract class Configuration extends AbstractPersistentBean {
 	}
 
 	/**
+	 * True when IP address checks are enabled in startup.
+	 *
+	 * @return The condition
+	 */
+	@XmlTransient
+	public boolean isIpAddressChecksEnabled() {
+		return (getStartup().isIpAddressChecksEnabled());
+	}
+
+	/**
+	 * {@link #isIpAddressChecksEnabled} negation.
+	 *
+	 * @return The negated condition
+	 */
+	public boolean isNotIpAddressChecksEnabled() {
+		return (! isIpAddressChecksEnabled());
+	}
+
+	/**
 	 * True when the selected startup map type is Google Maps
 	 *
 	 * @return The condition

--- a/skyve-war/src/generated/java/modules/admin/domain/Startup.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Startup.java
@@ -29,9 +29,9 @@ import org.skyve.util.Util;
 		and is shown to the administrator by default on first login.
  * 
  * @depend - - - MapType
+ * @depend - - - BackupType
  * @depend - - - CaptchaType
  * @depend - - - GeoIPCountryListType
- * @depend - - - BackupType
  * @navhas n geoIPCountries 0..n Country
  * @stereotype "transient"
  */
@@ -94,12 +94,6 @@ public abstract class Startup extends AbstractTransientBean {
 	public static final String mailTestRecipientPropertyName = "mailTestRecipient";
 
 	/** @hidden */
-	public static final String checkForBreachedPasswordPropertyName = "checkForBreachedPassword";
-
-	/** @hidden */
-	public static final String captchaTypePropertyName = "captchaType";
-
-	/** @hidden */
 	public static final String apiGoogleMapsKeyPropertyName = "apiGoogleMapsKey";
 
 	/** @hidden */
@@ -113,15 +107,6 @@ public abstract class Startup extends AbstractTransientBean {
 
 	/** @hidden */
 	public static final String apiCloudflareTurnstileSecretKeyPropertyName = "apiCloudflareTurnstileSecretKey";
-
-	/** @hidden */
-	public static final String geoIPKeyPropertyName = "geoIPKey";
-
-	/** @hidden */
-	public static final String geoIPCountryListTypePropertyName = "geoIPCountryListType";
-
-	/** @hidden */
-	public static final String geoIPCountriesPropertyName = "geoIPCountries";
 
 	/** @hidden */
 	public static final String accountAllowUserSelfRegistrationPropertyName = "accountAllowUserSelfRegistration";
@@ -143,6 +128,48 @@ public abstract class Startup extends AbstractTransientBean {
 
 	/** @hidden */
 	public static final String backupDirectoryNamePropertyName = "backupDirectoryName";
+
+	/** @hidden */
+	public static final String checkForBreachedPasswordPropertyName = "checkForBreachedPassword";
+
+	/** @hidden */
+	public static final String securityNotificationsEmailPropertyName = "securityNotificationsEmail";
+
+	/** @hidden */
+	public static final String disableIPAddressChecksPropertyName = "disableIPAddressChecks";
+
+	/** @hidden */
+	public static final String ipAddressHistoryCheckCountPropertyName = "ipAddressHistoryCheckCount";
+
+	/** @hidden */
+	public static final String captchaTypePropertyName = "captchaType";
+
+	/** @hidden */
+	public static final String geoIPKeyPropertyName = "geoIPKey";
+
+	/** @hidden */
+	public static final String geoIPCountryListTypePropertyName = "geoIPCountryListType";
+
+	/** @hidden */
+	public static final String geoIPCountriesPropertyName = "geoIPCountries";
+
+	/** @hidden */
+	public static final String disableGeoIPBlockNotificationsPropertyName = "disableGeoIPBlockNotifications";
+
+	/** @hidden */
+	public static final String disablePasswordChangeNotificationsPropertyName = "disablePasswordChangeNotifications";
+
+	/** @hidden */
+	public static final String disableDifferentCountryLoginNotificationsPropertyName = "disableDifferentCountryLoginNotifications";
+
+	/** @hidden */
+	public static final String disableIPAddressChangeNotificationsPropertyName = "disableIPAddressChangeNotifications";
+
+	/** @hidden */
+	public static final String disableAccessExceptionNotificationsPropertyName = "disableAccessExceptionNotifications";
+
+	/** @hidden */
+	public static final String disableSecurityExceptionNotificationsPropertyName = "disableSecurityExceptionNotifications";
 
 	/**
 	 * Type
@@ -202,6 +229,78 @@ public abstract class Startup extends AbstractTransientBean {
 			MapType result = null;
 
 			for (MapType value : values()) {
+				if (value.toLocalisedDescription().equals(description)) {
+					result = value;
+					break;
+				}
+			}
+
+			return result;
+		}
+
+		public static List<DomainValue> toDomainValues() {
+			return domainValues;
+		}
+	}
+
+	/**
+	 * Type
+	 * <br/>
+	 * Which external backup provider should be used this Skyve application? Note: additional charges may apply.
+	 **/
+	@XmlEnum
+	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
+	public static enum BackupType implements Enumeration {
+		none("none", "None (Internal Backups)"),
+		azure("org.skyve.impl.backup.AzureBlobStorageBackup", "Azure Blob Storage");
+
+		private String code;
+		private String description;
+
+		/** @hidden */
+		private DomainValue domainValue;
+
+		/** @hidden */
+		private static List<DomainValue> domainValues = Stream.of(values()).map(BackupType::toDomainValue).collect(Collectors.toUnmodifiableList());
+
+		private BackupType(String code, String description) {
+			this.code = code;
+			this.description = description;
+			this.domainValue = new DomainValue(code, description);
+		}
+
+		@Override
+		public String toCode() {
+			return code;
+		}
+
+		@Override
+		public String toLocalisedDescription() {
+			return Util.i18n(description);
+		}
+
+		@Override
+		public DomainValue toDomainValue() {
+			return domainValue;
+		}
+
+		public static BackupType fromCode(String code) {
+			BackupType result = null;
+
+			for (BackupType value : values()) {
+				if (value.code.equals(code)) {
+					result = value;
+					break;
+				}
+			}
+
+			return result;
+		}
+
+		public static BackupType fromLocalisedDescription(String description) {
+			BackupType result = null;
+
+			for (BackupType value : values()) {
 				if (value.toLocalisedDescription().equals(description)) {
 					result = value;
 					break;
@@ -361,78 +460,6 @@ public abstract class Startup extends AbstractTransientBean {
 	}
 
 	/**
-	 * Type
-	 * <br/>
-	 * Which external backup provider should be used this Skyve application? Note: additional charges may apply.
-	 **/
-	@XmlEnum
-	@Generated(value = "org.skyve.impl.generate.OverridableDomainGenerator")
-	public static enum BackupType implements Enumeration {
-		none("none", "None (Internal Backups)"),
-		azure("org.skyve.impl.backup.AzureBlobStorageBackup", "Azure Blob Storage");
-
-		private String code;
-		private String description;
-
-		/** @hidden */
-		private DomainValue domainValue;
-
-		/** @hidden */
-		private static List<DomainValue> domainValues = Stream.of(values()).map(BackupType::toDomainValue).collect(Collectors.toUnmodifiableList());
-
-		private BackupType(String code, String description) {
-			this.code = code;
-			this.description = description;
-			this.domainValue = new DomainValue(code, description);
-		}
-
-		@Override
-		public String toCode() {
-			return code;
-		}
-
-		@Override
-		public String toLocalisedDescription() {
-			return Util.i18n(description);
-		}
-
-		@Override
-		public DomainValue toDomainValue() {
-			return domainValue;
-		}
-
-		public static BackupType fromCode(String code) {
-			BackupType result = null;
-
-			for (BackupType value : values()) {
-				if (value.code.equals(code)) {
-					result = value;
-					break;
-				}
-			}
-
-			return result;
-		}
-
-		public static BackupType fromLocalisedDescription(String description) {
-			BackupType result = null;
-
-			for (BackupType value : values()) {
-				if (value.toLocalisedDescription().equals(description)) {
-					result = value;
-					break;
-				}
-			}
-
-			return result;
-		}
-
-		public static List<DomainValue> toDomainValues() {
-			return domainValues;
-		}
-	}
-
-	/**
 	 * Don't show this again
 	 * <br/>
 	 * Allow the user to bypass the setup screen and set the showSetup value to false.
@@ -534,22 +561,6 @@ public abstract class Startup extends AbstractTransientBean {
 	private String mailTestRecipient;
 
 	/**
-	 * Check for breached password
-	 * <br/>
-	 * When users try to create or change a password, this checks whether the new password has been compromised in known data breaches (requires internet access).
-	 * <br/>
-	 * Determines whether or not HaveIBeenPwned API is used as part of password validation.
-	 **/
-	private Boolean checkForBreachedPassword = Boolean.valueOf(true);
-
-	/**
-	 * CAPTCHA Type
-	 * <br/>
-	 * Which CAPTCHA service to use for the self-registration and self-service password reset (forgot password) function. You may choose between Cloudflare Turnstile and Google Recaptcha or leave blank to not enable a CAPTCHA.
-	 **/
-	private CaptchaType captchaType;
-
-	/**
 	 * Google Maps Key
 	 * <br/>
 	 * If using Google Maps for your map type, specify your map key here
@@ -583,25 +594,6 @@ public abstract class Startup extends AbstractTransientBean {
 	 * Cloudflare Turnstile secret key can be specified here to enable server-side validation for stronger security.
 	 **/
 	private String apiCloudflareTurnstileSecretKey;
-
-	/**
-	 * Geo IP Key/Token
-	 * <br/>
-	 * By supplying a Geo IP API token (default is ipinfo.io), you can allow/disallow countries for registration and password reset.
-	 **/
-	private String geoIPKey;
-
-	/**
-	 * Country List Type
-	 * <br/>
-	 * This determines whether the countries selected should be allowed (whitelist) or denied (blacklist) from accessing the application.
-	 **/
-	private GeoIPCountryListType geoIPCountryListType;
-
-	/**
-	 * Counties
-	 **/
-	private List<CountryExtension> geoIPCountries = new ChangeTrackingArrayList<>("geoIPCountries", this);
 
 	/**
 	 * Allow User Self Registration
@@ -650,6 +642,104 @@ public abstract class Startup extends AbstractTransientBean {
 					Must be from 3 to 63 characters long.
 	 **/
 	private String backupDirectoryName;
+
+	/**
+	 * Check for breached password
+	 * <br/>
+	 * When users try to create or change a password, this checks whether the new password has been compromised in known data breaches (requires internet access).
+	 * <br/>
+	 * Determines whether or not HaveIBeenPwned API is used as part of password validation.
+	 **/
+	private Boolean checkForBreachedPassword = Boolean.valueOf(true);
+
+	/**
+	 * Security Notifications Email Address
+	 * <br/>
+	 * Email address where security notifications will be sent. If not specified, security notifications will be sent to the support email address.
+	 **/
+	private String securityNotificationsEmail;
+
+	/**
+	 * Disable IP Address Checks
+	 * <br/>
+	 * When enabled, this disables IP address change logging and different country login checks. This means no security events will be logged for IP address changes or logins from different countries.
+	 **/
+	private Boolean disableIPAddressChecks = Boolean.valueOf(false);
+
+	/**
+	 * IP Address History Check Count
+	 * <br/>
+	 * Number of previous IP addresses to check when determining if a security event should be logged.
+	 **/
+	private Integer ipAddressHistoryCheckCount = Integer.valueOf(1);
+
+	/**
+	 * CAPTCHA Type
+	 * <br/>
+	 * Which CAPTCHA service to use for the self-registration and self-service password reset (forgot password) function. You may choose between Cloudflare Turnstile and Google Recaptcha or leave blank to not enable a CAPTCHA.
+	 **/
+	private CaptchaType captchaType;
+
+	/**
+	 * GEO IP Key/Token
+	 * <br/>
+	 * By supplying a Geo IP API token (default is ipinfo.io), you can allow/disallow countries for registration and password reset.
+	 **/
+	private String geoIPKey;
+
+	/**
+	 * Country List Type
+	 * <br/>
+	 * This determines whether the countries selected should be allowed (whitelist) or denied (blacklist) from accessing the application.
+	 **/
+	private GeoIPCountryListType geoIPCountryListType;
+
+	/**
+	 * Counties
+	 **/
+	private List<CountryExtension> geoIPCountries = new ChangeTrackingArrayList<>("geoIPCountries", this);
+
+	/**
+	 * Disable Geo IP Block Notifications
+	 * <br/>
+	 * When enabled, no notifications will be sent when a Geo IP block occurs.
+	 **/
+	private Boolean disableGeoIPBlockNotifications;
+
+	/**
+	 * Disable Password Change Notifications
+	 * <br/>
+	 * When enabled, no notifications will be sent when a password is changed.
+	 **/
+	private Boolean disablePasswordChangeNotifications;
+
+	/**
+	 * Disable Different Country Login Notifications
+	 * <br/>
+	 * When enabled, no notifications will be sent when a user logs in from a different country.
+	 **/
+	private Boolean disableDifferentCountryLoginNotifications;
+
+	/**
+	 * Disable IP Address Change Notifications
+	 * <br/>
+	 * When enabled, no notifications will be sent when a user logs in from a different IP address.
+	 **/
+	private Boolean disableIPAddressChangeNotifications;
+
+	/**
+	 * Disable Access Exception Notifications
+	 * <br/>
+	 * When enabled, no notifications will be sent when following an access exception.
+	 **/
+	private Boolean disableAccessExceptionNotifications;
+
+	/**
+	 * Disable Security Exception Notifications
+	 * <br/>
+	 * When enabled, no notifications will be sent when following a security exception.
+	 **/
+	private Boolean disableSecurityExceptionNotifications;
 
 	@Override
 	@XmlTransient
@@ -936,42 +1026,6 @@ public abstract class Startup extends AbstractTransientBean {
 	}
 
 	/**
-	 * {@link #checkForBreachedPassword} accessor.
-	 * @return	The value.
-	 **/
-	public Boolean getCheckForBreachedPassword() {
-		return checkForBreachedPassword;
-	}
-
-	/**
-	 * {@link #checkForBreachedPassword} mutator.
-	 * @param checkForBreachedPassword	The new value.
-	 **/
-	@XmlElement
-	public void setCheckForBreachedPassword(Boolean checkForBreachedPassword) {
-		preset(checkForBreachedPasswordPropertyName, checkForBreachedPassword);
-		this.checkForBreachedPassword = checkForBreachedPassword;
-	}
-
-	/**
-	 * {@link #captchaType} accessor.
-	 * @return	The value.
-	 **/
-	public CaptchaType getCaptchaType() {
-		return captchaType;
-	}
-
-	/**
-	 * {@link #captchaType} mutator.
-	 * @param captchaType	The new value.
-	 **/
-	@XmlElement
-	public void setCaptchaType(CaptchaType captchaType) {
-		preset(captchaTypePropertyName, captchaType);
-		this.captchaType = captchaType;
-	}
-
-	/**
 	 * {@link #apiGoogleMapsKey} accessor.
 	 * @return	The value.
 	 **/
@@ -1059,102 +1113,6 @@ public abstract class Startup extends AbstractTransientBean {
 	public void setApiCloudflareTurnstileSecretKey(String apiCloudflareTurnstileSecretKey) {
 		preset(apiCloudflareTurnstileSecretKeyPropertyName, apiCloudflareTurnstileSecretKey);
 		this.apiCloudflareTurnstileSecretKey = apiCloudflareTurnstileSecretKey;
-	}
-
-	/**
-	 * {@link #geoIPKey} accessor.
-	 * @return	The value.
-	 **/
-	public String getGeoIPKey() {
-		return geoIPKey;
-	}
-
-	/**
-	 * {@link #geoIPKey} mutator.
-	 * @param geoIPKey	The new value.
-	 **/
-	@XmlElement
-	public void setGeoIPKey(String geoIPKey) {
-		preset(geoIPKeyPropertyName, geoIPKey);
-		this.geoIPKey = geoIPKey;
-	}
-
-	/**
-	 * {@link #geoIPCountryListType} accessor.
-	 * @return	The value.
-	 **/
-	public GeoIPCountryListType getGeoIPCountryListType() {
-		return geoIPCountryListType;
-	}
-
-	/**
-	 * {@link #geoIPCountryListType} mutator.
-	 * @param geoIPCountryListType	The new value.
-	 **/
-	@XmlElement
-	public void setGeoIPCountryListType(GeoIPCountryListType geoIPCountryListType) {
-		preset(geoIPCountryListTypePropertyName, geoIPCountryListType);
-		this.geoIPCountryListType = geoIPCountryListType;
-	}
-
-	/**
-	 * {@link #geoIPCountries} accessor.
-	 * @return	The value.
-	 **/
-	@XmlElement
-	public List<CountryExtension> getGeoIPCountries() {
-		return geoIPCountries;
-	}
-
-	/**
-	 * {@link #geoIPCountries} accessor.
-	 * @param bizId	The bizId of the element in the list.
-	 * @return	The value of the element in the list.
-	 **/
-	public CountryExtension getGeoIPCountriesElementById(String bizId) {
-		return getElementById(geoIPCountries, bizId);
-	}
-
-	/**
-	 * {@link #geoIPCountries} mutator.
-	 * @param bizId	The bizId of the element in the list.
-	 * @param element	The new value of the element in the list.
-	 **/
-	public void setGeoIPCountriesElementById(String bizId, CountryExtension element) {
-		setElementById(geoIPCountries, element);
-	}
-
-	/**
-	 * {@link #geoIPCountries} add.
-	 * @param element	The element to add.
-	 **/
-	public boolean addGeoIPCountriesElement(CountryExtension element) {
-		return geoIPCountries.add(element);
-	}
-
-	/**
-	 * {@link #geoIPCountries} add.
-	 * @param index	The index in the list to add the element to.
-	 * @param element	The element to add.
-	 **/
-	public void addGeoIPCountriesElement(int index, CountryExtension element) {
-		geoIPCountries.add(index, element);
-	}
-
-	/**
-	 * {@link #geoIPCountries} remove.
-	 * @param element	The element to remove.
-	 **/
-	public boolean removeGeoIPCountriesElement(CountryExtension element) {
-		return geoIPCountries.remove(element);
-	}
-
-	/**
-	 * {@link #geoIPCountries} remove.
-	 * @param index	The index in the list to remove the element from.
-	 **/
-	public CountryExtension removeGeoIPCountriesElement(int index) {
-		return geoIPCountries.remove(index);
 	}
 
 	/**
@@ -1284,6 +1242,300 @@ public abstract class Startup extends AbstractTransientBean {
 	}
 
 	/**
+	 * {@link #checkForBreachedPassword} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getCheckForBreachedPassword() {
+		return checkForBreachedPassword;
+	}
+
+	/**
+	 * {@link #checkForBreachedPassword} mutator.
+	 * @param checkForBreachedPassword	The new value.
+	 **/
+	@XmlElement
+	public void setCheckForBreachedPassword(Boolean checkForBreachedPassword) {
+		preset(checkForBreachedPasswordPropertyName, checkForBreachedPassword);
+		this.checkForBreachedPassword = checkForBreachedPassword;
+	}
+
+	/**
+	 * {@link #securityNotificationsEmail} accessor.
+	 * @return	The value.
+	 **/
+	public String getSecurityNotificationsEmail() {
+		return securityNotificationsEmail;
+	}
+
+	/**
+	 * {@link #securityNotificationsEmail} mutator.
+	 * @param securityNotificationsEmail	The new value.
+	 **/
+	@XmlElement
+	public void setSecurityNotificationsEmail(String securityNotificationsEmail) {
+		preset(securityNotificationsEmailPropertyName, securityNotificationsEmail);
+		this.securityNotificationsEmail = securityNotificationsEmail;
+	}
+
+	/**
+	 * {@link #disableIPAddressChecks} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getDisableIPAddressChecks() {
+		return disableIPAddressChecks;
+	}
+
+	/**
+	 * {@link #disableIPAddressChecks} mutator.
+	 * @param disableIPAddressChecks	The new value.
+	 **/
+	@XmlElement
+	public void setDisableIPAddressChecks(Boolean disableIPAddressChecks) {
+		preset(disableIPAddressChecksPropertyName, disableIPAddressChecks);
+		this.disableIPAddressChecks = disableIPAddressChecks;
+	}
+
+	/**
+	 * {@link #ipAddressHistoryCheckCount} accessor.
+	 * @return	The value.
+	 **/
+	public Integer getIpAddressHistoryCheckCount() {
+		return ipAddressHistoryCheckCount;
+	}
+
+	/**
+	 * {@link #ipAddressHistoryCheckCount} mutator.
+	 * @param ipAddressHistoryCheckCount	The new value.
+	 **/
+	@XmlElement
+	public void setIpAddressHistoryCheckCount(Integer ipAddressHistoryCheckCount) {
+		preset(ipAddressHistoryCheckCountPropertyName, ipAddressHistoryCheckCount);
+		this.ipAddressHistoryCheckCount = ipAddressHistoryCheckCount;
+	}
+
+	/**
+	 * {@link #captchaType} accessor.
+	 * @return	The value.
+	 **/
+	public CaptchaType getCaptchaType() {
+		return captchaType;
+	}
+
+	/**
+	 * {@link #captchaType} mutator.
+	 * @param captchaType	The new value.
+	 **/
+	@XmlElement
+	public void setCaptchaType(CaptchaType captchaType) {
+		preset(captchaTypePropertyName, captchaType);
+		this.captchaType = captchaType;
+	}
+
+	/**
+	 * {@link #geoIPKey} accessor.
+	 * @return	The value.
+	 **/
+	public String getGeoIPKey() {
+		return geoIPKey;
+	}
+
+	/**
+	 * {@link #geoIPKey} mutator.
+	 * @param geoIPKey	The new value.
+	 **/
+	@XmlElement
+	public void setGeoIPKey(String geoIPKey) {
+		preset(geoIPKeyPropertyName, geoIPKey);
+		this.geoIPKey = geoIPKey;
+	}
+
+	/**
+	 * {@link #geoIPCountryListType} accessor.
+	 * @return	The value.
+	 **/
+	public GeoIPCountryListType getGeoIPCountryListType() {
+		return geoIPCountryListType;
+	}
+
+	/**
+	 * {@link #geoIPCountryListType} mutator.
+	 * @param geoIPCountryListType	The new value.
+	 **/
+	@XmlElement
+	public void setGeoIPCountryListType(GeoIPCountryListType geoIPCountryListType) {
+		preset(geoIPCountryListTypePropertyName, geoIPCountryListType);
+		this.geoIPCountryListType = geoIPCountryListType;
+	}
+
+	/**
+	 * {@link #geoIPCountries} accessor.
+	 * @return	The value.
+	 **/
+	@XmlElement
+	public List<CountryExtension> getGeoIPCountries() {
+		return geoIPCountries;
+	}
+
+	/**
+	 * {@link #geoIPCountries} accessor.
+	 * @param bizId	The bizId of the element in the list.
+	 * @return	The value of the element in the list.
+	 **/
+	public CountryExtension getGeoIPCountriesElementById(String bizId) {
+		return getElementById(geoIPCountries, bizId);
+	}
+
+	/**
+	 * {@link #geoIPCountries} mutator.
+	 * @param bizId	The bizId of the element in the list.
+	 * @param element	The new value of the element in the list.
+	 **/
+	public void setGeoIPCountriesElementById(String bizId, CountryExtension element) {
+		setElementById(geoIPCountries, element);
+	}
+
+	/**
+	 * {@link #geoIPCountries} add.
+	 * @param element	The element to add.
+	 **/
+	public boolean addGeoIPCountriesElement(CountryExtension element) {
+		return geoIPCountries.add(element);
+	}
+
+	/**
+	 * {@link #geoIPCountries} add.
+	 * @param index	The index in the list to add the element to.
+	 * @param element	The element to add.
+	 **/
+	public void addGeoIPCountriesElement(int index, CountryExtension element) {
+		geoIPCountries.add(index, element);
+	}
+
+	/**
+	 * {@link #geoIPCountries} remove.
+	 * @param element	The element to remove.
+	 **/
+	public boolean removeGeoIPCountriesElement(CountryExtension element) {
+		return geoIPCountries.remove(element);
+	}
+
+	/**
+	 * {@link #geoIPCountries} remove.
+	 * @param index	The index in the list to remove the element from.
+	 **/
+	public CountryExtension removeGeoIPCountriesElement(int index) {
+		return geoIPCountries.remove(index);
+	}
+
+	/**
+	 * {@link #disableGeoIPBlockNotifications} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getDisableGeoIPBlockNotifications() {
+		return disableGeoIPBlockNotifications;
+	}
+
+	/**
+	 * {@link #disableGeoIPBlockNotifications} mutator.
+	 * @param disableGeoIPBlockNotifications	The new value.
+	 **/
+	@XmlElement
+	public void setDisableGeoIPBlockNotifications(Boolean disableGeoIPBlockNotifications) {
+		preset(disableGeoIPBlockNotificationsPropertyName, disableGeoIPBlockNotifications);
+		this.disableGeoIPBlockNotifications = disableGeoIPBlockNotifications;
+	}
+
+	/**
+	 * {@link #disablePasswordChangeNotifications} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getDisablePasswordChangeNotifications() {
+		return disablePasswordChangeNotifications;
+	}
+
+	/**
+	 * {@link #disablePasswordChangeNotifications} mutator.
+	 * @param disablePasswordChangeNotifications	The new value.
+	 **/
+	@XmlElement
+	public void setDisablePasswordChangeNotifications(Boolean disablePasswordChangeNotifications) {
+		preset(disablePasswordChangeNotificationsPropertyName, disablePasswordChangeNotifications);
+		this.disablePasswordChangeNotifications = disablePasswordChangeNotifications;
+	}
+
+	/**
+	 * {@link #disableDifferentCountryLoginNotifications} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getDisableDifferentCountryLoginNotifications() {
+		return disableDifferentCountryLoginNotifications;
+	}
+
+	/**
+	 * {@link #disableDifferentCountryLoginNotifications} mutator.
+	 * @param disableDifferentCountryLoginNotifications	The new value.
+	 **/
+	@XmlElement
+	public void setDisableDifferentCountryLoginNotifications(Boolean disableDifferentCountryLoginNotifications) {
+		preset(disableDifferentCountryLoginNotificationsPropertyName, disableDifferentCountryLoginNotifications);
+		this.disableDifferentCountryLoginNotifications = disableDifferentCountryLoginNotifications;
+	}
+
+	/**
+	 * {@link #disableIPAddressChangeNotifications} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getDisableIPAddressChangeNotifications() {
+		return disableIPAddressChangeNotifications;
+	}
+
+	/**
+	 * {@link #disableIPAddressChangeNotifications} mutator.
+	 * @param disableIPAddressChangeNotifications	The new value.
+	 **/
+	@XmlElement
+	public void setDisableIPAddressChangeNotifications(Boolean disableIPAddressChangeNotifications) {
+		preset(disableIPAddressChangeNotificationsPropertyName, disableIPAddressChangeNotifications);
+		this.disableIPAddressChangeNotifications = disableIPAddressChangeNotifications;
+	}
+
+	/**
+	 * {@link #disableAccessExceptionNotifications} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getDisableAccessExceptionNotifications() {
+		return disableAccessExceptionNotifications;
+	}
+
+	/**
+	 * {@link #disableAccessExceptionNotifications} mutator.
+	 * @param disableAccessExceptionNotifications	The new value.
+	 **/
+	@XmlElement
+	public void setDisableAccessExceptionNotifications(Boolean disableAccessExceptionNotifications) {
+		preset(disableAccessExceptionNotificationsPropertyName, disableAccessExceptionNotifications);
+		this.disableAccessExceptionNotifications = disableAccessExceptionNotifications;
+	}
+
+	/**
+	 * {@link #disableSecurityExceptionNotifications} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getDisableSecurityExceptionNotifications() {
+		return disableSecurityExceptionNotifications;
+	}
+
+	/**
+	 * {@link #disableSecurityExceptionNotifications} mutator.
+	 * @param disableSecurityExceptionNotifications	The new value.
+	 **/
+	@XmlElement
+	public void setDisableSecurityExceptionNotifications(Boolean disableSecurityExceptionNotifications) {
+		preset(disableSecurityExceptionNotificationsPropertyName, disableSecurityExceptionNotifications);
+		this.disableSecurityExceptionNotifications = disableSecurityExceptionNotifications;
+	}
+
+	/**
 	 * True when the selected backup type is Azure Blob Storage
 	 *
 	 * @return The condition
@@ -1357,6 +1609,25 @@ public abstract class Startup extends AbstractTransientBean {
 	 */
 	public boolean isNotHasGeoIPKey() {
 		return (! isHasGeoIPKey());
+	}
+
+	/**
+	 * True when IP address checks are enabled.
+	 *
+	 * @return The condition
+	 */
+	@XmlTransient
+	public boolean isIpAddressChecksEnabled() {
+		return (!Boolean.TRUE.equals(getDisableIPAddressChecks()));
+	}
+
+	/**
+	 * {@link #isIpAddressChecksEnabled} negation.
+	 *
+	 * @return The negated condition
+	 */
+	public boolean isNotIpAddressChecksEnabled() {
+		return (! isIpAddressChecksEnabled());
 	}
 
 	/**

--- a/skyve-war/src/main/java/modules/admin/Configuration/Configuration.xml
+++ b/skyve-war/src/main/java/modules/admin/Configuration/Configuration.xml
@@ -275,5 +275,9 @@
 				<![CDATA[getStartup().getCaptchaType() == null]]>
 			</expression>
 		</condition>
+		<condition name="ipAddressChecksEnabled" usage="view">
+			<description>True when IP address checks are enabled in startup.</description>
+			<expression>getStartup().isIpAddressChecksEnabled()</expression>
+		</condition>
 	</conditions>
 </document>

--- a/skyve-war/src/main/java/modules/admin/Configuration/ConfigurationBizlet.java
+++ b/skyve-war/src/main/java/modules/admin/Configuration/ConfigurationBizlet.java
@@ -42,9 +42,10 @@ public class ConfigurationBizlet extends SingletonCachedBizlet<ConfigurationExte
 		// temporarily elevate access to find existing configuration regardless of user
 		ConfigurationExtension result = newInstance(bean, DocumentPermissionScope.customer);
 
-		// Set the startup and set the emailFrom to the startup mailsender
+		// initialise the startup bean
 		if (result.getStartup() == null) {
-			result.setStartup(Startup.newInstance());
+			StartupExtension startup = Startup.newInstance();
+			result.setStartup(startup);
 			result.setEmailFrom(result.getStartup().getMailSender());
 		}
 
@@ -65,12 +66,6 @@ public class ConfigurationBizlet extends SingletonCachedBizlet<ConfigurationExte
 					Binder.createCompoundBinding(User.contactPropertyName, Contact.namePropertyName)
 				);
 			result.setPasswordResetEmailBody(body);
-		}
-
-		// initialise the startup bean
-		if (result.getStartup() == null) {
-			StartupExtension startup = Startup.newInstance();
-			result.setStartup(startup);
 		}
 		
 		return result;

--- a/skyve-war/src/main/java/modules/admin/SelfRegistration/actions/Register.java
+++ b/skyve-war/src/main/java/modules/admin/SelfRegistration/actions/Register.java
@@ -72,7 +72,7 @@ public class Register implements ServerSideAction<SelfRegistrationExtension> {
 					LOGGER.warn(message);
 
 					// Record security event
-					SecurityUtil.log("GEO IP Block", message);
+					SecurityUtil.log(SecurityUtil.GEO_IP_BLOCK_EVENT_TYPE, message);
 
 					// Silently pass
 					bean.setPassSilently(Boolean.TRUE);

--- a/skyve-war/src/main/java/modules/admin/Startup/Startup.xml
+++ b/skyve-war/src/main/java/modules/admin/Startup/Startup.xml
@@ -102,24 +102,6 @@
 		</text>
 
 		<!-- api settings -->
-		<boolean name="checkForBreachedPassword">
-			<documentation>Determines whether or not HaveIBeenPwned API is used as part of password validation.</documentation>
-			<displayName>Check for breached password</displayName>
-			<description>When users try to create or change a password, this checks whether the new password has been compromised in known data breaches (requires internet access).</description>
-			<defaultValue>true</defaultValue>
-		</boolean>
-		<enum name="captchaType">
-			<displayName>CAPTCHA Type</displayName>
-			<description>
-				<![CDATA[
-					Which CAPTCHA service to use for the self-registration and self-service password reset (forgot password) function. You may choose between Cloudflare Turnstile and Google Recaptcha or leave blank to not enable a CAPTCHA.
-				]]>
-			</description>
-			<values>
-				<value code="Google Recaptcha" />
-				<value code="Cloudflare Turnstile" />
-			</values>
-		</enum>
 		<text name="apiGoogleMapsKey">
 			<displayName>Google Maps Key</displayName>
 			<description>If using Google Maps for your map type, specify your map key here</description>
@@ -161,33 +143,6 @@
 			</description>
 			<length>200</length>
 		</text>
-		<text name="geoIPKey" audited="false" sensitivity="secret">
-			<displayName>Geo IP Key/Token</displayName>
-			<description>
-				<![CDATA[
-					By supplying a Geo IP API token (default is ipinfo.io), you can allow/disallow countries for registration and password reset.
-				]]>
-			</description>
-			<length>15</length>
-		</text>
-		<enum name="geoIPCountryListType">
-			<displayName>Country List Type</displayName>
-			<description>This determines whether the countries selected should be allowed (whitelist) or denied (blacklist) from accessing the application.</description>
-			<values>
-				<value code="blacklist" description="Blacklist" />
-				<value code="whitelist" description="Whitelist" />
-			</values>
-		</enum>
-		<collection name="geoIPCountries" type="aggregation">
-			<displayName>Counties</displayName>
-			<!-- Descriptions can be different based on the user's locale -->
-			<domain>variant</domain>
-			<documentName>Country</documentName>
-			<minCardinality>0</minCardinality>
-			<ordering>
-				<order sort="ascending" by="name" />
-			</ordering>
-		</collection>
 
 		<!-- account settings -->
 		<boolean name="accountAllowUserSelfRegistration">
@@ -246,6 +201,90 @@
 			<validator regularExpression="^[a-z0-9]+(-[a-z0-9]+)*$"
 				validationMessage="This must be a valid DNS name, starting with a letter or number, containing only letters, numbers and the dash character. Every dash must be immediately preceeded and followed by a ltter or number." />
 		</text>
+		
+		<!-- security Settings -->
+		<boolean name="checkForBreachedPassword">
+			<documentation>Determines whether or not HaveIBeenPwned API is used as part of password validation.</documentation>
+			<displayName>Check for breached password</displayName>
+			<description>When users try to create or change a password, this checks whether the new password has been compromised in known data breaches (requires internet access).</description>
+			<defaultValue>true</defaultValue>
+		</boolean>
+		<text name="securityNotificationsEmail">
+			<displayName>Security Notifications Email Address</displayName>
+			<description>Email address where security notifications will be sent. If not specified, security notifications will be sent to the support email address.</description>
+			<length>200</length>
+			<validator type="email" />
+		</text>
+		<boolean name="disableIPAddressChecks">
+			<displayName>Disable IP Address Checks</displayName>
+			<description>When enabled, this disables IP address change logging and different country login checks. This means no security events will be logged for IP address changes or logins from different countries.</description>
+			<defaultValue>false</defaultValue>
+		</boolean>
+		<integer name="ipAddressHistoryCheckCount">
+			<displayName>IP Address History Check Count</displayName>
+			<description>Number of previous IP addresses to check when determining if a security event should be logged.</description>
+			<defaultValue>1</defaultValue>
+			<validator min="1" />
+		</integer>
+		<enum name="captchaType">
+			<displayName>CAPTCHA Type</displayName>
+			<description>
+				<![CDATA[
+					Which CAPTCHA service to use for the self-registration and self-service password reset (forgot password) function. You may choose between Cloudflare Turnstile and Google Recaptcha or leave blank to not enable a CAPTCHA.
+				]]>
+			</description>
+			<values>
+				<value code="Google Recaptcha" />
+				<value code="Cloudflare Turnstile" />
+			</values>
+		</enum>
+		<text name="geoIPKey" audited="false" sensitivity="secret">
+			<displayName>GEO IP Key/Token</displayName>
+			<description>By supplying a Geo IP API token (default is ipinfo.io), you can allow/disallow countries for registration and password reset.</description>
+			<length>15</length>
+		</text>
+		<enum name="geoIPCountryListType">
+			<displayName>Country List Type</displayName>
+			<description>This determines whether the countries selected should be allowed (whitelist) or denied (blacklist) from accessing the application.</description>
+			<values>
+				<value code="blacklist" description="Blacklist" />
+				<value code="whitelist" description="Whitelist" />
+			</values>
+		</enum>
+		<collection name="geoIPCountries" type="aggregation">
+			<displayName>Counties</displayName>
+			<!-- Descriptions can be different based on the user's locale -->
+			<domain>variant</domain>
+			<documentName>Country</documentName>
+			<minCardinality>0</minCardinality>
+			<ordering>
+				<order sort="ascending" by="name" />
+			</ordering>
+		</collection>
+		<boolean name="disableGeoIPBlockNotifications">
+			<displayName>Disable Geo IP Block Notifications</displayName>
+			<description>When enabled, no notifications will be sent when a Geo IP block occurs.</description>
+		</boolean>
+		<boolean name="disablePasswordChangeNotifications">
+			<displayName>Disable Password Change Notifications</displayName>
+			<description>When enabled, no notifications will be sent when a password is changed.</description>
+		</boolean>
+		<boolean name="disableDifferentCountryLoginNotifications">
+			<displayName>Disable Different Country Login Notifications</displayName>
+			<description>When enabled, no notifications will be sent when a user logs in from a different country.</description>
+		</boolean>
+		<boolean name="disableIPAddressChangeNotifications">
+			<displayName>Disable IP Address Change Notifications</displayName>
+			<description>When enabled, no notifications will be sent when a user logs in from a different IP address.</description>
+		</boolean>
+		<boolean name="disableAccessExceptionNotifications">
+			<displayName>Disable Access Exception Notifications</displayName>
+			<description>When enabled, no notifications will be sent when following an access exception.</description>
+		</boolean>
+		<boolean name="disableSecurityExceptionNotifications">
+			<displayName>Disable Security Exception Notifications</displayName>
+			<description>When enabled, no notifications will be sent when following a security exception.</description>
+		</boolean>
 	</attributes>
 	<conditions>
 		<condition name="backupTypeAzure" usage="view">
@@ -283,6 +322,10 @@
 			<expression>
 				<![CDATA[getCaptchaType() == null]]>
 			</expression>
+		</condition>
+		<condition name="ipAddressChecksEnabled">
+			<description>True when IP address checks are enabled.</description>
+			<expression>!Boolean.TRUE.equals(getDisableIPAddressChecks())</expression>
 		</condition>
 	</conditions>
 </document>

--- a/skyve-war/src/main/java/modules/admin/Startup/StartupExtension.java
+++ b/skyve-war/src/main/java/modules/admin/Startup/StartupExtension.java
@@ -539,7 +539,7 @@ public class StartupExtension extends Startup {
 	}
 
 	/**
-	 * Compares the current value of the security configuration against the
+	 * Compares the current value of the map configuration against the
 	 * new value from the startup page and if they value has changed, adds it to the
 	 * map to be persisted and updates the running configuration with the new value.
 	 * 
@@ -608,7 +608,7 @@ public class StartupExtension extends Startup {
 	}
 	
 	/**
-	 * Compares the current value of the map configuration against the
+	 * Compares the current value of the security configuration against the
 	 * new value from the startup page and if they value has changed, adds it to the
 	 * map to be persisted and updates the running configuration with the new value.
 	 * 

--- a/skyve-war/src/main/java/modules/admin/Startup/StartupExtension.java
+++ b/skyve-war/src/main/java/modules/admin/Startup/StartupExtension.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -57,7 +58,6 @@ public class StartupExtension extends Startup {
 	static final String ENVIRONMENT_IDENTIFIER_KEY = "identifier";
 	static final String ENVIRONMENT_SHOW_SETUP_KEY = "showSetup";
 	static final String ENVIRONMENT_SUPPORT_EMAIL_ADDRESS_KEY = "supportEmailAddress";
-
 	static final String MAP_STANZA_KEY = "map";
 	static final String MAP_CENTRE_KEY = "centre";
 	static final String MAP_LAYERS_KEY = "layers";
@@ -72,6 +72,15 @@ public class StartupExtension extends Startup {
 	static final String SMTP_UID_KEY = "uid";
 	static final String SMTP_PORT_KEY = "port";
 	static final String SMTP_SERVER_KEY = "server";
+
+	static final String SECURITY_STANZA_KEY = "security";
+	static final String SECURITY_NOTIFICATIONS_EMAIL_KEY = "securityNotificationsEmail";
+	static final String SECURITY_DISABLE_GEO_IP_NOTIFICATIONS_KEY = "disableGeoIPBlockNotifications";
+	static final String SECURITY_DISABLE_PASSWORD_CHANGE_NOTIFICATIONS_KEY = "disablePasswordChangeNotifications";
+	static final String SECURITY_DISABLE_DIFFERENT_COUNTRY_LOGIN_NOTIFICATIONS_KEY = "disableDifferentCountryLoginNotifications";
+	static final String SECURITY_DISABLE_IP_ADDRESS_CHANGE_NOTIFICATIONS_KEY = "disableIPAddressChangeNotifications";
+	static final String SECURITY_DISABLE_ACCESS_EXCEPTION_NOTIFICATIONS_KEY = "disableAccessExceptionNotifications";
+	static final String SECURITY_DISABLE_SECURITY_EXCEPTION_NOTIFICATIONS_KEY = "disableSecurityExceptionNotifications";
 
 	/**
 	 * Populate this bean's attributes from the current configuration properties values
@@ -154,6 +163,15 @@ public class StartupExtension extends Startup {
 			UtilImpl.GEO_IP_COUNTRY_CODES.forEach(cc -> countries.add(CountryExtension.fromCode(cc)));
 		}
 		setGeoIPKey(UtilImpl.GEO_IP_KEY);
+
+		// Security notification configurations
+		setSecurityNotificationsEmail(UtilImpl.SECURITY_NOTIFICATIONS_EMAIL_ADDRESS);
+		setDisableGeoIPBlockNotifications(UtilImpl.DISABLE_GEO_IP_BLOCK_NOTIFICATIONS);
+		setDisablePasswordChangeNotifications(UtilImpl.DISABLE_PASSWORD_CHANGE_NOTIFICATIONS);
+		setDisableDifferentCountryLoginNotifications(UtilImpl.DISABLE_DIFFERENT_COUNTRY_LOGIN_NOTIFICATIONS);
+		setDisableIPAddressChangeNotifications(UtilImpl.DISABLE_IP_ADDRESS_CHANGE_NOTIFICATIONS);
+		setDisableAccessExceptionNotifications(UtilImpl.DISABLE_ACCESS_EXCEPTION_NOTIFICATIONS);
+		setDisableSecurityExceptionNotifications(UtilImpl.DISABLE_SECURITY_EXCEPTION_NOTIFICATIONS);
 	}
 
 	/**
@@ -175,6 +193,7 @@ public class StartupExtension extends Startup {
 		putMap(properties);
 		putAccount(properties);
 		putBackup(properties);
+		putSecurity(properties);
 
 		// write the json out to the content directory
 		String json = marshall(properties);
@@ -520,7 +539,7 @@ public class StartupExtension extends Startup {
 	}
 
 	/**
-	 * Compares the current value of the map configuration against the
+	 * Compares the current value of the security configuration against the
 	 * new value from the startup page and if they value has changed, adds it to the
 	 * map to be persisted and updates the running configuration with the new value.
 	 * 
@@ -586,6 +605,69 @@ public class StartupExtension extends Startup {
 
 		LOGGER.info("No startup properties were modified, nothing to marshall.");
 		return null;
+	}
+	
+	/**
+	 * Compares the current value of the map configuration against the
+	 * new value from the startup page and if they value has changed, adds it to the
+	 * map to be persisted and updates the running configuration with the new value.
+	 * 
+	 * @param properties The current override configuration property map
+	 * @return The map of security properties which have been modified
+	 */
+	@SuppressWarnings({ "unchecked", "boxing" })
+	private Map<String, Object> putSecurity(final Map<String, Object> properties) {
+		// initialise or get the existing property map
+		Map<String, Object> map = (Map<String, Object>) properties.get(SECURITY_STANZA_KEY);
+		if (map == null) {
+			map = new HashMap<>();
+			properties.put(SECURITY_STANZA_KEY, map);
+		}
+
+		// add any values to the override configuration if they have changed
+		String securityNotificationsEmail = getSecurityNotificationsEmail();
+		if (!Objects.equals(UtilImpl.SECURITY_NOTIFICATIONS_EMAIL_ADDRESS, securityNotificationsEmail)) {
+			map.put(SECURITY_NOTIFICATIONS_EMAIL_KEY, securityNotificationsEmail);
+			UtilImpl.SECURITY_NOTIFICATIONS_EMAIL_ADDRESS = securityNotificationsEmail;
+		}
+		
+		boolean disableGeoIPBlockNotification = Boolean.TRUE.equals(getDisableGeoIPBlockNotifications());
+		if (UtilImpl.DISABLE_GEO_IP_BLOCK_NOTIFICATIONS != disableGeoIPBlockNotification) {
+			map.put(SECURITY_DISABLE_GEO_IP_NOTIFICATIONS_KEY, disableGeoIPBlockNotification);
+			UtilImpl.DISABLE_GEO_IP_BLOCK_NOTIFICATIONS = disableGeoIPBlockNotification;
+		}
+
+		boolean disablePasswordChangeNotification = Boolean.TRUE.equals(getDisablePasswordChangeNotifications());
+		if (UtilImpl.DISABLE_PASSWORD_CHANGE_NOTIFICATIONS != disablePasswordChangeNotification) {
+			map.put(SECURITY_DISABLE_PASSWORD_CHANGE_NOTIFICATIONS_KEY, disablePasswordChangeNotification);
+			UtilImpl.DISABLE_PASSWORD_CHANGE_NOTIFICATIONS = disablePasswordChangeNotification;
+		}
+		
+		boolean disableDifferentCountryLoginNotification = Boolean.TRUE.equals(getDisableDifferentCountryLoginNotifications());
+		if (UtilImpl.DISABLE_DIFFERENT_COUNTRY_LOGIN_NOTIFICATIONS != disableDifferentCountryLoginNotification) {
+			map.put(SECURITY_DISABLE_DIFFERENT_COUNTRY_LOGIN_NOTIFICATIONS_KEY, disableDifferentCountryLoginNotification);
+			UtilImpl.DISABLE_DIFFERENT_COUNTRY_LOGIN_NOTIFICATIONS = disableDifferentCountryLoginNotification;
+		}
+
+		boolean disableIPAddressChangeNotification = Boolean.TRUE.equals(getDisableIPAddressChangeNotifications());
+		if (UtilImpl.DISABLE_IP_ADDRESS_CHANGE_NOTIFICATIONS != disableIPAddressChangeNotification) {
+			map.put(SECURITY_DISABLE_IP_ADDRESS_CHANGE_NOTIFICATIONS_KEY, disableIPAddressChangeNotification);
+			UtilImpl.DISABLE_IP_ADDRESS_CHANGE_NOTIFICATIONS = disableIPAddressChangeNotification;
+		}
+		
+		boolean disableAccessExceptionNotification = Boolean.TRUE.equals(getDisableAccessExceptionNotifications());
+		if (UtilImpl.DISABLE_ACCESS_EXCEPTION_NOTIFICATIONS != disableAccessExceptionNotification) {
+			map.put(SECURITY_DISABLE_ACCESS_EXCEPTION_NOTIFICATIONS_KEY, disableAccessExceptionNotification);
+			UtilImpl.DISABLE_ACCESS_EXCEPTION_NOTIFICATIONS = disableAccessExceptionNotification;
+		}
+		
+		boolean disableSecurityExceptionNotification = Boolean.TRUE.equals(getDisableSecurityExceptionNotifications());
+		if (UtilImpl.DISABLE_SECURITY_EXCEPTION_NOTIFICATIONS != disableSecurityExceptionNotification) {
+			map.put(SECURITY_DISABLE_SECURITY_EXCEPTION_NOTIFICATIONS_KEY, disableSecurityExceptionNotification);
+			UtilImpl.DISABLE_SECURITY_EXCEPTION_NOTIFICATIONS = disableSecurityExceptionNotification;
+		}
+
+		return map;
 	}
 
 	/**

--- a/skyve-war/src/main/java/modules/admin/Startup/views/edit.xml
+++ b/skyve-war/src/main/java/modules/admin/Startup/views/edit.xml
@@ -125,13 +125,35 @@
 	        <column responsiveWidth="3"/>
 	        <column/>
 	        <column responsiveWidth="2"/>
+	        
+	        <!-- Password Security -->
+	        <row>
+	        	<item align="right">
+	        		<blurb>
+	        			<![CDATA[
+	        				<span style="font-weight: bold; color: #666;">Password Security</span>
+	        			]]>
+	        		</blurb>
+	        	</item>
+	        </row>
 	        <row>
 				<item>
 					<checkBox binding="checkForBreachedPassword" triState="false" />
 				</item>
 			</row>
+			
+			<!-- CAPTCHA Settings -->
 	        <row>
-	        	<item >
+	        	<item align="right">
+	        		<blurb>
+	        			<![CDATA[
+	        				<span style="font-weight: bold; color: #666;">CAPTCHA Protection</span>
+	        			]]>
+	        		</blurb>
+	        	</item>
+	        </row>
+	        <row>
+	        	<item>
 	        		<combo binding="captchaType">
 	        			<onChangedHandlers>
 	        				<rerender>
@@ -183,16 +205,49 @@
 	        		</blurb>
 	        	</item>
 	        </row>
+	        
+	        <!-- IP Settings -->
+	        <row>
+	        	<item align="right">
+	        		<blurb>
+	        			<![CDATA[
+	        				<span style="font-weight: bold; color: #666;">IP Tracking</span>
+	        			]]>
+	        		</blurb>
+	        	</item>
+	        </row>
+			<row>
+	            <item>
+	                <checkBox binding="disableIPAddressChecks" triState="false">
+						<onChangedHandlers>
+							<rerender>
+								<properties>
+									<c:property key="update">formSecurity</c:property>
+								</properties>
+							</rerender>
+						</onChangedHandlers>
+					</checkBox>
+	            </item>
+	        </row>
+	        <row>
+	            <item>
+	                <spinner binding="ipAddressHistoryCheckCount" min="0" max="10" visible="ipAddressChecksEnabled" />
+	            </item>
+	        </row>
+	        
+	        <!-- GEO IP Settings -->
+	        <row>
+	        	<item align="right">
+	        		<blurb>
+	        			<![CDATA[
+	        				<span style="font-weight: bold; color: #666;">GEO IP Blocking</span>
+	        			]]>
+	        		</blurb>
+	        	</item>
+	        </row>
 	        <row>
 	            <item>
 	                <textField binding="geoIPKey">
-	                	<onBlurHandlers>
-	                		<rerender>
-	        					<properties>
-	        						<c:property key="update">formSecurity</c:property>
-	        					</properties>
-	        				</rerender>
-	                	</onBlurHandlers>
 	                	<onChangedHandlers>
 	                		<rerender>
 	        					<properties>
@@ -204,19 +259,71 @@
 	            </item>
 	        </row>
 	    </form>
-	    <vbox visible="hasGeoIPKey">
-		    <form responsiveWidth="12">
-		        <column responsiveWidth="3"/>
-		        <column/>
-		        <column responsiveWidth="2"/>
-		        <row>
+		<vbox visible="hasGeoIPKey">
+			<form responsiveWidth="12">
+				<column responsiveWidth="3"/>
+				<column/>
+				<column responsiveWidth="2"/>
+				<row>
 					<item>
 						<radio binding="geoIPCountryListType"/>
 					</item>
 				</row>
-	        </form>
-	        <listMembership binding="geoIPCountries" candidatesHeading="Available Countries" membersHeading="Selected Countries" />
-        </vbox>
+			</form>
+			<listMembership binding="geoIPCountries" candidatesHeading="Available Countries" membersHeading="Selected Countries" />
+		</vbox>
+	        
+	   	<form responsiveWidth="12">
+	        <column responsiveWidth="3"/>
+	        <column/>
+	        <column responsiveWidth="2"/>
+	        
+	        <!-- Security Notifications -->
+	        <row>
+	        	<item align="right">
+	        		<blurb>
+	        			<![CDATA[
+	        				<span style="font-weight: bold; color: #666;">Notifications</span>
+	        			]]>
+	        		</blurb>
+	        	</item>
+	        </row>
+	        <row>
+				<item>
+					<default binding="securityNotificationsEmail" />
+				</item>
+			</row>
+			<row>
+				<item>
+					<checkBox binding="disableGeoIPBlockNotifications" triState="false" />
+				</item>
+			</row>
+			<row>
+				<item>
+					<checkBox binding="disablePasswordChangeNotifications" triState="false" />
+				</item>
+			</row>
+			<row>
+				<item>
+					<checkBox binding="disableDifferentCountryLoginNotifications" triState="false" />
+				</item>
+			</row>
+			<row>
+				<item>
+					<checkBox binding="disableIPAddressChangeNotifications" triState="false" />
+				</item>
+			</row>
+			<row>
+				<item>
+					<checkBox binding="disableAccessExceptionNotifications" triState="false" />
+				</item>
+			</row>
+			<row>
+				<item>
+					<checkBox binding="disableSecurityExceptionNotifications" triState="false" />
+				</item>
+			</row>
+	    </form>
     </vbox>
 
     <vbox border="true" borderTitle="admin.startup.accountSettings.frameset.title">

--- a/skyve-war/src/main/java/modules/admin/User/UserBizlet.java
+++ b/skyve-war/src/main/java/modules/admin/User/UserBizlet.java
@@ -285,7 +285,7 @@ public class UserBizlet extends Bizlet<UserExtension> {
 			}
 
 			// Record security event in security log
-			SecurityUtil.log("Password Change", bean.getUserName() + " changed their password");
+			SecurityUtil.log(SecurityUtil.PASSWORD_CHANGE_EVENT_TYPE, bean.getUserName() + " changed their password");
 			
 			// Clear stash
 			CORE.getStash().remove("passwordChanged");

--- a/skyve-war/src/main/java/modules/admin/UserLoginRecord/UserLoginRecordBizlet.java
+++ b/skyve-war/src/main/java/modules/admin/UserLoginRecord/UserLoginRecordBizlet.java
@@ -1,5 +1,6 @@
 package modules.admin.UserLoginRecord;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.skyve.CORE;
@@ -15,6 +16,7 @@ import org.skyve.util.SecurityUtil;
 
 import jakarta.inject.Inject;
 import modules.admin.UserLoginRecord.jobs.DifferentCountryLoginNotificationJob;
+import modules.admin.domain.Startup;
 import modules.admin.domain.User;
 import modules.admin.domain.UserLoginRecord;
 
@@ -33,66 +35,109 @@ public class UserLoginRecordBizlet extends Bizlet<UserLoginRecordExtension> {
 			+ "If this change is unexpected, it might indicate unauthorized access. Please review the user's recent activity for any discrepancies.";
 
 	/**
-	 * The preSave is overridden so as to add the country of the user based on the ip address.
-	 * The method also adds security logs if the ip address and/or the country code of the user changed from the previous login.
-	 * It also kicks off a job sending the user an email if the country changed from the previous login.
+	 * Performs the following security checks:
+	 * 1. If IP address checks are enabled, it geolocates the current IP address
+	 * 2. Retrieves the last X login records for the user (where X is configured in Startup)
+	 * 3. Checks if the current IP address and/or country exists in any of the previous records
+	 * 4. Logs a security event only if the current IP address or country is not found in any previous records
+	 * 5. Sends a notification email if a new country is detected
+	 * 
+	 * The method will only log one security event per login, prioritizing country changes over IP changes
+	 * if both are new.
+	 * 
+	 * @param bean The UserLoginRecord to be saved
+	 * @throws Exception if any error occurs during processing
 	 */
 	@Override
+	@SuppressWarnings("boxing")
 	public void preSave(UserLoginRecordExtension bean) throws Exception {
 		if (bean.isNotPersisted()) {
-			String userName = bean.getUserName();
+			// Check if IP address checks are enabled
+			Startup startup = Startup.newInstance();
+			if (startup.isIpAddressChecksEnabled()) {
+				String userName = bean.getUserName();
 
-			// Geolocate the IP so as to get the country code and country
-			String countryCode = null;
-			String ipAddress = bean.getIpAddress();
-			if (ipAddress != null) {
-				countryCode = geoIPService.geolocate(ipAddress).countryCode();
-				if(countryCode == null) {
-					LOGGER.info(userName + " has logged in from IP Address " + ipAddress);
-				}else {
-					LOGGER.info(userName + " has logged in from IP Address " + ipAddress + " in country: " + countryCode);
-				}
-				bean.setCountryCode(countryCode);
-			}
-			
-			// Get the previous login record of the current user
-			DocumentQuery q = CORE.getPersistence().newDocumentQuery(UserLoginRecord.MODULE_NAME, UserLoginRecord.DOCUMENT_NAME);
-			q.getFilter().addEquals(AppConstants.USER_NAME_ATTRIBUTE_NAME, userName);
-			q.addBoundOrdering(UserLoginRecord.loginDateTimePropertyName, SortDirection.descending);
-			q.setMaxResults(1);
-			UserLoginRecordExtension previousLoginRecord = q.beanResult();
-	
-			// If there is no previous record then this is probably their first login to the system
-			if (previousLoginRecord != null) {
-				String userIPAddress = bean.getIpAddress();
-	
-				// Check if the ip address changed since last login and if so log the event
-				String lastIpAddress = previousLoginRecord.getIpAddress();
-				if (lastIpAddress != null && !Objects.equals(userIPAddress, lastIpAddress)) {
-					// Check if the country has changed since the last login and if so send the user a warning message
-					String previousCountryCode = previousLoginRecord.getCountryCode();
-	
-					if (! Objects.equals(countryCode, previousCountryCode)) {
-						String country = bean.getCountryName();
-						String previousCountry = previousLoginRecord.getCountryName();
-						SecurityUtil.log("User Logged in from Different Country",
-											String.format(COUNTRY_CHANGE_LOG_MESSAGE,
-															userName,
-															(previousCountryCode == null) ? "??" : previousCountryCode,
-															(previousCountry == null) ? "Unknown" : previousCountry,
-															lastIpAddress,
-															(countryCode == null) ? "??" : countryCode,
-															(country == null) ? "Unknown" : country,
-															userIPAddress));
-						
-						// Run job to email user on country change
-						final Module module = CORE.getCustomer().getModule(User.MODULE_NAME);
-						final JobMetaData countryChangeNotificationJobMetaData = module.getJob(DifferentCountryLoginNotificationJob.JOB_NAME);
-						EXT.getJobScheduler().runOneShotJob(countryChangeNotificationJobMetaData, bean, CORE.getUser());
+				// Geolocate the IP so as to get the country code and country
+				String countryCode = null;
+				String ipAddress = bean.getIpAddress();
+				if (ipAddress != null) {
+					countryCode = geoIPService.geolocate(ipAddress).countryCode();
+					if(countryCode == null) {
+						LOGGER.info(userName + " has logged in from IP Address " + ipAddress);
 					} else {
-						// If the country has not changed then the security log shall only have details of an IP change
-						SecurityUtil.log("Change of IP Address from Last Login",
-											String.format(IP_CHANGE_LOG_MESSAGE, userName, lastIpAddress, userIPAddress));
+						LOGGER.info(userName + " has logged in from IP Address " + ipAddress + " in country: " + countryCode);
+					}
+					bean.setCountryCode(countryCode);
+				}
+				
+				// Get the x last previous login record of the current user
+				Integer ipAddressHistoryCountConfig = startup.getIpAddressHistoryCheckCount();
+				int ipAddressHistoryCount = ipAddressHistoryCountConfig != null ? ipAddressHistoryCountConfig : 1;
+
+				DocumentQuery q = CORE.getPersistence().newDocumentQuery(UserLoginRecord.MODULE_NAME, UserLoginRecord.DOCUMENT_NAME);
+				q.getFilter().addEquals(AppConstants.USER_NAME_ATTRIBUTE_NAME, userName);
+				q.addBoundOrdering(UserLoginRecord.loginDateTimePropertyName, SortDirection.descending);
+				q.setMaxResults(ipAddressHistoryCount);
+				List<UserLoginRecordExtension> previousLoginRecords = q.beanResults();
+		
+				// If there are previous records, check if current IP/country is new
+				if (previousLoginRecords != null && !previousLoginRecords.isEmpty() && previousLoginRecords.size() >= ipAddressHistoryCount) {
+					String userIPAddress = bean.getIpAddress();
+					boolean ipFound = false;
+					boolean countryFound = false;
+					String lastKnownIp = null;
+					String lastKnownCountryCode = null;
+					String lastKnownCountry = null;
+					
+					// Check each previous login record
+					for (UserLoginRecordExtension previousRecord : previousLoginRecords) {
+						String lastIpAddress = previousRecord.getIpAddress();
+						String previousCountryCode = previousRecord.getCountryCode();
+						
+						// Check if IP exists in previous records
+						if (lastIpAddress != null && Objects.equals(userIPAddress, lastIpAddress)) {
+							ipFound = true;
+						}
+						
+						// Check if country exists in previous records
+						if (previousCountryCode != null && Objects.equals(countryCode, previousCountryCode)) {
+							countryFound = true;
+						}
+						
+						// Keep track of the most recent values for logging
+						if (lastKnownIp == null && lastIpAddress != null) {
+							lastKnownIp = lastIpAddress;
+							lastKnownCountryCode = previousCountryCode;
+							lastKnownCountry = previousRecord.getCountryName();
+						}
+					}
+					
+					// Log security event if either IP or country is new
+					if (!ipFound || !countryFound) {
+						if (!countryFound) {
+							String country = bean.getCountryName();
+							SecurityUtil.log(SecurityUtil.DIFFERENT_COUNTRY_LOGIN_EVENT_TYPE,
+												String.format(COUNTRY_CHANGE_LOG_MESSAGE,
+																userName,
+																(lastKnownCountryCode == null) ? "??" : lastKnownCountryCode,
+																(lastKnownCountry == null) ? "Unknown" : lastKnownCountry,
+																(lastKnownIp == null) ? "Unknown" : lastKnownIp,
+																(countryCode == null) ? "??" : countryCode,
+																(country == null) ? "Unknown" : country,
+																userIPAddress));
+							
+							// Run job to email user on country change
+							final Module module = CORE.getCustomer().getModule(User.MODULE_NAME);
+							final JobMetaData countryChangeNotificationJobMetaData = module.getJob(DifferentCountryLoginNotificationJob.JOB_NAME);
+							EXT.getJobScheduler().runOneShotJob(countryChangeNotificationJobMetaData, bean, CORE.getUser());
+						} else {
+							// If only IP is new, log IP change
+							SecurityUtil.log(SecurityUtil.IP_ADDRESS_CHANGE_EVENT_TYPE,
+												String.format(IP_CHANGE_LOG_MESSAGE, 
+																userName, 
+																(lastKnownIp == null) ? "Unknown" : lastKnownIp, 
+																userIPAddress));
+						}
 					}
 				}
 			}

--- a/skyve-web/src/main/java/org/skyve/impl/web/SkyveContextListener.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/SkyveContextListener.java
@@ -840,6 +840,17 @@ public class SkyveContextListener implements ServletContextListener {
 		if (primeFlex != null) {
 			UtilImpl.PRIMEFLEX = Boolean.parseBoolean(primeFlex);
 		}
+		
+		Map<String, Object> security = getObject(null, "security", properties, false);
+		if (security != null) {
+			UtilImpl.SECURITY_NOTIFICATIONS_EMAIL_ADDRESS = getString("security", "securityNotificationsEmail", security, false);
+			UtilImpl.DISABLE_GEO_IP_BLOCK_NOTIFICATIONS = getBoolean("security", "disableGeoIPBlockNotifications", security);
+			UtilImpl.DISABLE_PASSWORD_CHANGE_NOTIFICATIONS = getBoolean("security", "disablePasswordChangeNotifications", security);
+			UtilImpl.DISABLE_DIFFERENT_COUNTRY_LOGIN_NOTIFICATIONS = getBoolean("security", "disableDifferentCountryLoginNotifications", security);
+			UtilImpl.DISABLE_IP_ADDRESS_CHANGE_NOTIFICATIONS = getBoolean("security", "disableIPAddressChangeNotifications", security);
+			UtilImpl.DISABLE_ACCESS_EXCEPTION_NOTIFICATIONS = getBoolean("security", "disableAccessExceptionNotifications", security);
+			UtilImpl.DISABLE_SECURITY_EXCEPTION_NOTIFICATIONS = getBoolean("security", "disableSecurityExceptionNotifications", security);
+		}
 
         configureArchiveProperties(properties);
 	}


### PR DESCRIPTION
[Trello](https://trello.com/c/YBgtwgeF)

**Notes**
These changes allow greater configuration of security log email notifications,  IP address change/different country login event types, as well as some general, more minor improvements to the SecurityUtil class.

**Changes**
- Added notification configuration attributes to `admin.Startup`:
	- Separate email address for security log notifications
	- Option to disable notifications for specific default event types
- Added `email` boolean parameter to `SecurityLog.log` methods
- Suppress email notifications when disabled for the given event type
- Refactored email content to only include non-null fields
- Updated email subject line to include event type
- Enabled complete disabling of IP address checks
- Added configuration option for number of IP addresses to check before logging a security event
- Add security stanza to JSON templates