### PR TITLE
Add concurrent session warning audit and config controls

### DIFF
--- a/skyve-core/src/main/java/org/skyve/impl/util/UtilImpl.java
+++ b/skyve-core/src/main/java/org/skyve/impl/util/UtilImpl.java
@@ -385,6 +385,8 @@ public class UtilImpl {
 	public static boolean IP_ADDRESS_CHANGE_NOTIFICATIONS = true;
 	public static boolean ACCESS_EXCEPTION_NOTIFICATIONS = true;
 	public static boolean SECURITY_EXCEPTION_NOTIFICATIONS = true;
+	public static boolean CONCURRENT_SESSION_WARNINGS = true;
+	public static boolean CONCURRENT_SESSION_NOTIFICATIONS = true;
 
 	public static boolean PRIMEFLEX = false;
 	

--- a/skyve-core/src/test/java/org/skyve/impl/util/UtilImplTest.java
+++ b/skyve-core/src/test/java/org/skyve/impl/util/UtilImplTest.java
@@ -90,6 +90,13 @@ public class UtilImplTest {
 	
 	@Test
 	@SuppressWarnings("static-method")
+	public void testConcurrentSessionFlagsDefaultToEnabled() {
+		assertThat(UtilImpl.CONCURRENT_SESSION_WARNINGS, is(true));
+		assertThat(UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS, is(true));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
 	public void testUnidecode() {
 		Assert.assertEquals("descricao", UtilImpl.unidecode("descrição"));
 		Assert.assertEquals("tache", UtilImpl.unidecode("tâche"));

--- a/skyve-core/src/test/resources/json/skyve.json
+++ b/skyve-core/src/test/resources/json/skyve.json
@@ -260,10 +260,13 @@
 		// Enable tracking of user IP changes, including cross-country logins
 		"ipAddressChecks": true,
 		"ipAddressHistoryCheckCount": 1,
+		// Log a security event when a user opens another session on a different browser/device
+		"concurrentSessionWarnings": true,
     	// Email address for security notifications
     	"securityNotificationsEmail": "security@yourdomain.com",
     	// Enable notifications for certain event types
     	"geoIPBlockNotifications": true,
+		"concurrentSessionNotifications": true,
     	"passwordChangeNotifications": true,
     	"differentCountryLoginNotifications": true,
     	"ipAddressChangeNotifications": true,

--- a/skyve-ext/src/main/java/org/skyve/impl/cache/StateUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/cache/StateUtil.java
@@ -154,6 +154,33 @@ public class StateUtil {
 		}
 		return false;
 	}
+
+	/**
+	 * Determines whether the user has at least one different registered session ID.
+	 *
+	 * @param userId The user identifier.
+	 * @param session The current session.
+	 * @return {@code true} if at least one other session ID is already registered for the user.
+	 */
+	@SuppressWarnings("rawtypes")
+	public static boolean hasOtherSession(@Nonnull String userId, @Nonnull HttpSession session) {
+		Cache<String, TreeSet> sessions = getSessions();
+		TreeSet sessionIds = sessions.get(userId);
+		return (sessionIds != null) && sessionIds.stream().anyMatch(sessionId -> ! session.getId().equals(sessionId));
+	}
+
+	/**
+	 * Returns the number of currently registered session IDs for a user.
+	 *
+	 * @param userId The user identifier.
+	 * @return The count of session IDs currently tracked for this user.
+	 */
+	@SuppressWarnings("rawtypes")
+	public static int getSessionCount(@Nonnull String userId) {
+		Cache<String, TreeSet> sessions = getSessions();
+		TreeSet sessionIds = sessions.get(userId);
+		return (sessionIds == null) ? 0 : sessionIds.size();
+	}
 	
 	public static void removeSessions(@Nonnull String userId) {
 		getSessions().remove(userId);

--- a/skyve-ext/src/main/java/org/skyve/impl/cache/StateUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/cache/StateUtil.java
@@ -166,7 +166,13 @@ public class StateUtil {
 	public static boolean hasOtherSession(@Nonnull String userId, @Nonnull HttpSession session) {
 		Cache<String, TreeSet> sessions = getSessions();
 		TreeSet sessionIds = sessions.get(userId);
-		return (sessionIds != null) && sessionIds.stream().anyMatch(sessionId -> ! session.getId().equals(sessionId));
+		if (sessionIds == null || sessionIds.isEmpty()) {
+			return false;
+		}
+		if (sessionIds.size() > 1) {
+			return true;
+		}
+		return ! sessionIds.contains(session.getId());
 	}
 
 	/**

--- a/skyve-ext/src/test/java/org/skyve/impl/cache/StateUtilTest.java
+++ b/skyve-ext/src/test/java/org/skyve/impl/cache/StateUtilTest.java
@@ -1,0 +1,98 @@
+package org.skyve.impl.cache;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyve.cache.SessionCacheConfig;
+import org.skyve.impl.util.UtilImpl;
+
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Unit tests for user-session tracking helpers in {@link StateUtil}.
+ */
+public class StateUtilTest {
+	private static final String USER_ID = "test-user";
+
+	private boolean originalForceNonPersistentCaching;
+	private String originalCacheDirectory;
+	private SessionCacheConfig originalSessionCache;
+	private Path cacheDirectory;
+
+	@Before
+	public void before() throws Exception {
+		originalForceNonPersistentCaching = UtilImpl.FORCE_NON_PERSISTENT_CACHING;
+		originalCacheDirectory = UtilImpl.CACHE_DIRECTORY;
+		originalSessionCache = UtilImpl.SESSION_CACHE;
+
+		cacheDirectory = Files.createTempDirectory("skyve-stateutil-cache");
+		UtilImpl.FORCE_NON_PERSISTENT_CACHING = true;
+		UtilImpl.CACHE_DIRECTORY = cacheDirectory.toString() + File.separator;
+		UtilImpl.SESSION_CACHE = new SessionCacheConfig(100, 10);
+
+		DefaultCaching.get().shutdown();
+		DefaultCaching.get().startup();
+		StateUtil.removeSessions(USER_ID);
+	}
+
+	@After
+	public void after() throws Exception {
+		StateUtil.removeSessions(USER_ID);
+		DefaultCaching.get().shutdown();
+
+		UtilImpl.FORCE_NON_PERSISTENT_CACHING = originalForceNonPersistentCaching;
+		UtilImpl.CACHE_DIRECTORY = originalCacheDirectory;
+		UtilImpl.SESSION_CACHE = originalSessionCache;
+
+		if (cacheDirectory != null) {
+			try (Stream<Path> paths = Files.walk(cacheDirectory)) {
+				paths.sorted((a, b) -> b.compareTo(a))
+					.map(Path::toFile)
+					.forEach(File::delete);
+			}
+		}
+	}
+
+	@Test
+	public void hasOtherSessionAndGetSessionCountTrackDistinctSessionIds() {
+		HttpSession sessionA = session("A");
+		HttpSession sessionB = session("B");
+
+		StateUtil.addSession(USER_ID, sessionA);
+		assertThat(StateUtil.getSessionCount(USER_ID), is(1));
+		assertThat(StateUtil.hasOtherSession(USER_ID, sessionA), is(false));
+
+		StateUtil.addSession(USER_ID, sessionB);
+		assertThat(StateUtil.getSessionCount(USER_ID), is(2));
+		assertThat(StateUtil.hasOtherSession(USER_ID, sessionA), is(true));
+		assertThat(StateUtil.hasOtherSession(USER_ID, sessionB), is(true));
+	}
+
+	@Test
+	public void duplicateSessionIdDoesNotCreateOtherSession() {
+		HttpSession sessionA1 = session("A");
+		HttpSession sessionA2 = session("A");
+
+		StateUtil.addSession(USER_ID, sessionA1);
+		StateUtil.addSession(USER_ID, sessionA2);
+
+		assertThat(StateUtil.getSessionCount(USER_ID), is(1));
+		assertThat(StateUtil.hasOtherSession(USER_ID, sessionA1), is(false));
+	}
+
+	private static HttpSession session(String id) {
+		HttpSession session = mock(HttpSession.class);
+		when(session.getId()).thenReturn(id);
+		return session;
+	}
+}

--- a/skyve-war/config/skyve.json
+++ b/skyve-war/config/skyve.json
@@ -405,14 +405,17 @@
 		// Enable tracking of user IP changes, including cross-country logins
 		"ipAddressChecks": true,
 		"ipAddressHistoryCheckCount": 1,
+		// Log a security event when a user opens another session on a different browser/device
+		"concurrentSessionWarnings": true,
 		// Email address for security notifications
 		"securityNotificationsEmail": "security@yourdomain.com",
 		// Enable notifications for certain event types
 		"geoIPBlockNotifications": true,
+		"concurrentSessionNotifications": true,
 		"passwordChangeNotifications": true,
 		"differentCountryLoginNotifications": true,
 		"ipAddressChangeNotifications": true,
 		"accessExceptionNotifications": true,
 		"securityExceptionNotifications": true
+		}
 	}
-}

--- a/skyve-war/src/generated/java/modules/admin/domain/Startup.java
+++ b/skyve-war/src/generated/java/modules/admin/domain/Startup.java
@@ -142,6 +142,9 @@ public abstract class Startup extends AbstractTransientBean {
 	public static final String ipAddressHistoryCheckCountPropertyName = "ipAddressHistoryCheckCount";
 
 	/** @hidden */
+	public static final String concurrentSessionWarningsPropertyName = "concurrentSessionWarnings";
+
+	/** @hidden */
 	public static final String captchaTypePropertyName = "captchaType";
 
 	/** @hidden */
@@ -155,6 +158,9 @@ public abstract class Startup extends AbstractTransientBean {
 
 	/** @hidden */
 	public static final String geoIPBlockNotificationsPropertyName = "geoIPBlockNotifications";
+
+	/** @hidden */
+	public static final String concurrentSessionNotificationsPropertyName = "concurrentSessionNotifications";
 
 	/** @hidden */
 	public static final String passwordChangeNotificationsPropertyName = "passwordChangeNotifications";
@@ -674,6 +680,13 @@ public abstract class Startup extends AbstractTransientBean {
 	private Integer ipAddressHistoryCheckCount = Integer.valueOf(1);
 
 	/**
+	 * Concurrent Session Warnings
+	 * <br/>
+	 * When enabled, a security event will be logged when a user starts a new session while another session is already active.
+	 **/
+	private Boolean concurrentSessionWarnings = Boolean.valueOf(true);
+
+	/**
 	 * CAPTCHA Type
 	 * <br/>
 	 * Which CAPTCHA service to use for the self-registration and self-service password reset (forgot password) function. You may choose between Cloudflare Turnstile and Google Recaptcha or leave blank to not enable a CAPTCHA.
@@ -707,6 +720,13 @@ public abstract class Startup extends AbstractTransientBean {
 	 * When enabled, notifications will be sent when a Geo IP block occurs.
 	 **/
 	private Boolean geoIPBlockNotifications;
+
+	/**
+	 * Concurrent Session Notifications
+	 * <br/>
+	 * When enabled, notifications will be sent when a concurrent session warning is logged.
+	 **/
+	private Boolean concurrentSessionNotifications = Boolean.valueOf(true);
 
 	/**
 	 * Password Change Notifications
@@ -1316,6 +1336,24 @@ public abstract class Startup extends AbstractTransientBean {
 	}
 
 	/**
+	 * {@link #concurrentSessionWarnings} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getConcurrentSessionWarnings() {
+		return concurrentSessionWarnings;
+	}
+
+	/**
+	 * {@link #concurrentSessionWarnings} mutator.
+	 * @param concurrentSessionWarnings	The new value.
+	 **/
+	@XmlElement
+	public void setConcurrentSessionWarnings(Boolean concurrentSessionWarnings) {
+		preset(concurrentSessionWarningsPropertyName, concurrentSessionWarnings);
+		this.concurrentSessionWarnings = concurrentSessionWarnings;
+	}
+
+	/**
 	 * {@link #captchaType} accessor.
 	 * @return	The value.
 	 **/
@@ -1445,6 +1483,24 @@ public abstract class Startup extends AbstractTransientBean {
 	public void setGeoIPBlockNotifications(Boolean geoIPBlockNotifications) {
 		preset(geoIPBlockNotificationsPropertyName, geoIPBlockNotifications);
 		this.geoIPBlockNotifications = geoIPBlockNotifications;
+	}
+
+	/**
+	 * {@link #concurrentSessionNotifications} accessor.
+	 * @return	The value.
+	 **/
+	public Boolean getConcurrentSessionNotifications() {
+		return concurrentSessionNotifications;
+	}
+
+	/**
+	 * {@link #concurrentSessionNotifications} mutator.
+	 * @param concurrentSessionNotifications	The new value.
+	 **/
+	@XmlElement
+	public void setConcurrentSessionNotifications(Boolean concurrentSessionNotifications) {
+		preset(concurrentSessionNotificationsPropertyName, concurrentSessionNotifications);
+		this.concurrentSessionNotifications = concurrentSessionNotifications;
 	}
 
 	/**

--- a/skyve-war/src/main/java/modules/admin/Startup/Startup.xml
+++ b/skyve-war/src/main/java/modules/admin/Startup/Startup.xml
@@ -226,6 +226,11 @@
 			<defaultValue>1</defaultValue>
 			<validator min="1" />
 		</integer>
+		<boolean name="concurrentSessionWarnings">
+			<displayName>Concurrent Session Warnings</displayName>
+			<description>When enabled, a security event will be logged when a user starts a new session while another session is already active.</description>
+			<defaultValue>true</defaultValue>
+		</boolean>
 		<enum name="captchaType">
 			<displayName>CAPTCHA Type</displayName>
 			<description>
@@ -264,6 +269,11 @@
 		<boolean name="geoIPBlockNotifications">
 			<displayName>Geo IP Block Notifications</displayName>
 			<description>When enabled, notifications will be sent when a Geo IP block occurs.</description>
+		</boolean>
+		<boolean name="concurrentSessionNotifications">
+			<displayName>Concurrent Session Notifications</displayName>
+			<description>When enabled, notifications will be sent when a concurrent session warning is logged.</description>
+			<defaultValue>true</defaultValue>
 		</boolean>
 		<boolean name="passwordChangeNotifications">
 			<displayName>Password Change Notifications</displayName>

--- a/skyve-war/src/main/java/modules/admin/Startup/StartupExtension.java
+++ b/skyve-war/src/main/java/modules/admin/Startup/StartupExtension.java
@@ -77,8 +77,10 @@ public class StartupExtension extends Startup {
 	static final String SECURITY_STANZA_KEY = "security";
 	static final String SECURITY_IP_ADDRESS_CHECKS_KEY = "ipAddressChecks";
 	static final String SECURITY_IP_ADDRESS_HISTORY_CHECK_COUNT_KEY = "ipAddressHistoryCheckCount";
+	static final String SECURITY_CONCURRENT_SESSION_WARNINGS_KEY = "concurrentSessionWarnings";
 	static final String SECURITY_NOTIFICATIONS_EMAIL_KEY = "securityNotificationsEmail";
 	static final String SECURITY_GEO_IP_NOTIFICATIONS_KEY = "geoIPBlockNotifications";
+	static final String SECURITY_CONCURRENT_SESSION_NOTIFICATIONS_KEY = "concurrentSessionNotifications";
 	static final String SECURITY_PASSWORD_CHANGE_NOTIFICATIONS_KEY = "passwordChangeNotifications";
 	static final String SECURITY_DIFFERENT_COUNTRY_LOGIN_NOTIFICATIONS_KEY = "differentCountryLoginNotifications";
 	static final String SECURITY_IP_ADDRESS_CHANGE_NOTIFICATIONS_KEY = "ipAddressChangeNotifications";
@@ -162,6 +164,7 @@ public class StartupExtension extends Startup {
 		// IP tracking configurations
 		setIpAddressChecks(Boolean.valueOf(UtilImpl.IP_ADDRESS_CHECKS));
 		setIpAddressHistoryCheckCount(Integer.valueOf(UtilImpl.IP_ADDRESS_HISTORY_CHECK_COUNT));
+		setConcurrentSessionWarnings(Boolean.valueOf(UtilImpl.CONCURRENT_SESSION_WARNINGS));
 
 		// convert country codes from csv to list
 		List<CountryExtension> countries = getGeoIPCountries();
@@ -174,6 +177,7 @@ public class StartupExtension extends Startup {
 		// Security notification configurations
 		setSecurityNotificationsEmail(UtilImpl.SECURITY_NOTIFICATIONS_EMAIL_ADDRESS);
 		setGeoIPBlockNotifications(Boolean.valueOf(UtilImpl.GEO_IP_BLOCK_NOTIFICATIONS));
+		setConcurrentSessionNotifications(Boolean.valueOf(UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS));
 		setPasswordChangeNotifications(Boolean.valueOf(UtilImpl.PASSWORD_CHANGE_NOTIFICATIONS));
 		setDifferentCountryLoginNotifications(Boolean.valueOf(UtilImpl.DIFFERENT_COUNTRY_LOGIN_NOTIFICATIONS));
 		setIpAddressChangeNotifications(Boolean.valueOf(UtilImpl.IP_ADDRESS_CHANGE_NOTIFICATIONS));
@@ -644,6 +648,12 @@ public class StartupExtension extends Startup {
 			UtilImpl.IP_ADDRESS_HISTORY_CHECK_COUNT = ipAddressHistoryCheckCount;
 		}
 
+		boolean concurrentSessionWarnings = BooleanUtils.isNotFalse(getConcurrentSessionWarnings()); // default to true
+		if (UtilImpl.CONCURRENT_SESSION_WARNINGS != concurrentSessionWarnings) {
+			map.put(SECURITY_CONCURRENT_SESSION_WARNINGS_KEY, concurrentSessionWarnings);
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = concurrentSessionWarnings;
+		}
+
 		String securityNotificationsEmail = getSecurityNotificationsEmail();
 		if (!Objects.equals(UtilImpl.SECURITY_NOTIFICATIONS_EMAIL_ADDRESS, securityNotificationsEmail)) {
 			map.put(SECURITY_NOTIFICATIONS_EMAIL_KEY, securityNotificationsEmail);
@@ -654,6 +664,12 @@ public class StartupExtension extends Startup {
 		if (UtilImpl.GEO_IP_BLOCK_NOTIFICATIONS != geoIPBlockNotifications) {
 			map.put(SECURITY_GEO_IP_NOTIFICATIONS_KEY, geoIPBlockNotifications);
 			UtilImpl.GEO_IP_BLOCK_NOTIFICATIONS = geoIPBlockNotifications;
+		}
+
+		boolean concurrentSessionNotifications = BooleanUtils.isNotFalse(getConcurrentSessionNotifications()); // default to true
+		if (UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS != concurrentSessionNotifications) {
+			map.put(SECURITY_CONCURRENT_SESSION_NOTIFICATIONS_KEY, concurrentSessionNotifications);
+			UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = concurrentSessionNotifications;
 		}
 
 		boolean passwordChangeNotifications = BooleanUtils.isNotFalse(getPasswordChangeNotifications()); // default to true

--- a/skyve-war/src/main/java/modules/admin/Startup/views/edit.xml
+++ b/skyve-war/src/main/java/modules/admin/Startup/views/edit.xml
@@ -229,11 +229,16 @@
 					</checkBox>
 	            </item>
 	        </row>
-	        <row>
-	            <item>
-	                <spinner binding="ipAddressHistoryCheckCount" min="0" max="10" visible="ipAddressChecksEnabled" />
-	            </item>
-	        </row>
+		        <row>
+		            <item>
+		                <spinner binding="ipAddressHistoryCheckCount" min="0" max="10" visible="ipAddressChecksEnabled" />
+		            </item>
+		        </row>
+		        <row>
+		        	<item>
+		        		<checkBox binding="concurrentSessionWarnings" triState="false" />
+		        	</item>
+		        </row>
 	        
 	        <!-- GEO IP Settings -->
 	        <row>
@@ -296,6 +301,11 @@
 			<row>
 				<item>
 					<checkBox binding="geoIPBlockNotifications" triState="false" />
+				</item>
+			</row>
+			<row>
+				<item>
+					<checkBox binding="concurrentSessionNotifications" triState="false" />
 				</item>
 			</row>
 			<row>

--- a/skyve-war/src/test/java/modules/admin/Startup/StartupExtensionTest.java
+++ b/skyve-war/src/test/java/modules/admin/Startup/StartupExtensionTest.java
@@ -22,6 +22,7 @@ import org.mockito.Spy;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.metadata.customer.Customer;
 
+import modules.admin.domain.Startup;
 import modules.admin.domain.Startup.BackupType;
 import modules.admin.domain.Startup.MapType;
 
@@ -190,6 +191,41 @@ public class StartupExtensionTest {
 		assertThat(valueCapture.getValue(), containsString(StartupExtension.MAP_LAYERS_KEY));
 		assertThat(valueCapture.getValue(), containsString(StartupExtension.MAP_TYPE_KEY));
 		assertThat(valueCapture.getValue(), containsString(StartupExtension.MAP_ZOOM_KEY));
+	}
+
+	@Test
+	public void testSaveConfigurationUpdatesConcurrentSessionSecurityProperties() throws Exception {
+		UtilImpl.CONCURRENT_SESSION_WARNINGS = true;
+		UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = true;
+
+		Mockito.when(bean.getConcurrentSessionWarnings()).thenReturn(Boolean.FALSE);
+		Mockito.when(bean.getConcurrentSessionNotifications()).thenReturn(Boolean.FALSE);
+
+		ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(String.class);
+		Mockito.doNothing().when(bean).writeConfiguration(valueCapture.capture());
+
+		bean.saveConfiguration();
+
+		Mockito.verify(bean, times(1)).writeConfiguration(anyString());
+		assertThat(valueCapture.getValue(), containsString(StartupExtension.SECURITY_STANZA_KEY));
+		assertThat(valueCapture.getValue(), containsString(StartupExtension.SECURITY_CONCURRENT_SESSION_WARNINGS_KEY));
+		assertThat(valueCapture.getValue(), containsString(StartupExtension.SECURITY_CONCURRENT_SESSION_NOTIFICATIONS_KEY));
+	}
+
+	@Test
+	public void testConcurrentSessionSettingsAccessorsAndDefaults() {
+		StartupExtension startup = new StartupExtension();
+
+		assertThat(Startup.concurrentSessionWarningsPropertyName, containsString("concurrentSessionWarnings"));
+		assertThat(Startup.concurrentSessionNotificationsPropertyName, containsString("concurrentSessionNotifications"));
+		assertThat(startup.getConcurrentSessionWarnings(), org.hamcrest.CoreMatchers.is(Boolean.TRUE));
+		assertThat(startup.getConcurrentSessionNotifications(), org.hamcrest.CoreMatchers.is(Boolean.TRUE));
+
+		startup.setConcurrentSessionWarnings(Boolean.FALSE);
+		startup.setConcurrentSessionNotifications(Boolean.FALSE);
+
+		assertThat(startup.getConcurrentSessionWarnings(), org.hamcrest.CoreMatchers.is(Boolean.FALSE));
+		assertThat(startup.getConcurrentSessionNotifications(), org.hamcrest.CoreMatchers.is(Boolean.FALSE));
 	}
 
 	@Test

--- a/skyve-web/src/main/java/org/skyve/impl/web/SkyveContextListener.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/SkyveContextListener.java
@@ -880,6 +880,12 @@ public class SkyveContextListener implements ServletContextListener {
 			UtilImpl.IP_ADDRESS_CHANGE_NOTIFICATIONS = getBoolean("security", "ipAddressChangeNotifications", security);
 			UtilImpl.ACCESS_EXCEPTION_NOTIFICATIONS = getBoolean("security", "accessExceptionNotifications", security);
 			UtilImpl.SECURITY_EXCEPTION_NOTIFICATIONS = getBoolean("security", "securityExceptionNotifications", security);
+			if (security.containsKey("concurrentSessionWarnings")) {
+				UtilImpl.CONCURRENT_SESSION_WARNINGS = getBoolean("security", "concurrentSessionWarnings", security);
+			}
+			if (security.containsKey("concurrentSessionNotifications")) {
+				UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = getBoolean("security", "concurrentSessionNotifications", security);
+			}
 		}
 
         configureArchiveProperties(properties);

--- a/skyve-web/src/main/java/org/skyve/impl/web/SkyveContextListener.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/SkyveContextListener.java
@@ -881,11 +881,11 @@ public class SkyveContextListener implements ServletContextListener {
 			UtilImpl.ACCESS_EXCEPTION_NOTIFICATIONS = getBoolean("security", "accessExceptionNotifications", security);
 			UtilImpl.SECURITY_EXCEPTION_NOTIFICATIONS = getBoolean("security", "securityExceptionNotifications", security);
 			if (security.containsKey("concurrentSessionWarnings")) {
-				UtilImpl.CONCURRENT_SESSION_WARNINGS = getBoolean("security", "concurrentSessionWarnings", security);
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = getBoolean("security", "concurrentSessionWarnings", security);
 			}
 			if (security.containsKey("concurrentSessionNotifications")) {
-				UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = getBoolean("security", "concurrentSessionNotifications", security);
-			}
+			UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = getBoolean("security", "concurrentSessionNotifications", security);
+		}
 		}
 
         configureArchiveProperties(properties);
@@ -905,8 +905,8 @@ public class SkyveContextListener implements ServletContextListener {
             throw new IllegalArgumentException("Archiving is not supported on multi-tenancy instances");
         }
 
-        Integer runtime = getNumber(archKey, "exportRuntimeSec", archiveProps, true).intValue();
-        Integer batchSize = getNumber(archKey, "exportBatchSize", archiveProps, true).intValue();
+		Integer runtime = Integer.valueOf(getNumber(archKey, "exportRuntimeSec", archiveProps, true).intValue());
+		Integer batchSize = Integer.valueOf(getNumber(archKey, "exportBatchSize", archiveProps, true).intValue());
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> docProps = (List<Map<String, Object>>) get(archKey, "documents", archiveProps, true);

--- a/skyve-web/src/main/java/org/skyve/impl/web/WebUtil.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/WebUtil.java
@@ -6,6 +6,7 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.security.Principal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -41,6 +42,7 @@ import org.skyve.metadata.customer.Customer;
 import org.skyve.metadata.model.document.Bizlet;
 import org.skyve.metadata.model.document.Document;
 import org.skyve.metadata.module.Module;
+import org.skyve.metadata.repository.ProvidedRepository;
 import org.skyve.metadata.repository.Repository;
 import org.skyve.metadata.user.User;
 import org.skyve.metadata.view.TextOutput.Sanitisation;
@@ -68,6 +70,7 @@ import jakarta.servlet.http.HttpSession;
 
 public class WebUtil {
     private static final Logger LOGGER = LoggerFactory.getLogger(WebUtil.class);
+	private static final String CONCURRENT_SESSION_EVENT_TYPE = "Concurrent Session";
 
 	private WebUtil() {
 		// Disallow instantiation.
@@ -115,7 +118,7 @@ public class WebUtil {
 				}
 				setSessionId(user, request);
 				session.setAttribute(WebContext.USER_SESSION_ATTRIBUTE_NAME, user);
-				StateUtil.addSession(user.getId(), session);
+				addSessionAndAuditConcurrentSessionWarning(user, request, session);
 				AbstractPersistence.get().setUser(user);
 				
 				// Get IP address of user to record in UserLoginRecord
@@ -215,6 +218,88 @@ public class WebUtil {
 		if (session != null) {
 			user.setSessionId(session.getId());
 		}
+	}
+
+	/**
+	 * Registers the current session for the user and logs a concurrent-session warning when policy allows.
+	 * This method is invoked only at session establishment points.
+	 *
+	 * @param user The authenticated or asserted user for the session.
+	 * @param request The active HTTP request.
+	 * @param session The HTTP session being registered.
+	 */
+	public static void addSessionAndAuditConcurrentSessionWarning(@Nonnull User user,
+																	@Nonnull HttpServletRequest request,
+																	@Nonnull HttpSession session) {
+		boolean sessionAlreadyRegistered = StateUtil.checkSession(user.getId(), session);
+		int existingSessionCount = StateUtil.getSessionCount(user.getId());
+		boolean hasOtherSession = StateUtil.hasOtherSession(user.getId(), session);
+		StateUtil.addSession(user.getId(), session);
+		boolean eligibleForWarning = false;
+		try {
+			eligibleForWarning = isConcurrentSessionWarningEligible(user, request);
+		}
+		catch (RuntimeException e) {
+			LOGGER.warn("Could not determine concurrent session warning eligibility for user {}.", user.getName(), e);
+		}
+
+		if (shouldLogConcurrentSessionWarning(UtilImpl.CONCURRENT_SESSION_WARNINGS,
+												sessionAlreadyRegistered,
+												hasOtherSession,
+												eligibleForWarning)) {
+			logConcurrentSessionWarning(user, existingSessionCount);
+		}
+	}
+
+	private static void logConcurrentSessionWarning(@Nonnull User user, int existingSessionCount) {
+		try {
+			SecurityUtil.log(CONCURRENT_SESSION_EVENT_TYPE,
+								buildConcurrentSessionWarningMessage(existingSessionCount),
+								user,
+								UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS);
+		}
+		catch (RuntimeException e) {
+			LOGGER.warn("Could not log concurrent session warning for user {}.", user.getName(), e);
+		}
+	}
+
+	static boolean shouldLogConcurrentSessionWarning(boolean concurrentSessionWarningsEnabled,
+														boolean sessionAlreadyRegistered,
+														boolean hasOtherSession,
+														boolean eligibleForWarning) {
+		return concurrentSessionWarningsEnabled && (! sessionAlreadyRegistered) && hasOtherSession && eligibleForWarning;
+	}
+
+	static @Nonnull String buildConcurrentSessionWarningMessage(int existingSessionCount) {
+		return "User logged in while another active session already existed. Existing session count: " + existingSessionCount + '.';
+	}
+
+	/**
+	 * Determines whether a session is eligible for concurrent-session warning auditing.
+	 * Public-form sessions and unauthenticated requests are excluded.
+	 *
+	 * @param user The current user.
+	 * @param request The active HTTP request.
+	 * @return {@code true} when the session should be considered for concurrent-session warnings.
+	 */
+	public static boolean isConcurrentSessionWarningEligible(@Nonnull User user, @Nonnull HttpServletRequest request) {
+		return isConcurrentSessionWarningEligible(user, request.getUserPrincipal(), ProvidedRepositoryFactory.get());
+	}
+
+	static boolean isConcurrentSessionWarningEligible(@Nonnull User user,
+														@Nullable Principal principal,
+														@Nonnull ProvidedRepository repository) {
+		return (principal != null) && (! isPublicUser(user, repository));
+	}
+
+	static boolean isPublicUser(@Nonnull User user, @Nonnull ProvidedRepository repository) {
+		String customerName = user.getCustomerName();
+		if (customerName == null) {
+			return false;
+		}
+
+		String publicUserName = repository.retrievePublicUserName(customerName);
+		return (publicUserName != null) && publicUserName.equals(user.getName());
 	}
 	
 	/**

--- a/skyve-web/src/main/java/org/skyve/impl/web/WebUtil.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/WebUtil.java
@@ -235,12 +235,18 @@ public class WebUtil {
 		int existingSessionCount = StateUtil.getSessionCount(user.getId());
 		boolean hasOtherSession = StateUtil.hasOtherSession(user.getId(), session);
 		StateUtil.addSession(user.getId(), session);
+
+		boolean shouldEvaluateEligibility = UtilImpl.CONCURRENT_SESSION_WARNINGS &&
+											(! sessionAlreadyRegistered) &&
+											hasOtherSession;
 		boolean eligibleForWarning = false;
-		try {
-			eligibleForWarning = isConcurrentSessionWarningEligible(user, request);
-		}
-		catch (RuntimeException e) {
-			LOGGER.warn("Could not determine concurrent session warning eligibility for user {}.", user.getName(), e);
+		if (shouldEvaluateEligibility) {
+			try {
+				eligibleForWarning = isConcurrentSessionWarningEligible(user, request);
+			}
+			catch (RuntimeException e) {
+				LOGGER.warn("Could not determine concurrent session warning eligibility for user {}.", user.getName(), e);
+			}
 		}
 
 		if (shouldLogConcurrentSessionWarning(UtilImpl.CONCURRENT_SESSION_WARNINGS,

--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/views/HarnessView.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/views/HarnessView.java
@@ -4,7 +4,6 @@ import java.util.Set;
 
 import org.skyve.CORE;
 import org.skyve.domain.messages.SecurityException;
-import org.skyve.impl.cache.StateUtil;
 import org.skyve.impl.metadata.repository.ProvidedRepositoryFactory;
 import org.skyve.impl.metadata.user.UserImpl;
 import org.skyve.impl.persistence.AbstractPersistence;
@@ -276,7 +275,7 @@ public abstract class HarnessView extends LocalisableView {
 		if (user != null) {
 			WebUtil.setSessionId(user, request);
 			session.setAttribute(WebContext.USER_SESSION_ATTRIBUTE_NAME, user);
-			StateUtil.addSession(user.getId(), session);
+			WebUtil.addSessionAndAuditConcurrentSessionWarning(user, request, session);
 		}
 
 		AbstractPersistence persistence = AbstractPersistence.get();

--- a/skyve-web/src/test/java/org/skyve/impl/web/SkyveContextListenerTest.java
+++ b/skyve-web/src/test/java/org/skyve/impl/web/SkyveContextListenerTest.java
@@ -2,9 +2,24 @@ package org.skyve.impl.web;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
 import org.junit.Test;
+import org.skyve.impl.metadata.repository.ProvidedRepositoryFactory;
+import org.skyve.impl.persistence.AbstractPersistence;
 import org.skyve.impl.util.UtilImpl;
+import org.skyve.impl.web.filter.ResponseHeaderFilter;
+import org.skyve.metadata.repository.ProvidedRepository;
+import org.skyve.persistence.DynamicPersistence;
+
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.ServletContext;
 
 public class SkyveContextListenerTest {
 	@Test
@@ -103,4 +118,162 @@ public class SkyveContextListenerTest {
 		assertThat(result3, is(test3 + "/"));
 		assertThat(result4, is("\\src\\main\\java\\modules" + "/"));
 	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	public void testPopulateUtilImplReadsConcurrentSessionSettingsWhenPresent() throws Exception {
+		boolean originalWarnings = UtilImpl.CONCURRENT_SESSION_WARNINGS;
+		boolean originalNotifications = UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS;
+		String originalPropertiesFilePath = System.getProperty("PROPERTIES_FILE_PATH");
+		Class<? extends AbstractPersistence> originalPersistenceImplementation = AbstractPersistence.IMPLEMENTATION_CLASS;
+		Class<? extends DynamicPersistence> originalDynamicPersistenceImplementation = AbstractPersistence.DYNAMIC_IMPLEMENTATION_CLASS;
+		Path tempDir = Files.createTempDirectory("skyve-context-listener-present");
+		try {
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = true;
+			UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = true;
+
+			Path configFile = writeConfiguration(tempDir, true);
+			System.setProperty("PROPERTIES_FILE_PATH", configFile.toString());
+
+			ProvidedRepository originalRepository = ProvidedRepositoryFactory.get();
+			ProvidedRepositoryFactory.set(mock(ProvidedRepository.class));
+			try {
+				invokePopulateUtilImpl(configFile, tempDir);
+			}
+			finally {
+				ProvidedRepositoryFactory.set(originalRepository);
+			}
+
+			assertThat(UtilImpl.CONCURRENT_SESSION_WARNINGS, is(false));
+			assertThat(UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS, is(false));
+		}
+		finally {
+			restoreProperty("PROPERTIES_FILE_PATH", originalPropertiesFilePath);
+			AbstractPersistence.IMPLEMENTATION_CLASS = originalPersistenceImplementation;
+			AbstractPersistence.DYNAMIC_IMPLEMENTATION_CLASS = originalDynamicPersistenceImplementation;
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = originalWarnings;
+			UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = originalNotifications;
+			deleteTree(tempDir);
+		}
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	public void testPopulateUtilImplLeavesConcurrentSessionSettingsWhenMissing() throws Exception {
+		boolean originalWarnings = UtilImpl.CONCURRENT_SESSION_WARNINGS;
+		boolean originalNotifications = UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS;
+		String originalPropertiesFilePath = System.getProperty("PROPERTIES_FILE_PATH");
+		Class<? extends AbstractPersistence> originalPersistenceImplementation = AbstractPersistence.IMPLEMENTATION_CLASS;
+		Class<? extends DynamicPersistence> originalDynamicPersistenceImplementation = AbstractPersistence.DYNAMIC_IMPLEMENTATION_CLASS;
+		Path tempDir = Files.createTempDirectory("skyve-context-listener-missing");
+		try {
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = false;
+			UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = false;
+
+			Path configFile = writeConfiguration(tempDir, false);
+			System.setProperty("PROPERTIES_FILE_PATH", configFile.toString());
+
+			ProvidedRepository originalRepository = ProvidedRepositoryFactory.get();
+			ProvidedRepositoryFactory.set(mock(ProvidedRepository.class));
+			try {
+				invokePopulateUtilImpl(configFile, tempDir);
+			}
+			finally {
+				ProvidedRepositoryFactory.set(originalRepository);
+			}
+
+			assertThat(UtilImpl.CONCURRENT_SESSION_WARNINGS, is(false));
+			assertThat(UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS, is(false));
+		}
+		finally {
+			restoreProperty("PROPERTIES_FILE_PATH", originalPropertiesFilePath);
+			AbstractPersistence.IMPLEMENTATION_CLASS = originalPersistenceImplementation;
+			AbstractPersistence.DYNAMIC_IMPLEMENTATION_CLASS = originalDynamicPersistenceImplementation;
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = originalWarnings;
+			UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = originalNotifications;
+			deleteTree(tempDir);
+		}
+	}
+
+	private static void invokePopulateUtilImpl(Path configFile, Path tempDir) throws Exception {
+		ServletContext context = mock(ServletContext.class);
+		when(context.getRealPath("/")).thenReturn(tempDir.toString());
+		when(context.getInitParameter("PROPERTIES_FILE_PATH")).thenReturn(configFile.toString());
+
+		FilterRegistration securityHeadersFilter = mock(FilterRegistration.class);
+		when(securityHeadersFilter.getClassName()).thenReturn(ResponseHeaderFilter.class.getName());
+		when(securityHeadersFilter.getName()).thenReturn(ResponseHeaderFilter.SECURITY_HEADERS_FILTER_NAME);
+
+		HashMap<String, FilterRegistration> filterRegistrations = new HashMap<>();
+		filterRegistrations.put(ResponseHeaderFilter.SECURITY_HEADERS_FILTER_NAME, securityHeadersFilter);
+		doReturn(filterRegistrations).when(context).getFilterRegistrations();
+
+		Method populateUtilImpl = SkyveContextListener.class.getDeclaredMethod("populateUtilImpl", ServletContext.class);
+		populateUtilImpl.setAccessible(true);
+		populateUtilImpl.invoke(null, context);
+	}
+
+	private static Path writeConfiguration(Path tempDir, boolean includeConcurrentSessionSettings) throws Exception {
+		StringBuilder security = new StringBuilder()
+				.append("\"ipAddressChecks\":true,")
+				.append("\"ipAddressHistoryCheckCount\":1,")
+				.append("\"securityNotificationsEmail\":\"security@test.com\",")
+				.append("\"geoIPBlockNotifications\":true,")
+				.append("\"passwordChangeNotifications\":true,")
+				.append("\"differentCountryLoginNotifications\":true,")
+				.append("\"ipAddressChangeNotifications\":true,")
+				.append("\"accessExceptionNotifications\":true,")
+				.append("\"securityExceptionNotifications\":true");
+		if (includeConcurrentSessionSettings) {
+			security.append(",\"concurrentSessionWarnings\":false,\"concurrentSessionNotifications\":false");
+		}
+
+		String json = "{"
+				+ "\"trace\":{\"xml\":false,\"http\":false,\"query\":false,\"command\":false,\"faces\":false,\"sql\":false,\"content\":false,\"security\":false,\"bizlet\":false,\"dirty\":false},"
+				+ "\"content\":{\"directory\":\"" + escapeJson(tempDir.toString()) + "\",\"gcCron\":\"0 7 0/1 1/1 * ? *\",\"fileStorage\":true},"
+				+ "\"url\":{\"server\":\"http://localhost:8080\",\"context\":\"/skyve\",\"home\":\"/\"},"
+				+ "\"state\":{\"directory\":null,\"multiple\":false,"
+				+ "\"conversations\":{\"heapSizeEntries\":10,\"offHeapSizeMB\":0,\"diskSizeGB\":0,\"expiryTimeMinutes\":10},"
+				+ "\"csrfTokens\":{\"heapSizeEntries\":10,\"offHeapSizeMB\":0,\"diskSizeGB\":0,\"expiryTimeMinutes\":10},"
+				+ "\"geoIPs\":{\"heapSizeEntries\":10,\"offHeapSizeMB\":0,\"diskSizeGB\":0,\"expiryTimeMinutes\":10},"
+				+ "\"sessions\":{\"heapSizeEntries\":10,\"offHeapSizeMB\":0,\"diskSizeGB\":0,\"expiryTimeMinutes\":10},"
+				+ "\"evictCron\":\"0 37 0 1/1 * ? *\"},"
+				+ "\"dataStores\":{\"skyve\":{\"jndi\":\"java:/SkyveDB\",\"dialect\":\"org.skyve.impl.persistence.hibernate.dialect.H2SpatialDialect\",\"oltpConnectionTimeoutInSeconds\":30,\"asyncConnectionTimeoutInSeconds\":300}},"
+				+ "\"hibernate\":{\"dataStore\":\"skyve\",\"ddlSync\":true,\"catalog\":null,\"schema\":null,\"prettySql\":false},"
+				+ "\"factories\":{\"persistenceClass\":null,\"dynamicPersistenceClass\":null,\"repositoryClass\":null,\"contentManagerClass\":null,\"numberGeneratorClass\":null,\"customisationsClass\":null,\"geoIPServiceClass\":null},"
+				+ "\"smtp\":{\"server\":\"localhost\",\"port\":25,\"uid\":null,\"pwd\":null,\"properties\":null,\"headers\":null,\"sender\":\"mailer@skyve.org\",\"testBogusSend\":false,\"testRecipient\":\"test@yourdomain.com\"},"
+				+ "\"map\":{\"type\":\"leaflet\",\"layers\":\"[]\"},"
+				+ "\"api\":{\"googleMapsV3Key\":null,\"googleRecaptchaSiteKey\":null,\"googleRecaptchaSecretKey\":null,\"cloudflareTurnstileSiteKey\":null,\"cloudflareTurnstileSecretKey\":null,\"geoIPKey\":null,\"geoIPCountryCodes\":null,\"geoIPWhitelist\":null,\"ckEditorConfigFileUrl\":null},"
+				+ "\"account\":{\"passwordHashingAlgorithm\":\"argon2\",\"allowUserSelfRegistration\":false,\"accountLockoutThreshold\":3,\"accountLockoutDurationMultipleInSeconds\":10,\"loginUri\":\"/login\",\"rememberMeTokenTimeoutHours\":336},"
+				+ "\"environment\":{\"identifier\":\"test\",\"devMode\":true,\"accessControl\":true,\"customer\":\"demo\",\"jobScheduler\":false,\"moduleDirectory\":null,\"supportEmailAddress\":\"support@test.com\",\"showSetup\":true},"
+				+ "\"security\":{" + security + "}"
+				+ "}";
+
+		Path configFile = tempDir.resolve("skyve-test.json");
+		Files.writeString(configFile, json);
+		return configFile;
+	}
+
+	private static void restoreProperty(String key, String originalValue) {
+		if (originalValue == null) {
+			System.clearProperty(key);
+		}
+		else {
+			System.setProperty(key, originalValue);
+		}
+	}
+
+	private static void deleteTree(Path root) throws Exception {
+		if (root == null) {
+			return;
+		}
+		Files.walk(root)
+				.sorted((a, b) -> b.compareTo(a))
+				.forEach(path -> path.toFile().delete());
+	}
+
+	private static String escapeJson(String value) {
+		return value.replace("\\", "\\\\");
+	}
+
 }

--- a/skyve-web/src/test/java/org/skyve/impl/web/SkyveContextListenerTest.java
+++ b/skyve-web/src/test/java/org/skyve/impl/web/SkyveContextListenerTest.java
@@ -167,7 +167,7 @@ public class SkyveContextListenerTest {
 		Class<? extends DynamicPersistence> originalDynamicPersistenceImplementation = AbstractPersistence.DYNAMIC_IMPLEMENTATION_CLASS;
 		Path tempDir = Files.createTempDirectory("skyve-context-listener-missing");
 		try {
-			UtilImpl.CONCURRENT_SESSION_WARNINGS = false;
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = true;
 			UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS = false;
 
 			Path configFile = writeConfiguration(tempDir, false);
@@ -182,7 +182,7 @@ public class SkyveContextListenerTest {
 				ProvidedRepositoryFactory.set(originalRepository);
 			}
 
-			assertThat(UtilImpl.CONCURRENT_SESSION_WARNINGS, is(false));
+			assertThat(UtilImpl.CONCURRENT_SESSION_WARNINGS, is(true));
 			assertThat(UtilImpl.CONCURRENT_SESSION_NOTIFICATIONS, is(false));
 		}
 		finally {

--- a/skyve-web/src/test/java/org/skyve/impl/web/WebUtilConcurrentSessionTest.java
+++ b/skyve-web/src/test/java/org/skyve/impl/web/WebUtilConcurrentSessionTest.java
@@ -1,0 +1,213 @@
+package org.skyve.impl.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.Principal;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyve.cache.SessionCacheConfig;
+import org.skyve.impl.cache.DefaultCaching;
+import org.skyve.impl.cache.StateUtil;
+import org.skyve.impl.metadata.repository.ProvidedRepositoryFactory;
+import org.skyve.impl.util.UtilImpl;
+import org.skyve.metadata.repository.ProvidedRepository;
+import org.skyve.metadata.user.User;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Unit tests for concurrent-session warning decision logic in {@link WebUtil}.
+ */
+class WebUtilConcurrentSessionTest {
+	private static final String USER_ID = "test-user";
+
+	private ProvidedRepository originalRepository;
+	private boolean originalForceNonPersistentCaching;
+	private String originalCacheDirectory;
+	private SessionCacheConfig originalSessionCache;
+	private Path cacheDirectory;
+
+	@BeforeEach
+	void beforeEach() throws Exception {
+		originalRepository = ProvidedRepositoryFactory.get();
+		originalForceNonPersistentCaching = UtilImpl.FORCE_NON_PERSISTENT_CACHING;
+		originalCacheDirectory = UtilImpl.CACHE_DIRECTORY;
+		originalSessionCache = UtilImpl.SESSION_CACHE;
+
+		cacheDirectory = Files.createTempDirectory("skyve-webutil-cache");
+		UtilImpl.FORCE_NON_PERSISTENT_CACHING = true;
+		UtilImpl.CACHE_DIRECTORY = cacheDirectory.toString() + File.separator;
+		UtilImpl.SESSION_CACHE = new SessionCacheConfig(100, 10);
+
+		DefaultCaching.get().shutdown();
+		DefaultCaching.get().startup();
+		StateUtil.removeSessions(USER_ID);
+	}
+
+	@AfterEach
+	void afterEach() throws Exception {
+		StateUtil.removeSessions(USER_ID);
+		DefaultCaching.get().shutdown();
+		ProvidedRepositoryFactory.set(originalRepository);
+		UtilImpl.FORCE_NON_PERSISTENT_CACHING = originalForceNonPersistentCaching;
+		UtilImpl.CACHE_DIRECTORY = originalCacheDirectory;
+		UtilImpl.SESSION_CACHE = originalSessionCache;
+
+		if (cacheDirectory != null) {
+			try (Stream<Path> paths = Files.walk(cacheDirectory)) {
+				paths.sorted((a, b) -> b.compareTo(a))
+					.map(Path::toFile)
+					.forEach(File::delete);
+			}
+		}
+	}
+
+	@Test
+	void shouldLogConcurrentSessionWarningOnlyWhenAllConditionsAreMet() {
+		assertTrue(WebUtil.shouldLogConcurrentSessionWarning(true, false, true, true));
+		assertFalse(WebUtil.shouldLogConcurrentSessionWarning(false, false, true, true));
+		assertFalse(WebUtil.shouldLogConcurrentSessionWarning(true, true, true, true));
+		assertFalse(WebUtil.shouldLogConcurrentSessionWarning(true, false, false, true));
+		assertFalse(WebUtil.shouldLogConcurrentSessionWarning(true, false, true, false));
+	}
+
+	@Test
+	void buildConcurrentSessionWarningMessageIncludesExistingSessionCount() {
+		assertEquals("User logged in while another active session already existed. Existing session count: 2.",
+						WebUtil.buildConcurrentSessionWarningMessage(2));
+	}
+
+	@Test
+	void isPublicUserMatchesConfiguredPublicUserName() {
+		User user = mock(User.class);
+		when(user.getCustomerName()).thenReturn("demo");
+		when(user.getName()).thenReturn("public");
+
+		ProvidedRepository repository = mock(ProvidedRepository.class);
+		when(repository.retrievePublicUserName("demo")).thenReturn("public");
+		assertTrue(WebUtil.isPublicUser(user, repository));
+
+		when(repository.retrievePublicUserName("demo")).thenReturn("someoneElse");
+		assertFalse(WebUtil.isPublicUser(user, repository));
+	}
+
+	@Test
+	void isPublicUserReturnsFalseWhenCustomerNameIsNull() {
+		User user = mock(User.class);
+		when(user.getCustomerName()).thenReturn(null);
+		ProvidedRepository repository = mock(ProvidedRepository.class);
+		assertFalse(WebUtil.isPublicUser(user, repository));
+	}
+
+	@Test
+	void concurrentSessionWarningEligibilityRequiresPrincipalAndNonPublicUser() {
+		User user = mock(User.class);
+		when(user.getCustomerName()).thenReturn("demo");
+		when(user.getName()).thenReturn("alice");
+
+		ProvidedRepository repository = mock(ProvidedRepository.class);
+		when(repository.retrievePublicUserName("demo")).thenReturn("public");
+		Principal principal = () -> "demo/alice";
+
+		assertTrue(WebUtil.isConcurrentSessionWarningEligible(user, principal, repository));
+		assertFalse(WebUtil.isConcurrentSessionWarningEligible(user, null, repository));
+
+		when(user.getName()).thenReturn("public");
+		assertFalse(WebUtil.isConcurrentSessionWarningEligible(user, principal, repository));
+	}
+
+	@Test
+	void concurrentSessionWarningEligibilityUsesRequestPrincipalAndRepositoryFactory() {
+		User user = mock(User.class);
+		when(user.getCustomerName()).thenReturn("demo");
+		when(user.getName()).thenReturn("alice");
+
+		ProvidedRepository repository = mock(ProvidedRepository.class);
+		when(repository.retrievePublicUserName("demo")).thenReturn("public");
+		ProvidedRepositoryFactory.set(repository);
+
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getUserPrincipal()).thenReturn(() -> "demo/alice");
+
+		assertTrue(WebUtil.isConcurrentSessionWarningEligible(user, request));
+	}
+
+	@Test
+	void addSessionAndAuditConcurrentSessionWarningAddsSessionWithoutLoggingWhenWarningsDisabled() {
+		boolean originalWarnings = UtilImpl.CONCURRENT_SESSION_WARNINGS;
+		try {
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = false;
+			ProvidedRepository repository = mock(ProvidedRepository.class);
+			when(repository.retrievePublicUserName("demo")).thenReturn("public");
+			ProvidedRepositoryFactory.set(repository);
+
+			User user = user("demo", "alice", USER_ID);
+			HttpSession session = session("A");
+			HttpServletRequest request = requestWithPrincipal("demo/alice");
+
+			WebUtil.addSessionAndAuditConcurrentSessionWarning(user, request, session);
+
+			assertEquals(1, StateUtil.getSessionCount(USER_ID));
+			assertTrue(StateUtil.checkSession(USER_ID, session));
+		}
+		finally {
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = originalWarnings;
+		}
+	}
+
+	@Test
+	void addSessionAndAuditConcurrentSessionWarningHandlesEligibilityFailures() {
+		boolean originalWarnings = UtilImpl.CONCURRENT_SESSION_WARNINGS;
+		try {
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = false;
+			ProvidedRepositoryFactory.set(mock(ProvidedRepository.class));
+			User user = user("demo", "alice", USER_ID);
+			HttpSession existingSession = session("A");
+			HttpSession currentSession = session("B");
+			StateUtil.addSession(USER_ID, existingSession);
+
+			HttpServletRequest request = mock(HttpServletRequest.class);
+			when(request.getUserPrincipal()).thenReturn(() -> "demo/alice");
+			when(user.getCustomerName()).thenThrow(new IllegalStateException("boom"));
+
+			WebUtil.addSessionAndAuditConcurrentSessionWarning(user, request, currentSession);
+
+			assertEquals(2, StateUtil.getSessionCount(USER_ID));
+			assertTrue(StateUtil.checkSession(USER_ID, currentSession));
+		}
+		finally {
+			UtilImpl.CONCURRENT_SESSION_WARNINGS = originalWarnings;
+		}
+	}
+
+	private static User user(String customerName, String userName, String userId) {
+		User user = mock(User.class);
+		when(user.getCustomerName()).thenReturn(customerName);
+		when(user.getName()).thenReturn(userName);
+		when(user.getId()).thenReturn(userId);
+		return user;
+	}
+
+	private static HttpSession session(String id) {
+		HttpSession session = mock(HttpSession.class);
+		when(session.getId()).thenReturn(id);
+		return session;
+	}
+
+	private static HttpServletRequest requestWithPrincipal(String principalName) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getUserPrincipal()).thenReturn(() -> principalName);
+		return request;
+	}
+}


### PR DESCRIPTION
Raise a `SecurityLog` when a second session is initiated from a different browser/device to support enhanced auditing and detection (i.e. a new session is started from a different browser, not a new tab within the same browser).

Add json/Startup.xml controls to toggle this behaviour on/off per Skyve instance.