### PR TITLE
Correct backups 'zip' regex

### DIFF
--- a/skyve-war/src/main/java/modules/admin/DataMaintenance/models/BackupsModel.java
+++ b/skyve-war/src/main/java/modules/admin/DataMaintenance/models/BackupsModel.java
@@ -172,7 +172,7 @@ public class BackupsModel extends ListModel<DataMaintenance> {
 				}
 			}
 		} else {
-			File[] files = FileUtil.listFiles(new File(dirPath), ".*.zip", SortDirection.descending);
+			File[] files = FileUtil.listFiles(new File(dirPath), ".*\\.zip", SortDirection.descending);
 			if (files != null) {
 				for (File file : files) {
 					Long fileSize = Long.valueOf(Files.size(file.toPath()));


### PR DESCRIPTION
Previous regex matched anything ending in `zip`, rather than `.zip`.