### PR TITLE
Potential fix for code scanning alert no. 38: Server-side request forgery

### DIFF
--- a/skyve-ext/src/main/java/org/skyve/impl/geoip/IPInfoIo.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/geoip/IPInfoIo.java
@@ -5,6 +5,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -23,12 +25,64 @@ public class IPInfoIo extends AbstractCachingGeoIPService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IPInfoIo.class);
 
+	// Simple, conservative patterns for IPv4 and IPv6 literals.
+	// These are intended to prevent URL path manipulation, not to be a complete IP parser.
+	private static final Pattern IPV4_PATTERN = Pattern.compile(
+			"^(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)" +
+			"(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}$");
+
+	private static final Pattern IPV6_PATTERN = Pattern.compile(
+			"^([0-9a-fA-F]{1,4})(:([0-9a-fA-F]{1,4})){1,7}$");
+
+	/**
+	 * Validate and normalise an IP address string to ensure it cannot manipulate the request URL.
+	 * Returns the trimmed IP if valid, or null if invalid.
+	 */
+	private static String sanitizeIpAddress(String ipAddress) {
+		if (ipAddress == null) {
+			return null;
+		}
+		String trimmed = ipAddress.trim();
+		if (trimmed.isEmpty()) {
+			return null;
+		}
+
+		// Reject characters that could break path or introduce query/fragment.
+		if (trimmed.contains("/") || trimmed.contains("?") || trimmed.contains("#")) {
+			return null;
+		}
+
+		Matcher ipv4Matcher = IPV4_PATTERN.matcher(trimmed);
+		if (ipv4Matcher.matches()) {
+			return trimmed;
+		}
+
+		Matcher ipv6Matcher = IPV6_PATTERN.matcher(trimmed);
+		if (ipv6Matcher.matches()) {
+			return trimmed;
+		}
+
+		return null;
+	}
+
 	@Override
 	protected IPGeolocation doGeolocation(String ipAddress) {
 		IPGeolocation result = IPGeolocation.EMPTY;
+
+		// Sanitize the IP address derived from HTTP headers before using it in a URL.
+		String safeIpAddress = sanitizeIpAddress(ipAddress);
+		if (safeIpAddress == null) {
+			LOGGER.warn("Skipping GeoIP lookup for invalid IP address value: {}", ipAddress);
+			return result;
+		}
 		
 		HttpClient client = HttpClient.newHttpClient();
-		String requestUrl = new StringBuilder(96).append(IPINFO_DOMAIN).append(ipAddress).append("/json?token=").append(UtilImpl.GEO_IP_KEY).toString();
+		String requestUrl = new StringBuilder(96)
+				.append(IPINFO_DOMAIN)
+				.append(safeIpAddress)
+				.append("/json?token=")
+				.append(UtilImpl.GEO_IP_KEY)
+				.toString();
 
 		HttpRequest request = HttpRequest.newBuilder().uri(URI.create(requestUrl)).GET().build();
 
@@ -53,11 +107,11 @@ public class IPInfoIo extends AbstractCachingGeoIPService {
 				result = new IPGeolocation(city, region, countryCode, location);
 			}
 			else {
-				LOGGER.error("Error fetching data IP : {} : HTTP Error - {}", ipAddress, response.statusCode());
+				LOGGER.error("Error fetching data IP : {} : HTTP Error - {}", safeIpAddress, response.statusCode());
 			}
 		}
 		catch (Exception e) {
-			LOGGER.error("Error fetching data: IP {}", ipAddress, e);
+			LOGGER.error("Error fetching data: IP {}", safeIpAddress, e);
 		}
 		
 		return result;


### PR DESCRIPTION
Potential fix for [https://github.com/skyvers/skyve/security/code-scanning/38](https://github.com/skyvers/skyve/security/code-scanning/38)

General fix: Validate and normalize the `ipAddress` before using it to construct the URL. Ensure it is a plain IP address (or, if appropriate, a host name) and does not contain characters that could alter the URL structure (such as `/`, `?`, `#`, `:` etc.). If validation fails, either refuse to send the request or fall back to a safe behavior (e.g., return `IPGeolocation.EMPTY` and log a warning). This keeps the existing use of `https://ipinfo.io/` but prevents user input from arbitrarily modifying the path/query.

Best way here: Implement a small private validation method inside `IPInfoIo` that:

- Accepts the `String ipAddress`.
- Trims it and checks it against a conservative regular expression that matches IPv4 and IPv6 literals.
- Optionally rejects addresses that contain characters that would break the path (`/`, `?`, `#`, `&`, `=`).
- Returns either the normalized/trimmed IP string, or `null` if invalid.

Then in `doGeolocation`, call this validator before building `requestUrl`. If the value is invalid, log and return `IPGeolocation.EMPTY` immediately, thus avoiding any outbound HTTP call with untrusted, unvalidated input. If valid, use the sanitized value to construct the URL.

Concretely, in `skyve-ext/src/main/java/org/skyve/impl/geoip/IPInfoIo.java`:

- Add imports for `java.util.regex.Pattern` and `java.util.regex.Matcher`.
- Add a `private static final Pattern` for IP matching (simple IPv4 and IPv6 coverage is enough).
- Add a private method like `private static String sanitizeIpAddress(String ipAddress)` that returns a safe, trimmed IP or `null`.
- In `doGeolocation`, before constructing `requestUrl`, call `sanitizeIpAddress(ipAddress)`; if it returns `null`, log and return `IPGeolocation.EMPTY`. Otherwise, use the sanitized value when appending to `IPINFO_DOMAIN`.

No changes are needed in `SecurityUtil`, `WebUtil`, or `AbstractCachingGeoIPService` to address this particular SSRF finding; they can continue to pass through the original header-derived IP, since the sink (`IPInfoIo`) now defends itself.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
