### PR TITLE
Set async-supported=true on servlets & filters

### DIFF
--- a/skyve-war/src/main/java/org/skyve/impl/web/spring/SpringSecurityConfig.java
+++ b/skyve-war/src/main/java/org/skyve/impl/web/spring/SpringSecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -29,8 +28,7 @@ import org.springframework.security.web.authentication.rememberme.PersistentToke
  */
 @Configuration
 @Import(SkyveSpringSecurityConfig.class)
-@EnableWebSecurity 
-@EnableAsync
+@EnableWebSecurity
 public class SpringSecurityConfig {
 	@Autowired
 	private SkyveSpringSecurity skyve;


### PR DESCRIPTION
In order to resolve the following warning coming out of the SSE sending code I've added `<async-supported>true</async-supported>` to all servlets and filters.
> RESTEASY002186: Failed to set servlet request into asynchronous mode, server sent events may not work