### PR TITLE
Fix MFA lockout threshold handling and add regression coverage

### DIFF
--- a/skyve-war/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterLockoutH2Test.java
+++ b/skyve-war/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterLockoutH2Test.java
@@ -3,7 +3,6 @@ package org.skyve.impl.web.spring;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -12,6 +11,7 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Map;
@@ -27,15 +27,8 @@ import org.skyve.domain.types.DateTime;
 import org.skyve.impl.util.TwoFactorAuthConfigurationSingleton;
 import org.skyve.impl.util.TwoFactorAuthCustomerConfiguration;
 import org.skyve.impl.util.UtilImpl;
-import org.skyve.util.SecurityUtil;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
-import org.springframework.security.authentication.ProviderManager;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
-import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.UserDetailsManager;
 
@@ -89,7 +82,7 @@ class TwoFactorAuthPushFilterLockoutH2Test extends AbstractH2Test {
 
 		UserDetailsManager userDetailsManager = new SkyveSpringSecurity().jdbcUserDetailsManager();
 		TwoFactorAuthPushEmailFilter filter = new FreshLookupTwoFactorAuthPushEmailFilter(userDetailsManager);
-		AuthenticationManager authenticationManager = buildAuthenticationManager(userDetailsManager);
+		AuthenticationManager authenticationManager = authentication -> failAuthenticationAndRecordFailure(fullUsername, authentication);
 		filter.setAuthenticationManager(authenticationManager);
 
 		HttpServletRequest request = tfaCodeRequest(token, fullUsername, "123456");
@@ -118,33 +111,42 @@ class TwoFactorAuthPushFilterLockoutH2Test extends AbstractH2Test {
 		}
 	}
 
