### PR TITLE
Deny access to inactive Skyve users even if OAuth successful

### DIFF
--- a/skyve-core/src/main/java/org/skyve/impl/metadata/repository/AbstractDynamicRepository.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/repository/AbstractDynamicRepository.java
@@ -156,8 +156,8 @@ public abstract class AbstractDynamicRepository extends MutableCachedRepository 
 	}
 
 	@Override
-	public void populatePermissions(User user) {
-		// nothing to do
+	public boolean populatePermissions(User user) {
+		return false;
 	}
 
 	@Override
@@ -166,8 +166,8 @@ public abstract class AbstractDynamicRepository extends MutableCachedRepository 
 	}
 	
 	@Override
-	public void populateUser(User user, Connection connection) {
-		// nothing to do
+	public boolean populateUser(User user, Connection connection) {
+		return false;
 	}
 
 	@Override

--- a/skyve-core/src/main/java/org/skyve/impl/metadata/repository/LocalDesignRepository.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/repository/LocalDesignRepository.java
@@ -99,7 +99,7 @@ public class LocalDesignRepository extends FileSystemRepository {
 	
 	@Override
 	public boolean populatePermissions(User user) {
-		return false;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/skyve-core/src/main/java/org/skyve/impl/metadata/repository/LocalDesignRepository.java
+++ b/skyve-core/src/main/java/org/skyve/impl/metadata/repository/LocalDesignRepository.java
@@ -98,8 +98,8 @@ public class LocalDesignRepository extends FileSystemRepository {
 	}
 	
 	@Override
-	public void populatePermissions(User user) {
-		throw new UnsupportedOperationException();
+	public boolean populatePermissions(User user) {
+		return false;
 	}
 
 	@Override
@@ -108,7 +108,7 @@ public class LocalDesignRepository extends FileSystemRepository {
 	}
 
 	@Override
-	public void populateUser(User user, Connection connection) {
+	public boolean populateUser(User user, Connection connection) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/skyve-core/src/main/java/org/skyve/metadata/repository/DelegatingProvidedRepositoryChain.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/repository/DelegatingProvidedRepositoryChain.java
@@ -313,10 +313,13 @@ public class DelegatingProvidedRepositoryChain extends ProvidedRepositoryDelegat
 	}
 
 	@Override
-	public void populatePermissions(User user) {
-		for (ProvidedRepository delegate : delegates) {
-			delegate.populatePermissions(user);
-		}
+	public boolean populatePermissions(User user) {
+	    for (ProvidedRepository delegate : delegates) {
+			if (delegate.populatePermissions(user)) {
+	            return true;
+	        }
+	    }
+	    return false;
 	}
 
 	@Override
@@ -327,10 +330,13 @@ public class DelegatingProvidedRepositoryChain extends ProvidedRepositoryDelegat
 	}
 
 	@Override
-	public void populateUser(User user, Connection connection) {
+	public boolean populateUser(User user, Connection connection) {
 		for (ProvidedRepository delegate : delegates) {
-			delegate.populateUser(user, connection);
+			if (delegate.populateUser(user, connection)) {
+				return true;
+			}
 		}
+		return false;
 	}
 	
 	@Override

--- a/skyve-core/src/main/java/org/skyve/metadata/repository/NoOpProvidedRepository.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/repository/NoOpProvidedRepository.java
@@ -124,8 +124,8 @@ public class NoOpProvidedRepository extends ProvidedRepositoryDelegate {
 	}
 
 	@Override
-	public void populatePermissions(User user) {
-		// do nothing
+	public boolean populatePermissions(User user) {
+		return false;
 	}
 
 	@Override
@@ -134,8 +134,8 @@ public class NoOpProvidedRepository extends ProvidedRepositoryDelegate {
 	}
 
 	@Override
-	public void populateUser(User user, Connection connection) {
-		// nothing to do
+	public boolean populateUser(User user, Connection connection) {
+		return false;
 	}
 
 	@Override

--- a/skyve-core/src/main/java/org/skyve/metadata/repository/ProvidedRepository.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/repository/ProvidedRepository.java
@@ -205,8 +205,9 @@ public interface ProvidedRepository extends CachedRepository {
 	/**
 	 * Populate the permissions available to a user.
 	 * @param user the user to populate permissions for
+	 * @return {@code true} if the user's permissions are successfully populated.
 	 */
-	void populatePermissions(@Nonnull User user);
+	boolean populatePermissions(@Nonnull User user);
 	
 	
 	/**
@@ -221,9 +222,10 @@ public interface ProvidedRepository extends CachedRepository {
 	/**
 	 * Populate user data from a data store using the given connection.
 	 * @param user User to populate.
-	 * @param connection	The connection to use.
+	 * @param connection The connection to use.
+	 * @return {@code true} if user is successfully populated.
 	 */
-	void populateUser(@Nonnull User user, @Nonnull Connection connection);
+	boolean populateUser(@Nonnull User user, @Nonnull Connection connection);
 	
 	/**
 	 * Return a list of admin.JobSchedule projections with at least the following document attributes populated

--- a/skyve-core/src/main/java/org/skyve/metadata/repository/SessionScopedDelegatingProvidedRepository.java
+++ b/skyve-core/src/main/java/org/skyve/metadata/repository/SessionScopedDelegatingProvidedRepository.java
@@ -323,11 +323,13 @@ public class SessionScopedDelegatingProvidedRepository extends ProvidedRepositor
 	}
 
 	@Override
-	public void populatePermissions(User user) {
+	public boolean populatePermissions(User user) {
 		ProvidedRepository delegate = getSessionDelegate();
 		if (delegate != null) {
-			delegate.populatePermissions(user);
+			return delegate.populatePermissions(user);
 		}
+
+		return false;
 	}
 
 	@Override
@@ -339,11 +341,13 @@ public class SessionScopedDelegatingProvidedRepository extends ProvidedRepositor
 	}
 
 	@Override
-	public void populateUser(User user, Connection connection) {
+	public boolean populateUser(User user, Connection connection) {
 		ProvidedRepository delegate = getSessionDelegate();
 		if (delegate != null) {
-			delegate.populateUser(user, connection);
+			return delegate.populateUser(user, connection);
 		}
+
+		return false;
 	}
 	
 	@Override

--- a/skyve-ext/src/main/java/org/skyve/util/SecurityUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/util/SecurityUtil.java
@@ -38,7 +38,7 @@ public class SecurityUtil {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(SecurityUtil.class);
 
-	private static final String FALLBACK_SECURITY_USER = "securityUser";
+	private static final String ANONYMOUS_SECURITY_USER = "securityUser";
 
 	/**
 	 * Creates a security log entry and optionally sends an email notification for the specified exception.
@@ -113,8 +113,8 @@ public class SecurityUtil {
 				superUser = new SuperUser(associatedUser);
 			} else {
 				superUser = new SuperUser();
-				superUser.setName(FALLBACK_SECURITY_USER);
-				superUser.setId(FALLBACK_SECURITY_USER);
+				superUser.setName(ANONYMOUS_SECURITY_USER);
+				superUser.setId(ANONYMOUS_SECURITY_USER);
 
 				// Attempt to determine the customer
 				String defaultCustomerName = UtilImpl.CUSTOMER;

--- a/skyve-war/src/main/webapp/home.jsp
+++ b/skyve-war/src/main/webapp/home.jsp
@@ -2,6 +2,7 @@
 <%@ page import="java.security.Principal"%>
 <%@ page import="java.util.Enumeration"%>
 <%@ page import="jakarta.servlet.http.Cookie"%>
+<%@ page import="org.skyve.domain.messages.SecurityException"%>
 <%@ page import="org.skyve.metadata.customer.Customer"%>
 <%@ page import="org.skyve.metadata.user.User"%>
 <%@ page import="org.skyve.metadata.repository.ProvidedRepository"%>
@@ -161,8 +162,10 @@
 			try {
 				persistence.begin();
 				user = WebUtil.processUserPrincipalForRequest(request, userName);
-			}
-			finally {
+			} catch (SecurityException e) {
+				response.sendRedirect(response.encodeRedirectURL(Util.getBaseUrl() + "login"));
+				return;
+			} finally {
 				if (persistence != null) {
 					persistence.commit(true);
 				}


### PR DESCRIPTION
[Trello](https://trello.com/c/S9fOv9cL)

**Notes**
This PR updates `LocalDataStoreRepository.populateUser` to include a check for the user's inactive status. As a result, users authenticated via OAuth who are marked as inactive will be denied access and redirected to the login page with a specific message.

To support this behavior without throwing a `SecurityException` in all use cases (e.g., `UserExtension.toMetadataUser`), the method was revised to return a boolean indicating success or failure.

Additionally, a minor adjustment was made to `SecurityLog` to ensure that logs can still be recorded even when no user is present in the current persistence context (e.g., operations performed by the `SuperUser`).

**Changes**
- Updated `ProvidedRepository.populateUser` to return boolean
- Redirect user to login page with error if user is authenticated but without permissions
- Updated `SecurityUtil.log` to use a fallback `SuperUser` to persist record