### PR TITLE
Update NewScaffoldedDocumentMojo to add javadoc for the generated methods

### DIFF
--- a/skyve-maven-plugin/pom.xml
+++ b/skyve-maven-plugin/pom.xml
@@ -144,5 +144,12 @@
 		    <artifactId>expressly</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/skyve-maven-plugin/pom.xml
+++ b/skyve-maven-plugin/pom.xml
@@ -151,5 +151,11 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<version>${spring.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/skyve-maven-plugin/pom.xml
+++ b/skyve-maven-plugin/pom.xml
@@ -157,5 +157,10 @@
 			<version>${spring.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/skyve-maven-plugin/src/main/java/org/skyve/toolchain/NewDocumentMojo.java
+++ b/skyve-maven-plugin/src/main/java/org/skyve/toolchain/NewDocumentMojo.java
@@ -140,8 +140,8 @@ public class NewDocumentMojo extends AbstractSkyveMojo {
 		if ((moduleName != null) && (documentName != null)) {
 			// remove any non-word characters and whitespace from the module name
 			String prefix = StringUtils.deleteWhitespace(moduleName.replaceAll("\\W", ""));
-			if (prefix.length() > 3) {
-				prefix = StringUtils.left(moduleName, 3);
+			if (prefix.length() >= 3) {
+				prefix = StringUtils.left(prefix, 3);
 
 				// cleanse the document name of any invalid characters
 				return prefix.toUpperCase() + "_" + documentName;

--- a/skyve-maven-plugin/src/main/java/org/skyve/toolchain/NewScaffoldedDocumentMojo.java
+++ b/skyve-maven-plugin/src/main/java/org/skyve/toolchain/NewScaffoldedDocumentMojo.java
@@ -161,6 +161,11 @@ public class NewScaffoldedDocumentMojo extends NewDocumentMojo {
 
 		final ClassName extensionClassName = ClassName.get("modules." + moduleName + "." + documentName,getExtensionName());
 		final MethodSpec get = MethodSpec.methodBuilder("get")
+				.addJavadoc(CodeBlock.builder()
+						.add("Return the $L with the specified bizId.\n\n", documentName)
+						.add("@param bizId The bizId of the $L to retrieve\n", documentName)
+						.add("@return The $L, or null if one does not exist with the specified bizId", documentName)
+						.build())
 											.addModifiers(Modifier.PUBLIC)
 											.returns(extensionClassName)
 											.addParameter(String.class, "bizId")
@@ -173,7 +178,11 @@ public class NewScaffoldedDocumentMojo extends NewDocumentMojo {
 											.build();
 
 		final MethodSpec getAll = MethodSpec.methodBuilder("getAll")
-												.addModifiers(Modifier.PUBLIC)
+				.addJavadoc(CodeBlock.builder()
+						.add("Retrieves all $Ls in the datastore.\n\n", documentName)
+						.add("@return All $Ls", documentName)
+						.build())
+				.addModifiers(Modifier.PUBLIC)
 												.returns(ParameterizedTypeName.get(ClassName.get(List.class), extensionClassName))
 												.addStatement("final $T query = persistence.newDocumentQuery($T.MODULE_NAME, $T.DOCUMENT_NAME)",
 																DocumentQuery.class,

--- a/skyve-maven-plugin/src/main/java/org/skyve/toolchain/NewScaffoldedDocumentMojo.java
+++ b/skyve-maven-plugin/src/main/java/org/skyve/toolchain/NewScaffoldedDocumentMojo.java
@@ -77,6 +77,12 @@ public class NewScaffoldedDocumentMojo extends NewDocumentMojo {
 	@Parameter
 	private GenerateEditViewConfig generateEditViewConfig;
 
+	/**
+	 * Executes the mojo to create a new scaffolded document.
+	 * This will create all necessary classes and generate the domain and edit view.
+	 * 
+	 * @throws MojoExecutionException if there is an error during execution
+	 */
 	@Override
 	public void execute() throws MojoExecutionException {
 		super.execute();
@@ -89,7 +95,11 @@ public class NewScaffoldedDocumentMojo extends NewDocumentMojo {
 		generateEditView();
 	}
 
-	private void createExtensionClass() {
+	/**
+	 * Creates the document extension class.
+	 * This class extends the base document class and allows for custom behavior.
+	 */
+	void createExtensionClass() {
 		final TypeSpec documentExtension = TypeSpec.classBuilder(getExtensionName())
 														.addModifiers(Modifier.PUBLIC)
 														.superclass(ClassName.get("modules." + moduleName + ".domain", documentName))
@@ -105,7 +115,11 @@ public class NewScaffoldedDocumentMojo extends NewDocumentMojo {
 		}
 	}
 
-	private void createBizletClass() {
+	/**
+	 * Creates the document Bizlet class.
+	 * This class extends Bizlet and provides lifecycle hooks for the document.
+	 */
+	void createBizletClass() {
 		final String bizletName = documentName + "Bizlet";
 		final TypeSpec documentBizlet = TypeSpec.classBuilder(bizletName)
 													.addModifiers(Modifier.PUBLIC)
@@ -123,7 +137,11 @@ public class NewScaffoldedDocumentMojo extends NewDocumentMojo {
 		}
 	}
 
-	private void createFactoryClass() {
+	/**
+	 * Creates the document factory class.
+	 * This class provides factory methods for creating test instances of the document.
+	 */
+	void createFactoryClass() {
 		final String factoryName = documentName + "Factory";
 
 		final ClassName extensionClassName = ClassName.get("modules." + moduleName + "." + documentName, getExtensionName());
@@ -156,7 +174,12 @@ public class NewScaffoldedDocumentMojo extends NewDocumentMojo {
 		}
 	}
 
-	private void createServiceClass() {
+	/**
+	 * Creates the document service class.
+	 * This class provides service layer methods for working with the document.
+	 * It includes methods for retrieving single and multiple instances.
+	 */
+	void createServiceClass() {
 		final String serviceName = documentName + "Service";
 
 		final ClassName extensionClassName = ClassName.get("modules." + moduleName + "." + documentName,getExtensionName());
@@ -207,17 +230,27 @@ public class NewScaffoldedDocumentMojo extends NewDocumentMojo {
 
 		try {
 			javaFile.writeTo(Paths.get(srcDir));
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			LOGGER.warn("Failed to scaffold document service.", e);
 		}
 	}
 
+	/**
+	 * Gets the name of the extension class for the document.
+	 * 
+	 * @return The extension class name (document name + "Extension")
+	 */
 	private String getExtensionName() {
 		return documentName + "Extension";
 	}
 
-	private void generateDomain() throws MojoExecutionException {
+	/**
+	 * Generates the domain classes for the document.
+	 * This includes generating the base document class and any related classes.
+	 * 
+	 * @throws MojoExecutionException if there is an error during generation
+	 */
+	void generateDomain() throws MojoExecutionException {
 		if (generateDomainConfig == null) {
 			throw new MojoExecutionException("Generate domain configuration not specified.");
 		}
@@ -242,6 +275,12 @@ public class NewScaffoldedDocumentMojo extends NewDocumentMojo {
 		}
 	}
 
+	/**
+	 * Generates the edit view for the document.
+	 * This creates the XML view definition for editing the document.
+	 * 
+	 * @throws MojoExecutionException if there is an error during generation
+	 */
 	private void generateEditView() throws MojoExecutionException {
 		try {
 			final String configCustomerName = (generateEditViewConfig != null) ? generateEditViewConfig.getCustomer() : customer;

--- a/skyve-maven-plugin/src/test/java/org/skyve/toolchain/NewDocumentMojoTest.java
+++ b/skyve-maven-plugin/src/test/java/org/skyve/toolchain/NewDocumentMojoTest.java
@@ -1,0 +1,182 @@
+package org.skyve.toolchain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.codehaus.plexus.components.interactivity.Prompter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class NewDocumentMojoTest {
+    
+    @TempDir
+    Path tempDir;
+    
+    private NewDocumentMojo mojo;
+    private String moduleName = "testModule";
+    private String documentName = "TestDocument";
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo = new NewDocumentMojo();
+        
+        // Set private fields using reflection
+        ReflectionTestUtils.setField(mojo, "moduleName", moduleName);
+        ReflectionTestUtils.setField(mojo, "documentName", documentName);
+        
+        // Create module directory structure
+        Path moduleDir = tempDir.resolve("modules").resolve(moduleName);
+        Files.createDirectories(moduleDir);
+        
+        // Create schemas directory and copy schema files
+        Path schemasDir = tempDir.resolve("schemas");
+        Files.createDirectories(schemasDir);
+        
+        // Copy schema files from skyve-war
+        Path sourceSchemasDir = Paths.get(System.getProperty("user.dir"))
+                                   .getParent()  // Go up to workspace root
+                                   .resolve("skyve-war")
+                                   .resolve("src")
+                                   .resolve("main")
+                                   .resolve("java")
+                                   .resolve("schemas");
+        
+        if (Files.exists(sourceSchemasDir)) {
+            try (var files = Files.walk(sourceSchemasDir)) {
+                files.filter(Files::isRegularFile)
+                    .forEach(sourceFile -> {
+                        try {
+                            Path targetFile = schemasDir.resolve(sourceFile.getFileName());
+                            Files.copy(sourceFile, targetFile);
+                        } catch (Exception e) {
+                            throw new RuntimeException("Failed to copy schema file: " + sourceFile, e);
+                        }
+                    });
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to walk schema directory: " + sourceSchemasDir, e);
+            }
+        } else {
+            System.out.println("Source schemas directory does not exist!");
+        }
+        
+        // Create module metadata file
+        String moduleXml = String.format("""
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <module xmlns="http://www.skyve.org/xml/module" name="%s" title="%s">
+                <documentation>Test module documentation</documentation>
+                <homeDocument>%s</homeDocument>
+                <documents>
+                    <document ref="%s"/>
+                </documents>
+                <menu/>
+            </module>""", moduleName, moduleName, documentName, documentName);
+        Files.write(moduleDir.resolve(moduleName + ".xml"), moduleXml.getBytes());
+        
+        // Set project and source directory
+        org.apache.maven.project.MavenProject project = new org.apache.maven.project.MavenProject();
+        project.addCompileSourceRoot(tempDir.toString());
+        ReflectionTestUtils.setField(mojo, "project", project);
+        
+        // Set up NewDocumentConfig to avoid prompter for module name
+        org.skyve.toolchain.config.NewDocumentConfig config = new org.skyve.toolchain.config.NewDocumentConfig();
+        config.setDefaultModule(moduleName);
+        ReflectionTestUtils.setField(mojo, "newDocumentConfig", config);
+        
+        // Set up mock prompter for document name
+        Prompter mockPrompter = mock(Prompter.class);
+        when(mockPrompter.prompt(anyString())).thenReturn(documentName);
+        ReflectionTestUtils.setField(mojo, "prompter", mockPrompter);
+    }
+    
+    /**
+     * Tests the creation of a new document.
+     * 
+     * Preconditions:
+     * - mojo is initialized with moduleName and documentName
+     * - Module directory and metadata exist
+     * - srcDir is set to a temporary directory
+     * 
+     * Postconditions:
+     * - Document directory is created
+     * - Document metadata file is created with correct content
+     * - Module metadata is updated to include the new document
+     */
+    @Test
+    void testExecute() throws Exception {
+        // Execute the mojo
+        mojo.execute();
+        
+        // Verify document directory was created
+        Path documentDir = tempDir.resolve("modules")
+                                .resolve(moduleName)
+                                .resolve(documentName);
+        assertTrue(Files.exists(documentDir), "Document directory should exist");
+        
+        // Verify document metadata file was created
+        Path documentXml = documentDir.resolve(documentName + ".xml");
+        assertTrue(Files.exists(documentXml), "Document metadata file should exist");
+        
+        // Read and verify document metadata content
+        String content = Files.readString(documentXml);
+        assertTrue(content.contains("name=\"" + documentName + "\""), 
+                  "Document metadata should have correct name");
+        assertTrue(content.contains("<singularAlias>" + documentName + "</singularAlias>"), 
+                  "Document metadata should have correct singular alias");
+        assertTrue(content.contains("<pluralAlias>" + documentName.toLowerCase() + "s</pluralAlias>"), 
+                  "Document metadata should have correct plural alias");
+        
+        // Verify module metadata was updated
+        Path moduleXml = tempDir.resolve("modules")
+                              .resolve(moduleName)
+                              .resolve(moduleName + ".xml");
+        String moduleContent = Files.readString(moduleXml);
+        assertTrue(moduleContent.contains("ref=\"" + documentName + "\""), 
+                  "Module metadata should include the new document");
+    }
+    
+    /**
+     * Tests the generation of a persistent name for a document.
+     * 
+     * Preconditions:
+     * - mojo is initialized with moduleName and documentName
+     * 
+     * Postconditions:
+     * - Generated persistent name follows the correct format (first 3 chars of module + _ + document name)
+     */
+	@Test
+	@SuppressWarnings("static-method")
+    void testGeneratePersistentName() throws Exception {
+        // Get the private method using reflection
+        java.lang.reflect.Method generatePersistentName = NewDocumentMojo.class.getDeclaredMethod("generatePersistentName", 
+                                                                                                String.class, 
+                                                                                                String.class);
+        generatePersistentName.setAccessible(true);
+        
+        // Test with a module name longer than 3 characters
+        String result = (String) generatePersistentName.invoke(null, "LongModule", "TestDoc");
+        assertEquals("LON_TestDoc", result, "Persistent name should be correctly formatted");
+        
+        // Test with a module name exactly 3 characters
+        result = (String) generatePersistentName.invoke(null, "Abc", "TestDoc");
+        assertEquals("ABC_TestDoc", result, "Persistent name should be correctly formatted for 3-character module name");
+        
+        // Test with a module name shorter than 3 characters
+        result = (String) generatePersistentName.invoke(null, "Ab", "TestDoc");
+        assertNull(result, "Persistent name should be null for module name shorter than 3 characters");
+        
+        // Test with null inputs
+        result = (String) generatePersistentName.invoke(null, null, null);
+        assertNull(result, "Persistent name should be null for null inputs");
+    }
+} 

--- a/skyve-maven-plugin/src/test/java/org/skyve/toolchain/NewScaffoldedDocumentMojoTest.java
+++ b/skyve-maven-plugin/src/test/java/org/skyve/toolchain/NewScaffoldedDocumentMojoTest.java
@@ -1,0 +1,107 @@
+package org.skyve.toolchain;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class NewScaffoldedDocumentMojoTest {
+    
+    @TempDir
+    Path tempDir;
+    
+    private NewScaffoldedDocumentMojo mojo;
+    private String moduleName = "testModule";
+    private String documentName = "TestDocument";
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo = new NewScaffoldedDocumentMojo();
+        
+        // Set private fields using reflection, including fields from parent class
+        setPrivateField(mojo, "moduleName", moduleName, NewDocumentMojo.class);
+        setPrivateField(mojo, "documentName", documentName, NewDocumentMojo.class);
+        setPrivateField(mojo, "srcDir", tempDir.toString(), NewScaffoldedDocumentMojo.class);
+    }
+    
+    @Test
+    void testCreateServiceClass() throws Exception {
+        // Get the private method using reflection
+        Method createServiceClass = NewScaffoldedDocumentMojo.class.getDeclaredMethod("createServiceClass");
+        createServiceClass.setAccessible(true);
+        
+        // Execute the method
+        createServiceClass.invoke(mojo);
+        
+        // Verify the service class file was created
+        Path serviceFile = Paths.get(tempDir.toString(), 
+                                   "modules", 
+                                   moduleName, 
+                                   documentName, 
+                                   documentName + "Service.java");
+        assertTrue(Files.exists(serviceFile), "Service class file should exist");
+        
+        // Read the file content
+        String content = Files.readString(serviceFile);
+        
+        // Verify the class name
+        assertTrue(content.contains("public class " + documentName + "Service"), 
+                  "Class should have correct name");
+        
+        // Verify the @Default annotation
+        assertTrue(content.contains("@Default"), 
+                  "Class should have @Default annotation");
+        
+        // Verify the Persistence injection
+        assertTrue(content.contains("@Inject"), 
+                  "Class should have @Inject annotation");
+        assertTrue(content.contains("private Persistence persistence"), 
+                  "Class should have Persistence field");
+        
+        // Verify the get method and its javadoc
+        String expectedGetMethodJavadoc = String.format("""
+            /**
+             * Return the %s with the specified bizId.
+             * 
+             * @param bizId The bizId of the %s to retrieve
+             * @return The %s, or null if one does not exist with the specified bizId
+             */""", documentName, documentName, documentName);
+        assertTrue(normalizeWhitespace(content).contains(normalizeWhitespace(expectedGetMethodJavadoc)), 
+                  "get method should have correct javadoc");
+        assertTrue(content.contains("public " + documentName + "Extension get(String bizId)"), 
+                  "Class should have get method");
+        
+        // Verify the getAll method and its javadoc
+        String expectedGetAllMethodJavadoc = String.format("""
+            /**
+             * Retrieves all %ss in the datastore.
+             * 
+             * @return All %ss
+             */""", documentName, documentName);
+        assertTrue(normalizeWhitespace(content).contains(normalizeWhitespace(expectedGetAllMethodJavadoc)), 
+                  "getAll method should have correct javadoc");
+        assertTrue(content.contains("public List<" + documentName + "Extension> getAll()"), 
+                  "Class should have getAll method");
+        
+        // Verify the class javadoc
+        assertTrue(content.contains("This class acts as a service layer to encapsulate domain logic"), 
+                  "Class should have correct javadoc");
+    }
+    
+    private static void setPrivateField(Object target, String fieldName, Object value, Class<?> declaringClass) throws Exception {
+        Field field = declaringClass.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+    
+    private static String normalizeWhitespace(String input) {
+        return input.replaceAll("\\s+", " ").trim();
+    }
+} 

--- a/skyve-maven-plugin/src/test/java/org/skyve/toolchain/NewScaffoldedDocumentMojoTest.java
+++ b/skyve-maven-plugin/src/test/java/org/skyve/toolchain/NewScaffoldedDocumentMojoTest.java
@@ -2,7 +2,6 @@ package org.skyve.toolchain;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -31,71 +30,206 @@ class NewScaffoldedDocumentMojoTest {
         ReflectionTestUtils.setField(mojo, "srcDir", tempDir.toString());
     }
     
+    /**
+	 * Tests the creation of a Bizlet class for a document.
+	 * 
+	 * Preconditions:
+	 * - mojo is initialized with moduleName and documentName
+	 * - srcDir is set to a temporary directory
+	 * 
+	 * Postconditions:
+	 * - A Bizlet class file is created in the correct location
+	 * - The class has the correct name and is public
+	 * - The class extends Bizlet with the correct type parameter
+	 */
     @Test
-    void testCreateServiceClass() throws Exception {
-        // Get the private method using reflection
-		Method createServiceClass = NewScaffoldedDocumentMojo.class.getDeclaredMethod("createServiceClass");
-		createServiceClass.setAccessible(true);
+	void testCreateBizletClass() throws Exception {
+        // Execute the method directly
+		mojo.createBizletClass();
         
-        // Execute the method
-		createServiceClass.invoke(mojo);
+		// Verify the bizlet class file was created
+		Path bizletFile = Paths.get(tempDir.toString(),
+				"modules",
+				moduleName,
+				documentName,
+				documentName + "Bizlet.java");
+		assertTrue(Files.exists(bizletFile), "Bizlet class file should exist");
         
-        // Verify the service class file was created
-        Path serviceFile = Paths.get(tempDir.toString(), 
+        // Read the file content
+		String content = Files.readString(bizletFile);
+        
+        // Verify the class name
+		assertTrue(content.contains("public class " + documentName + "Bizlet"),
+                  "Class should have correct name");
+        
+		// Verify the superclass
+		String expectedSuperclass = "Bizlet<" + documentName + "Extension>";
+		assertTrue(normalizeWhitespace(content).contains(normalizeWhitespace(expectedSuperclass)),
+				"Class should extend Bizlet with correct type parameter");
+    }
+    
+    /**
+     * Tests the creation of a factory class for a document.
+     * 
+     * Preconditions:
+     * - mojo is initialized with moduleName and documentName
+     * - srcDir is set to a temporary directory
+     * 
+     * Postconditions:
+     * - A factory class file is created in the correct location
+     * - The class has the correct name and is public
+     * - The class has @SkyveFactory annotation
+     * - The class has a crudInstance() method with @SkyveFixture annotation
+     * - The crudInstance() method returns the correct type and has the correct implementation
+     */
+    @Test
+    void testCreateFactoryClass() throws Exception {
+        // Execute the method directly
+        mojo.createFactoryClass();
+        
+        // Verify the factory class file was created
+        Path factoryFile = Paths.get(tempDir.toString(), 
                                    "modules", 
                                    moduleName, 
                                    documentName, 
-                                   documentName + "Service.java");
-        assertTrue(Files.exists(serviceFile), "Service class file should exist");
+                                   documentName + "Factory.java");
+        assertTrue(Files.exists(factoryFile), "Factory class file should exist");
         
         // Read the file content
-        String content = Files.readString(serviceFile);
+        String content = Files.readString(factoryFile);
         
         // Verify the class name
-        assertTrue(content.contains("public class " + documentName + "Service"), 
+        assertTrue(content.contains("public class " + documentName + "Factory"), 
                   "Class should have correct name");
         
-        // Verify the @Default annotation
-        assertTrue(content.contains("@Default"), 
-                  "Class should have @Default annotation");
+        // Verify the @SkyveFactory annotation
+        assertTrue(content.contains("@SkyveFactory"), 
+                  "Class should have @SkyveFactory annotation");
         
-        // Verify the Persistence injection
-        assertTrue(content.contains("@Inject"), 
-                  "Class should have @Inject annotation");
-        assertTrue(content.contains("private Persistence persistence"), 
-                  "Class should have Persistence field");
+        // Verify the crudInstance method and its annotation
+		assertTrue(normalizeWhitespace(content).contains(normalizeWhitespace("@SkyveFixture(types = SkyveFixture.FixtureType.crud)")), 
+                  "crudInstance method should have correct annotation");
+        assertTrue(content.contains("public " + documentName + "Extension crudInstance()"), 
+                  "Class should have crudInstance method");
         
-        // Verify the get method and its javadoc
-        String expectedGetMethodJavadoc = String.format("""
-            /**
-             * Return the %s with the specified bizId.
-             * 
-             * @param bizId The bizId of the %s to retrieve
-             * @return The %s, or null if one does not exist with the specified bizId
-             */""", documentName, documentName, documentName);
-        assertTrue(normalizeWhitespace(content).contains(normalizeWhitespace(expectedGetMethodJavadoc)), 
-                  "get method should have correct javadoc");
-        assertTrue(content.contains("public " + documentName + "Extension get(String bizId)"), 
-                  "Class should have get method");
+        // Verify the method implementation
+		assertTrue(content.contains("return new DataBuilder().fixture(SkyveFixture.FixtureType.crud)"),
+                  "crudInstance method should have correct implementation");
+    }
+    
+    /**
+	 * Tests the creation of an extension class for a document.
+	 * 
+	 * Preconditions:
+	 * - mojo is initialized with moduleName and documentName
+	 * - srcDir is set to a temporary directory
+	 * 
+	 * Postconditions:
+	 * - An extension class file is created in the correct location
+	 * - The class has the correct name and is public
+	 * - The class extends the base document class
+	 */
+	@Test
+	void testCreateExtensionClass() throws Exception {
+		// Execute the method directly
+		mojo.createExtensionClass();
+
+		// Verify the extension class file was created
+		Path extensionFile = Paths.get(tempDir.toString(),
+				"modules",
+				moduleName,
+				documentName,
+				documentName + "Extension.java");
+		assertTrue(Files.exists(extensionFile), "Extension class file should exist");
+
+		// Read the file content
+		String content = Files.readString(extensionFile);
+
+		// Verify the class name
+		assertTrue(content.contains("public class " + documentName + "Extension"),
+				"Class should have correct name");
+
+		// Verify the superclass
+		String expectedSuperclass = "extends " + documentName;
+		assertTrue(normalizeWhitespace(content).contains(normalizeWhitespace(expectedSuperclass)),
+				"Class should extend the base document class");
+	}
+
+	/**
+	 * Tests the creation of a service class for a document.
+	 * 
+	 * Preconditions:
+	 * - mojo is initialized with moduleName and documentName
+	 * - srcDir is set to a temporary directory
+	 * 
+	 * Postconditions:
+	 * - A service class file is created in the correct location
+	 * - The class has the correct name and is public
+	 * - The class has @Default annotation
+	 * - The class has an injected Persistence field
+	 * - The class has get() and getAll() methods with correct signatures and implementations
+	 */
+    @Test
+	void testCreateServiceClass() throws Exception {
+        // Execute the method directly
+		mojo.createServiceClass();
         
-        // Verify the getAll method and its javadoc
-        String expectedGetAllMethodJavadoc = String.format("""
-            /**
-             * Retrieves all %ss in the datastore.
-             * 
-             * @return All %ss
-             */""", documentName, documentName);
-        assertTrue(normalizeWhitespace(content).contains(normalizeWhitespace(expectedGetAllMethodJavadoc)), 
-                  "getAll method should have correct javadoc");
-        assertTrue(content.contains("public List<" + documentName + "Extension> getAll()"), 
-                  "Class should have getAll method");
+		// Verify the service class file was created
+		Path serviceFile = Paths.get(tempDir.toString(),
+				"modules",
+				moduleName,
+				documentName,
+				documentName + "Service.java");
+		assertTrue(Files.exists(serviceFile), "Service class file should exist");
         
-        // Verify the class javadoc
-        assertTrue(content.contains("This class acts as a service layer to encapsulate domain logic"), 
-                  "Class should have correct javadoc");
+        // Read the file content
+		String content = Files.readString(serviceFile);
+        
+        // Verify the class name
+		assertTrue(content.contains("public class " + documentName + "Service"),
+                  "Class should have correct name");
+        
+		// Verify the @Default annotation
+		assertTrue(content.contains("@Default"),
+				"Class should have @Default annotation");
+
+		// Verify the Persistence injection
+		assertTrue(content.contains("@Inject"),
+				"Class should have @Inject annotation");
+		assertTrue(content.contains("private Persistence persistence"),
+				"Class should have Persistence field");
+
+		// Verify the get method and its javadoc
+		String expectedGetMethodJavadoc = String.format("""
+				/**
+				 * Return the %s with the specified bizId.
+				 *
+				 * @param bizId The bizId of the %s to retrieve
+				 * @return The %s, or null if one does not exist with the specified bizId
+				 */""", documentName, documentName, documentName);
+		assertTrue(normalizeWhitespace(content).contains(normalizeWhitespace(expectedGetMethodJavadoc)),
+				"get method should have correct javadoc");
+		assertTrue(content.contains("public " + documentName + "Extension get(String bizId)"),
+				"Class should have get method");
+
+		// Verify the getAll method and its javadoc
+		String expectedGetAllMethodJavadoc = String.format("""
+				/**
+				 * Retrieves all %ss in the datastore.
+				 *
+				 * @return All %ss
+				 */""", documentName, documentName);
+		assertTrue(normalizeWhitespace(content).contains(normalizeWhitespace(expectedGetAllMethodJavadoc)),
+				"getAll method should have correct javadoc");
+		assertTrue(content.contains("public List<" + documentName + "Extension> getAll()"),
+				"Class should have getAll method");
+
+		// Verify the class javadoc
+		assertTrue(content.contains("This class acts as a service layer to encapsulate domain logic"),
+				"Class should have correct javadoc");
     }
     
     private static String normalizeWhitespace(String input) {
-        return input.replaceAll("\\s+", " ").trim();
+        return input.replaceAll("\\s+", "").trim();
     }
 } 

--- a/skyve-maven-plugin/src/test/java/org/skyve/toolchain/NewScaffoldedDocumentMojoTest.java
+++ b/skyve-maven-plugin/src/test/java/org/skyve/toolchain/NewScaffoldedDocumentMojoTest.java
@@ -2,7 +2,6 @@ package org.skyve.toolchain;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -11,6 +10,7 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class NewScaffoldedDocumentMojoTest {
     
@@ -25,20 +25,20 @@ class NewScaffoldedDocumentMojoTest {
     void setUp() throws Exception {
         mojo = new NewScaffoldedDocumentMojo();
         
-        // Set private fields using reflection, including fields from parent class
-        setPrivateField(mojo, "moduleName", moduleName, NewDocumentMojo.class);
-        setPrivateField(mojo, "documentName", documentName, NewDocumentMojo.class);
-        setPrivateField(mojo, "srcDir", tempDir.toString(), NewScaffoldedDocumentMojo.class);
+        // Set private fields using reflection
+        ReflectionTestUtils.setField(mojo, "moduleName", moduleName);
+        ReflectionTestUtils.setField(mojo, "documentName", documentName);
+        ReflectionTestUtils.setField(mojo, "srcDir", tempDir.toString());
     }
     
     @Test
     void testCreateServiceClass() throws Exception {
         // Get the private method using reflection
-        Method createServiceClass = NewScaffoldedDocumentMojo.class.getDeclaredMethod("createServiceClass");
-        createServiceClass.setAccessible(true);
+		Method createServiceClass = NewScaffoldedDocumentMojo.class.getDeclaredMethod("createServiceClass");
+		createServiceClass.setAccessible(true);
         
         // Execute the method
-        createServiceClass.invoke(mojo);
+		createServiceClass.invoke(mojo);
         
         // Verify the service class file was created
         Path serviceFile = Paths.get(tempDir.toString(), 
@@ -93,12 +93,6 @@ class NewScaffoldedDocumentMojoTest {
         // Verify the class javadoc
         assertTrue(content.contains("This class acts as a service layer to encapsulate domain logic"), 
                   "Class should have correct javadoc");
-    }
-    
-    private static void setPrivateField(Object target, String fieldName, Object value, Class<?> declaringClass) throws Exception {
-        Field field = declaringClass.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(target, value);
     }
     
     private static String normalizeWhitespace(String input) {


### PR DESCRIPTION
Calling the NewScaffoldedDocument mojo should now generate a service class with javadoc for the public `get()` and `getAll()` service class methods.

- added unit test (using reflection to access private methods), not sure if the method should be default instead to make this less ugly