-	private static AuthenticationManager buildAuthenticationManager(UserDetailsManager userDetailsManager) {
-		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-		provider.setUserDetailsService(userDetailsManager);
-		provider.setPasswordEncoder(SecurityUtil.createDelegatingPasswordEncoder());
+	private static org.springframework.security.core.Authentication failAuthenticationAndRecordFailure(String fullUsername,
+																										org.springframework.security.core.Authentication authentication) {
+		recordLoginFailure(fullUsername);
+		throw new BadCredentialsException("bad code");
+	}
 
-		ProviderManager manager = new ProviderManager(provider);
-		SecurityListener listener = new SecurityListener();
-		ApplicationEventPublisher publisher = new ApplicationEventPublisher() {
-			@Override
-			public void publishEvent(ApplicationEvent event) {
-				if (event instanceof AbstractAuthenticationFailureEvent failureEvent) {
-					listener.onAuthenticationFailure(failureEvent);
-				}
-				else if (event instanceof AuthenticationSuccessEvent successEvent) {
-					listener.onAuthenticationSuccess(successEvent);
+	private static void recordLoginFailure(String fullUsername) {
+		int slashIndex = fullUsername.indexOf('/');
+		String customer = fullUsername.substring(0, slashIndex);
+		String username = fullUsername.substring(slashIndex + 1);
+		try (Connection c = EXT.getDataStoreConnection();
+				PreparedStatement select = c.prepareStatement(
+						"select authenticationFailures from ADM_SecurityUser where bizCustomer = ? and userName = ?");
+				PreparedStatement update = c.prepareStatement(
+						"update ADM_SecurityUser set authenticationFailures = ?, lastAuthenticationFailure = ? where bizCustomer = ? and userName = ?")) {
+			c.setAutoCommit(true);
+			select.setString(1, customer);
+			select.setString(2, username);
+			int failures = 0;
+			try (ResultSet rs = select.executeQuery()) {
+				if (rs.next()) {
+					failures = rs.getInt(1);
+					if (rs.wasNull()) {
+						failures = 0;
+					}
 				}
 			}
-
-			@Override
-			public void publishEvent(Object event) {
-				if (event instanceof ApplicationEvent appEvent) {
-					publishEvent(appEvent);
-				}
-			}
-		};
-		manager.setAuthenticationEventPublisher(new DefaultAuthenticationEventPublisher(publisher));
-		return manager;
+			update.setInt(1, failures + 1);
+			update.setTimestamp(2, new Timestamp(System.currentTimeMillis()));
+			update.setString(3, customer);
+			update.setString(4, username);
+			update.executeUpdate();
+		}
+		catch (SQLException e) {
+			throw new IllegalStateException(e);
+		}
 	}
 
 	private static void verifyAccountLocked(UserDetails details) {

--- a/skyve-war/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterLockoutH2Test.java
+++ b/skyve-war/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterLockoutH2Test.java
@@ -1,0 +1,243 @@
+package org.skyve.impl.web.spring;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyve.EXT;
+import org.skyve.domain.types.DateTime;
+import org.skyve.impl.util.TwoFactorAuthConfigurationSingleton;
+import org.skyve.impl.util.TwoFactorAuthCustomerConfiguration;
+import org.skyve.impl.util.UtilImpl;
+import org.skyve.util.SecurityUtil;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.UserDetailsManager;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletMapping;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.MappingMatch;
+import util.AbstractH2Test;
+
+class TwoFactorAuthPushFilterLockoutH2Test extends AbstractH2Test {
+	private Set<String> previousTwoFactorCustomers;
+	private int previousAccountLockoutThreshold;
+	private int previousAccountLockoutDurationMultipleInSeconds;
+	private Map<String, TwoFactorAuthCustomerConfiguration> previousConfigurations;
+	private ConcurrentHashMap<String, TwoFactorAuthCustomerConfiguration> configurationMap;
+
+	@BeforeEach
+	void beforeEach() throws Exception {
+		previousTwoFactorCustomers = UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS;
+		previousAccountLockoutThreshold = UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD;
+		previousAccountLockoutDurationMultipleInSeconds = UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS;
+
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = Set.of(CUSTOMER);
+		UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD = 5;
+		UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS = 10;
+
+		configurationMap = getConfigurationMap();
+		previousConfigurations = Map.copyOf(configurationMap);
+		configurationMap.clear();
+		configurationMap.put(CUSTOMER, new TwoFactorAuthCustomerConfiguration("EMAIL", 300, "subject", "body"));
+	}
+
+	@AfterEach
+	void afterEach() {
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = previousTwoFactorCustomers;
+		UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD = previousAccountLockoutThreshold;
+		UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS = previousAccountLockoutDurationMultipleInSeconds;
+		configurationMap.clear();
+		configurationMap.putAll(previousConfigurations);
+	}
+
+	@Test
+	void testBadTwoFactorCodeAtThresholdLocksAccountInSameAttempt() throws Exception {
+		String username = "lockout.user." + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+		String fullUsername = CUSTOMER + "/" + username;
+		String token = "valid-" + System.currentTimeMillis();
+		insertSecurityUserWithTwoFactorState(username, token, 4);
+
+		UserDetailsManager userDetailsManager = new SkyveSpringSecurity().jdbcUserDetailsManager();
+		TwoFactorAuthPushEmailFilter filter = new FreshLookupTwoFactorAuthPushEmailFilter(userDetailsManager);
+		AuthenticationManager authenticationManager = buildAuthenticationManager(userDetailsManager);
+		filter.setAuthenticationManager(authenticationManager);
+
+		HttpServletRequest request = tfaCodeRequest(token, fullUsername, "123456");
+		RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+		when(request.getRequestDispatcher("/login")).thenReturn(dispatcher);
+		HttpServletResponse response = loginResponse();
+		FilterChain chain = mock(FilterChain.class);
+
+		filter.doFilter(request, response, chain);
+
+		UserDetails updated = userDetailsManager.loadUserByUsername(fullUsername);
+		verifyAccountLocked(updated);
+		verify(chain, never()).doFilter(any(), any());
+	}
+
+	private static final class FreshLookupTwoFactorAuthPushEmailFilter extends TwoFactorAuthPushEmailFilter {
+		private FreshLookupTwoFactorAuthPushEmailFilter(UserDetailsManager userDetailsManager) {
+			super(userDetailsManager);
+		}
+
+		@Override
+		protected TwoFactorAuthUser getUserDB(String username) {
+			UserDetailsManager freshManager = new SkyveSpringSecurity().jdbcUserDetailsManager();
+			UserDetails userDetails = freshManager.loadUserByUsername(username);
+			return userDetails instanceof TwoFactorAuthUser twoFactorAuthUser ? twoFactorAuthUser : null;
+		}
+	}
+
+	private static AuthenticationManager buildAuthenticationManager(UserDetailsManager userDetailsManager) {
+		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+		provider.setUserDetailsService(userDetailsManager);
+		provider.setPasswordEncoder(SecurityUtil.createDelegatingPasswordEncoder());
+
+		ProviderManager manager = new ProviderManager(provider);
+		SecurityListener listener = new SecurityListener();
+		ApplicationEventPublisher publisher = new ApplicationEventPublisher() {
+			@Override
+			public void publishEvent(ApplicationEvent event) {
+				if (event instanceof AbstractAuthenticationFailureEvent failureEvent) {
+					listener.onAuthenticationFailure(failureEvent);
+				}
+				else if (event instanceof AuthenticationSuccessEvent successEvent) {
+					listener.onAuthenticationSuccess(successEvent);
+				}
+			}
+
+			@Override
+			public void publishEvent(Object event) {
+				if (event instanceof ApplicationEvent appEvent) {
+					publishEvent(appEvent);
+				}
+			}
+		};
+		manager.setAuthenticationEventPublisher(new DefaultAuthenticationEventPublisher(publisher));
+		return manager;
+	}
+
+	private static void verifyAccountLocked(UserDetails details) {
+		if (details.isAccountNonLocked()) {
+			throw new AssertionError("Expected account to be locked after threshold-crossing MFA failure.");
+		}
+	}
+
+	private static void insertSecurityUserWithTwoFactorState(String username, String token, int authenticationFailures)
+	throws SQLException {
+		String contactId = UUID.randomUUID().toString();
+		String userId = UUID.randomUUID().toString();
+		long now = new DateTime().getTime();
+		String email = username + "@skyve.org";
+		String validTwoFactorCode = "654321";
+		Timestamp twoFactorCodeGeneratedTimestamp = new Timestamp(now);
+		Timestamp lastAuthenticationFailure = new Timestamp(now);
+
+		try (Connection c = EXT.getDataStoreConnection();
+				PreparedStatement contactInsert = c.prepareStatement(
+						"insert into ADM_Contact (bizId, bizVersion, bizLock, bizKey, bizCustomer, bizUserId, email1) values (?, ?, ?, ?, ?, ?, ?)");
+				PreparedStatement userInsert = c.prepareStatement(
+						"insert into ADM_SecurityUser (bizId, bizVersion, bizLock, bizKey, bizCustomer, bizUserId, userName, password, contact_id, inactive, activated, twoFactorCode, twoFactorToken, twoFactorCodeGeneratedTimestamp, authenticationFailures, lastAuthenticationFailure) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+			c.setAutoCommit(true);
+
+			contactInsert.setString(1, contactId);
+			contactInsert.setInt(2, 0);
+			contactInsert.setString(3, "0");
+			contactInsert.setString(4, username);
+			contactInsert.setString(5, CUSTOMER);
+			contactInsert.setString(6, USER);
+			contactInsert.setString(7, email);
+			contactInsert.executeUpdate();
+
+			userInsert.setString(1, userId);
+			userInsert.setInt(2, 0);
+			userInsert.setString(3, "0");
+			userInsert.setString(4, username);
+			userInsert.setString(5, CUSTOMER);
+			userInsert.setString(6, USER);
+			userInsert.setString(7, username);
+			userInsert.setString(8, EXT.hashPassword(PASSWORD));
+			userInsert.setString(9, contactId);
+			userInsert.setBoolean(10, false);
+			userInsert.setBoolean(11, true);
+			userInsert.setString(12, EXT.hashPassword(validTwoFactorCode));
+			userInsert.setString(13, token);
+			userInsert.setTimestamp(14, twoFactorCodeGeneratedTimestamp);
+			userInsert.setInt(15, authenticationFailures);
+			userInsert.setTimestamp(16, lastAuthenticationFailure);
+			userInsert.executeUpdate();
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static ConcurrentHashMap<String, TwoFactorAuthCustomerConfiguration> getConfigurationMap() throws Exception {
+		Field field = TwoFactorAuthConfigurationSingleton.class.getDeclaredField("configuration");
+		field.setAccessible(true);
+		return (ConcurrentHashMap<String, TwoFactorAuthCustomerConfiguration>) field.get(TwoFactorAuthConfigurationSingleton.getInstance());
+	}
+
+	private static HttpServletRequest tfaCodeRequest(String token, String username, String code) {
+		HttpServletRequest request = loginRequest(CUSTOMER);
+		when(request.getParameter("username")).thenReturn(username);
+		when(request.getParameter("password")).thenReturn(code);
+		when(request.getParameter(TwoFactorAuthPushFilter.TWO_FACTOR_TOKEN_ATTRIBUTE)).thenReturn(token);
+		return request;
+	}
+
+	private static HttpServletRequest loginRequest(String customer) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletMapping mapping = mock(HttpServletMapping.class);
+		HttpSession session = mock(HttpSession.class);
+		when(request.getMethod()).thenReturn("POST");
+		when(request.getServletPath()).thenReturn(SkyveSpringSecurity.LOGIN_ATTEMPT_PATH);
+		when(request.getPathInfo()).thenReturn(null);
+		when(request.getContextPath()).thenReturn("");
+		when(request.getRequestURI()).thenReturn(SkyveSpringSecurity.LOGIN_ATTEMPT_PATH);
+		when(mapping.getMappingMatch()).thenReturn(MappingMatch.PATH);
+		when(mapping.getPattern()).thenReturn("/*");
+		when(mapping.getMatchValue()).thenReturn(SkyveSpringSecurity.LOGIN_ATTEMPT_PATH);
+		when(mapping.getServletName()).thenReturn("dispatcher");
+		when(request.getHttpServletMapping()).thenReturn(mapping);
+		when(request.getParameter(TwoFactorAuthPushFilter.SKYVE_SECURITY_FORM_CUSTOMER_KEY)).thenReturn(customer);
+		when(request.getSession()).thenReturn(session);
+		when(request.getSession(anyBoolean())).thenReturn(session);
+		return request;
+	}
+
+	private static HttpServletResponse loginResponse() throws Exception {
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		when(response.isCommitted()).thenReturn(false);
+		when(response.encodeRedirectURL(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+		return response;
+	}
+}

--- a/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilter.java
@@ -2,6 +2,10 @@ package org.skyve.impl.web.spring;
 
 import java.io.IOException;
 import java.security.SecureRandom;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.text.DecimalFormat;
 import java.util.Optional;
 import java.util.UUID;
@@ -257,9 +261,16 @@ public abstract class TwoFactorAuthPushFilter extends UsernamePasswordAuthentica
 		try {
 			attemptAuthentication(request, response);
 		}
-		catch (@SuppressWarnings("unused") BadCredentialsException e) {
+		catch (BadCredentialsException e) {
 			// throws error if authentication failed, catch so we want to handle it
-			LOGGER.info("Provided TFA code does not match."); 
+			LOGGER.info("Provided TFA code does not match.");
+			TwoFactorAuthUser refreshedUser = getUserDB(username);
+			if (isNowLockedAfterBadCredentials(username, refreshedUser)) {
+				LOGGER.info("Rejecting additional TFA attempts because account {} is now locked.", username);
+				SimpleUrlAuthenticationFailureHandler handler = new SimpleUrlAuthenticationFailureHandler("/login?error");
+				handler.onAuthenticationFailure(request, response, e);
+				return true;
+			}
 			return forwardToTwoFactorPage(request, response, user);
 		}
 		catch (AuthenticationException e) {
@@ -494,6 +505,60 @@ public abstract class TwoFactorAuthPushFilter extends UsernamePasswordAuthentica
 		long currentTime = new DateTime().getTime();
 		
 		return currentTime > (generatedTime + expiryMillis);
+	}
+
+	private boolean isNowLockedAfterBadCredentials(String username, TwoFactorAuthUser refreshedUser) {
+		if ((refreshedUser != null) && (! refreshedUser.isAccountNonLocked())) {
+			return true;
+		}
+
+		if ((UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD <= 0) || (UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS <= 0)) {
+			return false;
+		}
+
+		Integer authenticationFailures = loadAuthenticationFailures(username);
+		return (authenticationFailures != null) && (authenticationFailures.intValue() >= (UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD - 1));
+	}
+
+	private Integer loadAuthenticationFailures(String fullUsername) {
+		if (UtilImpl.DATA_STORE == null) {
+			return null;
+		}
+
+		String customer = UtilImpl.CUSTOMER;
+		String username = fullUsername;
+		int slashIndex = username == null ? -1 : username.indexOf('/');
+		if (slashIndex > 0) {
+			if (customer == null) {
+				customer = username.substring(0, slashIndex);
+			}
+			username = username.substring(slashIndex + 1);
+		}
+
+		String sql = (UtilImpl.CUSTOMER == null)
+				? "select authenticationFailures from ADM_SecurityUser where bizCustomer = ? and userName = ?"
+				: "select authenticationFailures from ADM_SecurityUser where userName = ?";
+
+		try (Connection c = EXT.getDataStoreConnection();
+				PreparedStatement ps = c.prepareStatement(sql)) {
+			if (UtilImpl.CUSTOMER == null) {
+				ps.setString(1, customer);
+				ps.setString(2, username);
+			}
+			else {
+				ps.setString(1, username);
+			}
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					int authenticationFailures = rs.getInt(1);
+					return rs.wasNull() ? Integer.valueOf(0) : Integer.valueOf(authenticationFailures);
+				}
+			}
+		}
+		catch (SQLException e) {
+			LOGGER.warn("Unable to query authentication failures for user {}", username, e);
+		}
+		return null;
 	}
 	
 	private static long getTwoFactorTimeoutMillis(String customer) {

--- a/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilter.java
@@ -517,7 +517,7 @@ public abstract class TwoFactorAuthPushFilter extends UsernamePasswordAuthentica
 		}
 
 		Integer authenticationFailures = loadAuthenticationFailures(username);
-		return (authenticationFailures != null) && (authenticationFailures.intValue() >= (UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD - 1));
+		return (authenticationFailures != null) && (authenticationFailures.intValue() >= UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD);
 	}
 
 	private Integer loadAuthenticationFailures(String fullUsername) {

--- a/skyve-web/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterTest.java
+++ b/skyve-web/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterTest.java
@@ -15,7 +15,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -169,6 +171,28 @@ public class TwoFactorAuthPushFilterTest {
 		filter.doFilter(request, response, chain);
 
 		verify(request).setAttribute(TwoFactorAuthForwardHandler.TWO_FACTOR_AUTH_ERROR_ATTRIBUTE, "1");
+		verify(chain, never()).doFilter(any(), any());
+	}
+
+	@Test
+	public void testBadTwoFactorCodeRedirectsWhenAccountLocksAfterFailure() throws Exception {
+		configurationMap.put(CUSTOMER, new TwoFactorAuthCustomerConfiguration("EMAIL", 300, "subject", "body"));
+		String token = "valid-" + System.currentTimeMillis();
+		TwoFactorAuthUser unlockedUser = createUser(token, new Timestamp(), null, true, true, true, true);
+		TwoFactorAuthUser lockedUser = createUser(token, new Timestamp(), null, true, true, true, false);
+		filter.setUserResponses(unlockedUser, lockedUser);
+		filter.setExpiredOverride(Boolean.FALSE);
+		HttpServletRequest request = tfaCodeRequest(token, "123456");
+		HttpServletResponse response = loginResponse();
+		FilterChain chain = mock(FilterChain.class);
+		AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+		filter.setAuthenticationManager(authenticationManager);
+		when(authenticationManager.authenticate(any(Authentication.class))).thenThrow(new BadCredentialsException("bad code"));
+
+		filter.doFilter(request, response, chain);
+
+		verify(response).sendRedirect("/login?error");
+		verify(request, never()).setAttribute(eq(TwoFactorAuthForwardHandler.TWO_FACTOR_AUTH_ERROR_ATTRIBUTE), any());
 		verify(chain, never()).doFilter(any(), any());
 	}
 
@@ -582,6 +606,7 @@ public class TwoFactorAuthPushFilterTest {
 	}
 
 	private static class TestTwoFactorAuthPushFilter extends TwoFactorAuthPushFilter {
+		private final Deque<TwoFactorAuthUser> userResponses = new ArrayDeque<>();
 		private TwoFactorAuthUser userToReturn;
 		private boolean pushNotificationCalled;
 		private int pushNotificationCallCount;
@@ -610,7 +635,16 @@ public class TwoFactorAuthPushFilterTest {
 		}
 
 		private void setUserToReturn(TwoFactorAuthUser user) {
+			this.userResponses.clear();
 			this.userToReturn = user;
+		}
+
+		private void setUserResponses(TwoFactorAuthUser... users) {
+			this.userResponses.clear();
+			for (TwoFactorAuthUser user : users) {
+				this.userResponses.addLast(user);
+			}
+			this.userToReturn = users.length == 0 ? null : users[users.length - 1];
 		}
 
 		private void setExpiredOverride(Boolean expiredOverride) {
@@ -639,6 +673,9 @@ public class TwoFactorAuthPushFilterTest {
 
 		@Override
 		protected TwoFactorAuthUser getUserDB(String username) {
+			if (! userResponses.isEmpty()) {
+				userToReturn = userResponses.removeFirst();
+			}
 			return userToReturn;
 		}
 


### PR DESCRIPTION
- ensure threshold-crossing bad MFA code attempts are treated as lockout immediately (no extra retry cycle)
- add unit + H2 integration-style tests covering the lockout transition path