### PR TITLE
Fix MFA lockout threshold handling and add regression coverage

### DIFF
--- a/skyve-war/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterLockoutH2Test.java
+++ b/skyve-war/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterLockoutH2Test.java
@@ -1,0 +1,245 @@
+package org.skyve.impl.web.spring;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyve.EXT;
+import org.skyve.domain.types.DateTime;
+import org.skyve.impl.util.TwoFactorAuthConfigurationSingleton;
+import org.skyve.impl.util.TwoFactorAuthCustomerConfiguration;
+import org.skyve.impl.util.UtilImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.UserDetailsManager;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletMapping;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.MappingMatch;
+import util.AbstractH2Test;
+
+class TwoFactorAuthPushFilterLockoutH2Test extends AbstractH2Test {
+	private Set<String> previousTwoFactorCustomers;
+	private int previousAccountLockoutThreshold;
+	private int previousAccountLockoutDurationMultipleInSeconds;
+	private Map<String, TwoFactorAuthCustomerConfiguration> previousConfigurations;
+	private ConcurrentHashMap<String, TwoFactorAuthCustomerConfiguration> configurationMap;
+
+	@BeforeEach
+	void beforeEach() throws Exception {
+		previousTwoFactorCustomers = UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS;
+		previousAccountLockoutThreshold = UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD;
+		previousAccountLockoutDurationMultipleInSeconds = UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS;
+
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = Set.of(CUSTOMER);
+		UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD = 5;
+		UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS = 10;
+
+		configurationMap = getConfigurationMap();
+		previousConfigurations = Map.copyOf(configurationMap);
+		configurationMap.clear();
+		configurationMap.put(CUSTOMER, new TwoFactorAuthCustomerConfiguration("EMAIL", 300, "subject", "body"));
+	}
+
+	@AfterEach
+	void afterEach() {
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = previousTwoFactorCustomers;
+		UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD = previousAccountLockoutThreshold;
+		UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS = previousAccountLockoutDurationMultipleInSeconds;
+		configurationMap.clear();
+		configurationMap.putAll(previousConfigurations);
+	}
+
+	@Test
+	void testBadTwoFactorCodeAtThresholdLocksAccountInSameAttempt() throws Exception {
+		String username = "lockout.user." + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+		String fullUsername = CUSTOMER + "/" + username;
+		String token = "valid-" + System.currentTimeMillis();
+		insertSecurityUserWithTwoFactorState(username, token, 4);
+
+		UserDetailsManager userDetailsManager = new SkyveSpringSecurity().jdbcUserDetailsManager();
+		TwoFactorAuthPushEmailFilter filter = new FreshLookupTwoFactorAuthPushEmailFilter(userDetailsManager);
+		AuthenticationManager authenticationManager = authentication -> failAuthenticationAndRecordFailure(fullUsername, authentication);
+		filter.setAuthenticationManager(authenticationManager);
+
+		HttpServletRequest request = tfaCodeRequest(token, fullUsername, "123456");
+		RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+		when(request.getRequestDispatcher("/login")).thenReturn(dispatcher);
+		HttpServletResponse response = loginResponse();
+		FilterChain chain = mock(FilterChain.class);
+
+		filter.doFilter(request, response, chain);
+
+		UserDetails updated = userDetailsManager.loadUserByUsername(fullUsername);
+		verifyAccountLocked(updated);
+		verify(chain, never()).doFilter(any(), any());
+	}
+
+	private static final class FreshLookupTwoFactorAuthPushEmailFilter extends TwoFactorAuthPushEmailFilter {
+		private FreshLookupTwoFactorAuthPushEmailFilter(UserDetailsManager userDetailsManager) {
+			super(userDetailsManager);
+		}
+
+		@Override
+		protected TwoFactorAuthUser getUserDB(String username) {
+			UserDetailsManager freshManager = new SkyveSpringSecurity().jdbcUserDetailsManager();
+			UserDetails userDetails = freshManager.loadUserByUsername(username);
+			return userDetails instanceof TwoFactorAuthUser twoFactorAuthUser ? twoFactorAuthUser : null;
+		}
+	}
+
+	private static org.springframework.security.core.Authentication failAuthenticationAndRecordFailure(String fullUsername,
+																										org.springframework.security.core.Authentication authentication) {
+		recordLoginFailure(fullUsername);
+		throw new BadCredentialsException("bad code");
+	}
+
+	private static void recordLoginFailure(String fullUsername) {
+		int slashIndex = fullUsername.indexOf('/');
+		String customer = fullUsername.substring(0, slashIndex);
+		String username = fullUsername.substring(slashIndex + 1);
+		try (Connection c = EXT.getDataStoreConnection();
+				PreparedStatement select = c.prepareStatement(
+						"select authenticationFailures from ADM_SecurityUser where bizCustomer = ? and userName = ?");
+				PreparedStatement update = c.prepareStatement(
+						"update ADM_SecurityUser set authenticationFailures = ?, lastAuthenticationFailure = ? where bizCustomer = ? and userName = ?")) {
+			c.setAutoCommit(true);
+			select.setString(1, customer);
+			select.setString(2, username);
+			int failures = 0;
+			try (ResultSet rs = select.executeQuery()) {
+				if (rs.next()) {
+					failures = rs.getInt(1);
+					if (rs.wasNull()) {
+						failures = 0;
+					}
+				}
+			}
+			update.setInt(1, failures + 1);
+			update.setTimestamp(2, new Timestamp(System.currentTimeMillis()));
+			update.setString(3, customer);
+			update.setString(4, username);
+			update.executeUpdate();
+		}
+		catch (SQLException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static void verifyAccountLocked(UserDetails details) {
+		if (details.isAccountNonLocked()) {
+			throw new AssertionError("Expected account to be locked after threshold-crossing MFA failure.");
+		}
+	}
+
+	private static void insertSecurityUserWithTwoFactorState(String username, String token, int authenticationFailures)
+	throws SQLException {
+		String contactId = UUID.randomUUID().toString();
+		String userId = UUID.randomUUID().toString();
+		long now = new DateTime().getTime();
+		String email = username + "@skyve.org";
+		String validTwoFactorCode = "654321";
+		Timestamp twoFactorCodeGeneratedTimestamp = new Timestamp(now);
+		Timestamp lastAuthenticationFailure = new Timestamp(now);
+
+		try (Connection c = EXT.getDataStoreConnection();
+				PreparedStatement contactInsert = c.prepareStatement(
+						"insert into ADM_Contact (bizId, bizVersion, bizLock, bizKey, bizCustomer, bizUserId, email1) values (?, ?, ?, ?, ?, ?, ?)");
+				PreparedStatement userInsert = c.prepareStatement(
+						"insert into ADM_SecurityUser (bizId, bizVersion, bizLock, bizKey, bizCustomer, bizUserId, userName, password, contact_id, inactive, activated, twoFactorCode, twoFactorToken, twoFactorCodeGeneratedTimestamp, authenticationFailures, lastAuthenticationFailure) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+			c.setAutoCommit(true);
+
+			contactInsert.setString(1, contactId);
+			contactInsert.setInt(2, 0);
+			contactInsert.setString(3, "0");
+			contactInsert.setString(4, username);
+			contactInsert.setString(5, CUSTOMER);
+			contactInsert.setString(6, USER);
+			contactInsert.setString(7, email);
+			contactInsert.executeUpdate();
+
+			userInsert.setString(1, userId);
+			userInsert.setInt(2, 0);
+			userInsert.setString(3, "0");
+			userInsert.setString(4, username);
+			userInsert.setString(5, CUSTOMER);
+			userInsert.setString(6, USER);
+			userInsert.setString(7, username);
+			userInsert.setString(8, EXT.hashPassword(PASSWORD));
+			userInsert.setString(9, contactId);
+			userInsert.setBoolean(10, false);
+			userInsert.setBoolean(11, true);
+			userInsert.setString(12, EXT.hashPassword(validTwoFactorCode));
+			userInsert.setString(13, token);
+			userInsert.setTimestamp(14, twoFactorCodeGeneratedTimestamp);
+			userInsert.setInt(15, authenticationFailures);
+			userInsert.setTimestamp(16, lastAuthenticationFailure);
+			userInsert.executeUpdate();
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static ConcurrentHashMap<String, TwoFactorAuthCustomerConfiguration> getConfigurationMap() throws Exception {
+		Field field = TwoFactorAuthConfigurationSingleton.class.getDeclaredField("configuration");
+		field.setAccessible(true);
+		return (ConcurrentHashMap<String, TwoFactorAuthCustomerConfiguration>) field.get(TwoFactorAuthConfigurationSingleton.getInstance());
+	}
+
+	private static HttpServletRequest tfaCodeRequest(String token, String username, String code) {
+		HttpServletRequest request = loginRequest(CUSTOMER);
+		when(request.getParameter("username")).thenReturn(username);
+		when(request.getParameter("password")).thenReturn(code);
+		when(request.getParameter(TwoFactorAuthPushFilter.TWO_FACTOR_TOKEN_ATTRIBUTE)).thenReturn(token);
+		return request;
+	}
+
+	private static HttpServletRequest loginRequest(String customer) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletMapping mapping = mock(HttpServletMapping.class);
+		HttpSession session = mock(HttpSession.class);
+		when(request.getMethod()).thenReturn("POST");
+		when(request.getServletPath()).thenReturn(SkyveSpringSecurity.LOGIN_ATTEMPT_PATH);
+		when(request.getPathInfo()).thenReturn(null);
+		when(request.getContextPath()).thenReturn("");
+		when(request.getRequestURI()).thenReturn(SkyveSpringSecurity.LOGIN_ATTEMPT_PATH);
+		when(mapping.getMappingMatch()).thenReturn(MappingMatch.PATH);
+		when(mapping.getPattern()).thenReturn("/*");
+		when(mapping.getMatchValue()).thenReturn(SkyveSpringSecurity.LOGIN_ATTEMPT_PATH);
+		when(mapping.getServletName()).thenReturn("dispatcher");
+		when(request.getHttpServletMapping()).thenReturn(mapping);
+		when(request.getParameter(TwoFactorAuthPushFilter.SKYVE_SECURITY_FORM_CUSTOMER_KEY)).thenReturn(customer);
+		when(request.getSession()).thenReturn(session);
+		when(request.getSession(anyBoolean())).thenReturn(session);
+		return request;
+	}
+
+	private static HttpServletResponse loginResponse() throws Exception {
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		when(response.isCommitted()).thenReturn(false);
+		when(response.encodeRedirectURL(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+		return response;
+	}
+}

--- a/skyve-war/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterLockoutH2Test.java
+++ b/skyve-war/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterLockoutH2Test.java
@@ -14,11 +14,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,9 @@ import org.skyve.impl.util.TwoFactorAuthCustomerConfiguration;
 import org.skyve.impl.util.UtilImpl;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.event.AuthenticationFailureLockedEvent;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.UserDetailsManager;
 
@@ -47,6 +52,8 @@ class TwoFactorAuthPushFilterLockoutH2Test extends AbstractH2Test {
 	private int previousAccountLockoutDurationMultipleInSeconds;
 	private Map<String, TwoFactorAuthCustomerConfiguration> previousConfigurations;
 	private ConcurrentHashMap<String, TwoFactorAuthCustomerConfiguration> configurationMap;
+	private final Set<String> insertedContactIds = new HashSet<>();
+	private final Set<String> insertedSecurityUserIds = new HashSet<>();
 
 	@BeforeEach
 	void beforeEach() throws Exception {
@@ -66,11 +73,14 @@ class TwoFactorAuthPushFilterLockoutH2Test extends AbstractH2Test {
 
 	@AfterEach
 	void afterEach() {
+		deleteInsertedRows();
 		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = previousTwoFactorCustomers;
 		UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD = previousAccountLockoutThreshold;
 		UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS = previousAccountLockoutDurationMultipleInSeconds;
-		configurationMap.clear();
-		configurationMap.putAll(previousConfigurations);
+		if ((configurationMap != null) && (previousConfigurations != null)) {
+			configurationMap.clear();
+			configurationMap.putAll(previousConfigurations);
+		}
 	}
 
 	@Test
@@ -96,6 +106,23 @@ class TwoFactorAuthPushFilterLockoutH2Test extends AbstractH2Test {
 		UserDetails updated = userDetailsManager.loadUserByUsername(fullUsername);
 		verifyAccountLocked(updated);
 		verify(chain, never()).doFilter(any(), any());
+		verify(response).sendRedirect("/login?error");
+		verify(dispatcher, never()).forward(any(), any());
+	}
+
+	@Test
+	void testLockedAuthenticationFailureStillIncrementsFailuresPastThreshold() throws Exception {
+		String username = "locked.user." + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+		String fullUsername = CUSTOMER + "/" + username;
+		String token = "valid-" + System.currentTimeMillis();
+		insertSecurityUserWithTwoFactorState(username, token, UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD);
+
+		SecurityListener listener = new SecurityListener();
+		listener.onAuthenticationFailure(new AuthenticationFailureLockedEvent(
+				new UsernamePasswordAuthenticationToken(fullUsername, "bad"),
+				new LockedException("locked")));
+
+		Assertions.assertEquals(Integer.valueOf(UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD + 1), loadAuthenticationFailures(fullUsername));
 	}
 
 	private static final class FreshLookupTwoFactorAuthPushEmailFilter extends TwoFactorAuthPushEmailFilter {
@@ -155,7 +182,28 @@ class TwoFactorAuthPushFilterLockoutH2Test extends AbstractH2Test {
 		}
 	}
 
-	private static void insertSecurityUserWithTwoFactorState(String username, String token, int authenticationFailures)
+	private static Integer loadAuthenticationFailures(String fullUsername) {
+		int slashIndex = fullUsername.indexOf('/');
+		String customer = fullUsername.substring(0, slashIndex);
+		String username = fullUsername.substring(slashIndex + 1);
+		try (Connection c = EXT.getDataStoreConnection();
+				PreparedStatement ps = c.prepareStatement("select authenticationFailures from ADM_SecurityUser where bizCustomer = ? and userName = ?")) {
+			ps.setString(1, customer);
+			ps.setString(2, username);
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					int failures = rs.getInt(1);
+					return rs.wasNull() ? Integer.valueOf(0) : Integer.valueOf(failures);
+				}
+			}
+		}
+		catch (SQLException e) {
+			throw new IllegalStateException(e);
+		}
+		return null;
+	}
+
+	private void insertSecurityUserWithTwoFactorState(String username, String token, int authenticationFailures)
 	throws SQLException {
 		String contactId = UUID.randomUUID().toString();
 		String userId = UUID.randomUUID().toString();
@@ -198,6 +246,36 @@ class TwoFactorAuthPushFilterLockoutH2Test extends AbstractH2Test {
 			userInsert.setInt(15, authenticationFailures);
 			userInsert.setTimestamp(16, lastAuthenticationFailure);
 			userInsert.executeUpdate();
+		}
+
+		insertedContactIds.add(contactId);
+		insertedSecurityUserIds.add(userId);
+	}
+
+	private void deleteInsertedRows() {
+		if (insertedSecurityUserIds.isEmpty() && insertedContactIds.isEmpty()) {
+			return;
+		}
+
+		try (Connection c = EXT.getDataStoreConnection();
+				PreparedStatement deleteUsers = c.prepareStatement("delete from ADM_SecurityUser where bizId = ?");
+				PreparedStatement deleteContacts = c.prepareStatement("delete from ADM_Contact where bizId = ?")) {
+			c.setAutoCommit(true);
+			for (String securityUserId : insertedSecurityUserIds) {
+				deleteUsers.setString(1, securityUserId);
+				deleteUsers.executeUpdate();
+			}
+			for (String contactId : insertedContactIds) {
+				deleteContacts.setString(1, contactId);
+				deleteContacts.executeUpdate();
+			}
+		}
+		catch (SQLException e) {
+			throw new IllegalStateException(e);
+		}
+		finally {
+			insertedSecurityUserIds.clear();
+			insertedContactIds.clear();
 		}
 	}
 

--- a/skyve-web/src/main/java/org/skyve/impl/web/spring/SkyveSpringSecurity.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/spring/SkyveSpringSecurity.java
@@ -178,6 +178,30 @@ public class SkyveSpringSecurity {
 		
 		return currentTime < (generatedTime + expiryMillis);
 	}
+
+	static boolean hasActiveLockout(int authenticationFailures, Timestamp lastAuthenticationFailure, long currentTimeMillis) {
+		if (lastAuthenticationFailure == null) {
+			return false;
+		}
+		return hasActiveLockout(authenticationFailures, lastAuthenticationFailure.getTime(), currentTimeMillis);
+	}
+
+	static boolean hasActiveLockout(int authenticationFailures, long lastAuthenticationFailureMillis, long currentTimeMillis) {
+		if ((UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD <= 0) || (UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS <= 0)) {
+			return false;
+		}
+		if (authenticationFailures < UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD) {
+			return false;
+		}
+
+		long lockoutMillis = lockoutDurationMillis(authenticationFailures);
+		long millisRemaining = (lastAuthenticationFailureMillis + lockoutMillis) - currentTimeMillis;
+		return millisRemaining > 0L;
+	}
+
+	static long lockoutDurationMillis(int authenticationFailures) {
+		return authenticationFailures * (long) UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS * 1000L;
+	}
 	
 	public UserDetailsManager jdbcUserDetailsManager() {
 		JdbcUserDetailsManager result = new JdbcUserDetailsManager() {
@@ -284,22 +308,17 @@ public class SkyveSpringSecurity {
 								if (useTFAPushCodeAsPassword( twoFactorGenerated, customerName)) {
 									password = twoFactorCode;
 								} 
-								
-								if ((lastAuthenticationFailure != null) &&
-										(UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD > 0) && 
-										(UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS > 0)) {
-									if (authenticationFailures >= UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD) {
-										long lockoutMillis = authenticationFailures * UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS * 1000;
-										long millisRemaining = (lastAuthenticationFailure.getTime() + lockoutMillis) - System.currentTimeMillis();
-										if (millisRemaining > 0) {
-											long secondsRemaining = millisRemaining / 1000;
-											if (secondsRemaining == 0) {
-												secondsRemaining++;
-											}
-											locked = true;
-											LOGGER.warn("Account {} is locked for another {} seconds", springUsername, Long.valueOf(secondsRemaining));
-										}
+
+								long currentTimeMillis = System.currentTimeMillis();
+								if (hasActiveLockout(authenticationFailures, lastAuthenticationFailure, currentTimeMillis)) {
+									long lockoutMillis = lockoutDurationMillis(authenticationFailures);
+									long millisRemaining = (lastAuthenticationFailure.getTime() + lockoutMillis) - currentTimeMillis;
+									long secondsRemaining = millisRemaining / 1000L;
+									if (secondsRemaining == 0L) {
+										secondsRemaining++;
 									}
+									locked = true;
+									LOGGER.warn("Account {} is locked for another {} seconds", springUsername, Long.valueOf(secondsRemaining));
 								}
 								
 								

--- a/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilter.java
@@ -501,11 +501,17 @@ public abstract class TwoFactorAuthPushFilter extends UsernamePasswordAuthentica
 			return false;
 		}
 
-		Integer authenticationFailures = loadAuthenticationFailures(username);
-		return (authenticationFailures != null) && (authenticationFailures.intValue() >= UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD);
+		LockoutState lockoutState = loadLockoutState(username);
+		if ((lockoutState == null) || (! lockoutState.hasLastAuthenticationFailure)) {
+			return false;
+		}
+
+		return SkyveSpringSecurity.hasActiveLockout(lockoutState.authenticationFailures,
+													lockoutState.lastAuthenticationFailureMillis,
+													currentTimeMillis());
 	}
 
-	private Integer loadAuthenticationFailures(String fullUsername) {
+	private LockoutState loadLockoutState(String fullUsername) {
 		if (UtilImpl.DATA_STORE == null) {
 			return null;
 		}
@@ -521,8 +527,8 @@ public abstract class TwoFactorAuthPushFilter extends UsernamePasswordAuthentica
 		}
 
 		String sql = (UtilImpl.CUSTOMER == null)
-				? "select authenticationFailures from ADM_SecurityUser where bizCustomer = ? and userName = ?"
-				: "select authenticationFailures from ADM_SecurityUser where userName = ?";
+				? "select authenticationFailures, lastAuthenticationFailure from ADM_SecurityUser where bizCustomer = ? and userName = ?"
+				: "select authenticationFailures, lastAuthenticationFailure from ADM_SecurityUser where userName = ?";
 
 		try (Connection c = EXT.getDataStoreConnection();
 				PreparedStatement ps = c.prepareStatement(sql)) {
@@ -536,7 +542,16 @@ public abstract class TwoFactorAuthPushFilter extends UsernamePasswordAuthentica
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
 					int authenticationFailures = rs.getInt(1);
-					return rs.wasNull() ? Integer.valueOf(0) : Integer.valueOf(authenticationFailures);
+					if (rs.wasNull()) {
+						authenticationFailures = 0;
+					}
+					java.sql.Timestamp lastAuthenticationFailure = rs.getTimestamp(2);
+					long lastAuthenticationFailureMillis = 0L;
+					boolean hasLastAuthenticationFailure = lastAuthenticationFailure != null;
+					if (hasLastAuthenticationFailure) {
+						lastAuthenticationFailureMillis = lastAuthenticationFailure.getTime();
+					}
+					return new LockoutState(authenticationFailures, lastAuthenticationFailureMillis, hasLastAuthenticationFailure);
 				}
 			}
 		}
@@ -544,6 +559,18 @@ public abstract class TwoFactorAuthPushFilter extends UsernamePasswordAuthentica
 			LOGGER.warn("Unable to query authentication failures for user {}", username, e);
 		}
 		return null;
+	}
+
+	private static final class LockoutState {
+		private final int authenticationFailures;
+		private final long lastAuthenticationFailureMillis;
+		private final boolean hasLastAuthenticationFailure;
+
+		private LockoutState(int authenticationFailures, long lastAuthenticationFailureMillis, boolean hasLastAuthenticationFailure) {
+			this.authenticationFailures = authenticationFailures;
+			this.lastAuthenticationFailureMillis = lastAuthenticationFailureMillis;
+			this.hasLastAuthenticationFailure = hasLastAuthenticationFailure;
+		}
 	}
 	
 	private static long getTwoFactorTimeoutMillis(String customer) {

--- a/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilter.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilter.java
@@ -2,6 +2,10 @@ package org.skyve.impl.web.spring;
 
 import java.io.IOException;
 import java.security.SecureRandom;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.text.DecimalFormat;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -249,9 +253,16 @@ public abstract class TwoFactorAuthPushFilter extends UsernamePasswordAuthentica
 		try {
 			attemptAuthentication(request, response);
 		}
-		catch (@SuppressWarnings("unused") BadCredentialsException e) {
+		catch (BadCredentialsException e) {
 			// throws error if authentication failed, catch so we want to handle it
-			LOGGER.info("Provided TFA code does not match."); 
+			LOGGER.info("Provided TFA code does not match.");
+			TwoFactorAuthUser refreshedUser = getUserDB(username);
+			if (isNowLockedAfterBadCredentials(username, refreshedUser)) {
+				LOGGER.info("Rejecting additional TFA attempts because account {} is now locked.", username);
+				SimpleUrlAuthenticationFailureHandler handler = new SimpleUrlAuthenticationFailureHandler("/login?error");
+				handler.onAuthenticationFailure(request, response, e);
+				return true;
+			}
 			return forwardToTwoFactorPage(request, response, user);
 		}
 		catch (AuthenticationException e) {
@@ -479,6 +490,60 @@ public abstract class TwoFactorAuthPushFilter extends UsernamePasswordAuthentica
 		long currentTime = new DateTime(System.currentTimeMillis()).getTime();
 		
 		return currentTime > (generatedTime + expiryMillis);
+	}
+
+	private boolean isNowLockedAfterBadCredentials(String username, TwoFactorAuthUser refreshedUser) {
+		if ((refreshedUser != null) && (! refreshedUser.isAccountNonLocked())) {
+			return true;
+		}
+
+		if ((UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD <= 0) || (UtilImpl.ACCOUNT_LOCKOUT_DURATION_MULTIPLE_IN_SECONDS <= 0)) {
+			return false;
+		}
+
+		Integer authenticationFailures = loadAuthenticationFailures(username);
+		return (authenticationFailures != null) && (authenticationFailures.intValue() >= UtilImpl.ACCOUNT_LOCKOUT_THRESHOLD);
+	}
+
+	private Integer loadAuthenticationFailures(String fullUsername) {
+		if (UtilImpl.DATA_STORE == null) {
+			return null;
+		}
+
+		String customer = UtilImpl.CUSTOMER;
+		String username = fullUsername;
+		int slashIndex = username == null ? -1 : username.indexOf('/');
+		if (slashIndex > 0) {
+			if (customer == null) {
+				customer = username.substring(0, slashIndex);
+			}
+			username = username.substring(slashIndex + 1);
+		}
+
+		String sql = (UtilImpl.CUSTOMER == null)
+				? "select authenticationFailures from ADM_SecurityUser where bizCustomer = ? and userName = ?"
+				: "select authenticationFailures from ADM_SecurityUser where userName = ?";
+
+		try (Connection c = EXT.getDataStoreConnection();
+				PreparedStatement ps = c.prepareStatement(sql)) {
+			if (UtilImpl.CUSTOMER == null) {
+				ps.setString(1, customer);
+				ps.setString(2, username);
+			}
+			else {
+				ps.setString(1, username);
+			}
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					int authenticationFailures = rs.getInt(1);
+					return rs.wasNull() ? Integer.valueOf(0) : Integer.valueOf(authenticationFailures);
+				}
+			}
+		}
+		catch (SQLException e) {
+			LOGGER.warn("Unable to query authentication failures for user {}", username, e);
+		}
+		return null;
 	}
 	
 	private static long getTwoFactorTimeoutMillis(String customer) {

--- a/skyve-web/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterTest.java
+++ b/skyve-web/src/test/java/org/skyve/impl/web/spring/TwoFactorAuthPushFilterTest.java
@@ -14,7 +14,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -277,12 +279,16 @@ class TwoFactorAuthPushFilterTest {
 	}
 
 	private static TwoFactorAuthUser createUser(String token, Timestamp timestamp) {
+		return createUser(token, timestamp, true);
+	}
+
+	private static TwoFactorAuthUser createUser(String token, Timestamp timestamp, boolean accountNonLocked) {
 		return new TwoFactorAuthUser(USERNAME,
 								"ignored",
 								true,
 								true,
 								true,
-								true,
+								accountNonLocked,
 								Collections.emptyList(),
 								CUSTOMER,
 								USER,
@@ -332,6 +338,30 @@ class TwoFactorAuthPushFilterTest {
 		filter.doFilter(request, response, chain);
 
 		verify(request).setAttribute(TwoFactorAuthForwardHandler.TWO_FACTOR_AUTH_ERROR_ATTRIBUTE, "1");
+		verify(chain, never()).doFilter(any(), any());
+	}
+
+	@Test
+	void testBadTwoFactorCodeRedirectsWhenAccountLocksAfterFailure() throws Exception {
+		configurationMap.put(CUSTOMER, new TwoFactorAuthCustomerConfiguration("EMAIL", 300, "subject", "body"));
+		String token = "valid-" + System.currentTimeMillis();
+		TwoFactorAuthUser unlockedUser = createUser(token, new Timestamp(), true);
+		TwoFactorAuthUser lockedUser = createUser(token, new Timestamp(), false);
+		filter.setUserResponses(unlockedUser, lockedUser);
+		HttpServletRequest request = loginRequest(CUSTOMER);
+		when(request.getParameter("username")).thenReturn(CUSTOMER + "/bob");
+		when(request.getParameter("password")).thenReturn("123456");
+		when(request.getParameter(TwoFactorAuthPushFilter.TWO_FACTOR_TOKEN_ATTRIBUTE)).thenReturn(token);
+		HttpServletResponse response = responseWithRedirect();
+		FilterChain chain = mock(FilterChain.class);
+		AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+		filter.setAuthenticationManager(authenticationManager);
+		when(authenticationManager.authenticate(any(Authentication.class))).thenThrow(new BadCredentialsException("bad code"));
+
+		filter.doFilter(request, response, chain);
+
+		verify(response).sendRedirect("/login?error");
+		verify(request, never()).setAttribute(eq(TwoFactorAuthForwardHandler.TWO_FACTOR_AUTH_ERROR_ATTRIBUTE), any());
 		verify(chain, never()).doFilter(any(), any());
 	}
 
@@ -481,6 +511,7 @@ class TwoFactorAuthPushFilterTest {
 	}
 
 	private static class TestTwoFactorAuthPushFilter extends TwoFactorAuthPushFilter {
+		private final Deque<TwoFactorAuthUser> userResponses = new ArrayDeque<>();
 		private TwoFactorAuthUser userToReturn;
 		private boolean pushNotificationCalled;
 		private int pushNotificationCallCount;
@@ -508,7 +539,16 @@ class TwoFactorAuthPushFilterTest {
 		}
 
 		private void setUserToReturn(TwoFactorAuthUser user) {
+			this.userResponses.clear();
 			this.userToReturn = user;
+		}
+
+		private void setUserResponses(TwoFactorAuthUser... users) {
+			this.userResponses.clear();
+			for (TwoFactorAuthUser user : users) {
+				this.userResponses.addLast(user);
+			}
+			this.userToReturn = users.length == 0 ? null : users[users.length - 1];
 		}
 
 		private void setExpiredOverride(Boolean expiredOverride) {
@@ -536,6 +576,9 @@ class TwoFactorAuthPushFilterTest {
 
 		@Override
 		protected TwoFactorAuthUser getUserDB(String username) {
+			if (! userResponses.isEmpty()) {
+				userToReturn = userResponses.removeFirst();
+			}
 			return userToReturn;
 		}
 


### PR DESCRIPTION
Addresses a defect where n+1 MFA attempts were allowed.

- ensure threshold-crossing bad MFA code attempts are treated as lockout immediately (no extra retry cycle)
- add unit + H2 integration-style tests covering the lockout transition path