### PR TITLE
[datagrid] Fix a bug where the action column in a data grid isn't displayed

### DIFF
--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/pipeline/component/TabularComponentBuilder.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/pipeline/component/TabularComponentBuilder.java
@@ -903,7 +903,9 @@ public abstract class TabularComponentBuilder extends ComponentBuilder {
 				children.add(button);
 			}
 
-			if (! children.isEmpty()) {
+			// If any of the 'add','remove' or 'zoom' controls were added to the row
+			// or header above, add the control column to the grid component
+			if (! children.isEmpty() || !columnHeader.getChildren().isEmpty()) {
 				if (children.size() > 1) {
 					col.setWidth(DOUBLE_ACTION_COLUMN_WIDTH);
 					col.setStyle("text-align:center !important");


### PR DESCRIPTION
If the data grid "action" column would only contain the 'add' control the column wasn't being added to the grid.

Using these properties on the grid will replicate the issue: 
showZoom="false"
showAdd="true"
showRemove="false"