### PR TITLE
Patch TwoFactorAuthConfigurationSingleton to log instead of failing to startup in non-production environments

### DIFF
--- a/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
@@ -9,6 +9,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.skyve.CORE;
 import org.skyve.EXT;
 import org.skyve.domain.messages.DomainException;
+import org.slf4j.Logger;
+import org.skyve.util.logging.SkyveLoggerFactory;
 
 /**
  * Caches and serves customer-level two-factor-authentication configuration.
@@ -21,6 +23,7 @@ import org.skyve.domain.messages.DomainException;
  * reads and updates.
  */
 public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
+	private static final Logger LOGGER = SkyveLoggerFactory.getLogger(TwoFactorAuthConfigurationSingleton.class);
 	private static TwoFactorAuthConfigurationSingleton instance = new TwoFactorAuthConfigurationSingleton();
 
 	private final ConcurrentHashMap<String, TwoFactorAuthCustomerConfiguration> configuration = new ConcurrentHashMap<>();
@@ -103,7 +106,7 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 	 */
 	@Override
 	public void startup() {
-		try (Connection c = EXT.getDataStoreConnection()) {
+		try (Connection c = getDataStoreConnection()) {
 			String query = "select twoFactorType, twofactorPushCodeTimeOutSeconds, twoFactorEmailSubject, twoFactorEmailBody, bizCustomer " +
 								"from ADM_Configuration " +
 								"where twoFactorType is not null and twofactorPushCodeTimeOutSeconds is not null";
@@ -124,8 +127,39 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 			}
 		}
 		catch (SQLException e) {
+			if (shouldIgnoreStartupFailure(e)) {
+				LOGGER.warn("Skipping TFA database configuration read during non-production bootstrap.", e);
+				return;
+			}
 			throw new DomainException("Failure reading customer configuration from database.", e);
 		}
+	}
+
+	/**
+	 * Obtains a JDBC connection to the configured Skyve datastore.
+	 *
+	 * @return An open datastore connection
+	 * @throws SQLException If the connection cannot be created
+	 */
+	Connection getDataStoreConnection() throws SQLException {
+		return EXT.getDataStoreConnection();
+	}
+
+	/**
+	 * Determines whether startup database-read failures should be tolerated.
+	 *
+	 * <p>This is limited to non-production bootstrap-style environments where
+	 * customer-level two-factor authentication has been pre-configured in JSON and
+	 * the configuration table may not yet exist.
+	 *
+	 * @param exception The SQL failure raised while reading TFA settings
+	 * @return {@code true} when startup should continue despite the failure
+	 */
+	@SuppressWarnings("static-method")
+	boolean shouldIgnoreStartupFailure(@SuppressWarnings("unused") SQLException exception) {
+		return (UtilImpl.ENVIRONMENT_IDENTIFIER != null) &&
+				(UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS != null) &&
+				(! UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS.isEmpty());
 	}
 	
 	/**

--- a/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
@@ -144,20 +144,21 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 	private static String buildStartupFailureMessage() {
 		boolean tfaCustomersConfigured = (UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS != null) &&
 				(! UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS.isEmpty());
-		return "Failure reading two-factor authentication customer configuration from database table " +
-				ADM_CONFIGURATION_TABLE_NAME +
-				". Troubleshooting: confirm table " +
-				ADM_CONFIGURATION_TABLE_NAME +
-				" exists in the configured datastore/schema; confirm schema synchronisation or migrations completed successfully before startup; " +
-				"check whether JSON property " +
-				TFA_CUSTOMERS_JSON_PATH +
-				" is configured. " +
-				TFA_CUSTOMERS_JSON_PATH +
-				" configured: " +
-				tfaCustomersConfigured +
-				". On a brand-new database, either create/bootstrap the admin configuration table before enabling TFA customers in JSON, or temporarily remove/empty " +
-				TFA_CUSTOMERS_JSON_PATH +
-				" until the admin configuration exists.";
+		StringBuilder message = new StringBuilder(512);
+		message.append("Failure reading two-factor authentication customer configuration from database table ");
+		message.append(ADM_CONFIGURATION_TABLE_NAME);
+		message.append(". Skyve reads this table during every application startup to preload customer TFA settings, even when ");
+		message.append(TFA_CUSTOMERS_JSON_PATH);
+		message.append(" is empty. Troubleshooting: confirm schema synchronisation or migrations completed successfully, confirm ");
+		message.append(ADM_CONFIGURATION_TABLE_NAME);
+		message.append(" exists in the configured datastore/schema, and check whether ");
+		message.append(TFA_CUSTOMERS_JSON_PATH);
+		message.append(" is configured in JSON. ");
+		message.append(TFA_CUSTOMERS_JSON_PATH);
+		message.append(" configured: ");
+		message.append(tfaCustomersConfigured);
+		message.append('.');
+		return message.toString();
 	}
 	
 	/**

--- a/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
@@ -4,13 +4,15 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.skyve.CORE;
 import org.skyve.EXT;
 import org.skyve.domain.messages.DomainException;
-import org.slf4j.Logger;
 import org.skyve.util.logging.SkyveLoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * Caches and serves customer-level two-factor-authentication configuration.
@@ -23,6 +25,7 @@ import org.skyve.util.logging.SkyveLoggerFactory;
  * reads and updates.
  */
 public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
+	private static final String ADM_CONFIGURATION_TABLE_NAME = "adm_configuration";
 	private static final Logger LOGGER = SkyveLoggerFactory.getLogger(TwoFactorAuthConfigurationSingleton.class);
 	private static TwoFactorAuthConfigurationSingleton instance = new TwoFactorAuthConfigurationSingleton();
 
@@ -156,10 +159,25 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 	 * @return {@code true} when startup should continue despite the failure
 	 */
 	@SuppressWarnings("static-method")
-	boolean shouldIgnoreStartupFailure(@SuppressWarnings("unused") SQLException exception) {
+	boolean shouldIgnoreStartupFailure(SQLException exception) {
 		return (UtilImpl.ENVIRONMENT_IDENTIFIER != null) &&
 				(UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS != null) &&
-				(! UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS.isEmpty());
+				(! UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS.isEmpty()) &&
+				isMissingConfigurationTableFailure(exception);
+	}
+
+	private static boolean isMissingConfigurationTableFailure(SQLException exception) {
+		for (SQLException current = exception; current != null; current = current.getNextException()) {
+			String state = current.getSQLState();
+			String message = current.getMessage();
+			boolean syntaxOrObjectState = (state != null) && state.startsWith("42");
+			boolean missingConfigurationTable = (message != null) &&
+					message.toLowerCase(Locale.ROOT).contains(ADM_CONFIGURATION_TABLE_NAME);
+			if (missingConfigurationTable && (syntaxOrObjectState || (current instanceof SQLSyntaxErrorException))) {
+				return true;
+			}
+		}
+		return false;
 	}
 	
 	/**

--- a/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
@@ -1,11 +1,10 @@
 package org.skyve.impl.util;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.SQLSyntaxErrorException;
-import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.skyve.CORE;
@@ -25,7 +24,8 @@ import org.slf4j.Logger;
  * reads and updates.
  */
 public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
-	private static final String ADM_CONFIGURATION_TABLE_NAME = "adm_configuration";
+	private static final String ADM_CONFIGURATION_TABLE_NAME = "ADM_Configuration";
+	private static final String[] TABLE_TYPES = new String[] {"TABLE"};
 	private static final Logger LOGGER = SkyveLoggerFactory.getLogger(TwoFactorAuthConfigurationSingleton.class);
 	private static TwoFactorAuthConfigurationSingleton instance = new TwoFactorAuthConfigurationSingleton();
 
@@ -110,8 +110,14 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 	@Override
 	public void startup() {
 		try (Connection c = getDataStoreConnection()) {
+			if (shouldSkipDatabaseConfigurationRead(c)) {
+				LOGGER.warn("Skipping TFA database configuration read during non-production bootstrap because {} does not exist.",
+								ADM_CONFIGURATION_TABLE_NAME);
+				return;
+			}
+
 			String query = "select twoFactorType, twofactorPushCodeTimeOutSeconds, twoFactorEmailSubject, twoFactorEmailBody, bizCustomer " +
-								"from ADM_Configuration " +
+								"from " + ADM_CONFIGURATION_TABLE_NAME + " " +
 								"where twoFactorType is not null and twofactorPushCodeTimeOutSeconds is not null";
 			try (PreparedStatement s = c.prepareStatement(query)) {
 				try (ResultSet rs = s.executeQuery()) {
@@ -130,10 +136,6 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 			}
 		}
 		catch (SQLException e) {
-			if (shouldIgnoreStartupFailure(e)) {
-				LOGGER.warn("Skipping TFA database configuration read during non-production bootstrap.", e);
-				return;
-			}
 			throw new DomainException("Failure reading customer configuration from database.", e);
 		}
 	}
@@ -144,37 +146,39 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 	 * @return An open datastore connection
 	 * @throws SQLException If the connection cannot be created
 	 */
+	@SuppressWarnings("static-method")
 	Connection getDataStoreConnection() throws SQLException {
 		return EXT.getDataStoreConnection();
 	}
 
 	/**
-	 * Determines whether startup database-read failures should be tolerated.
+	 * Determines whether the startup database read should be skipped.
 	 *
 	 * <p>This is limited to non-production bootstrap-style environments where
 	 * customer-level two-factor authentication has been pre-configured in JSON and
 	 * the configuration table may not yet exist.
 	 *
-	 * @param exception The SQL failure raised while reading TFA settings
-	 * @return {@code true} when startup should continue despite the failure
+	 * @param connection The open datastore connection
+	 * @return {@code true} when startup should continue without reading database-backed
+	 *         TFA settings
+	 * @throws SQLException If table metadata cannot be read
 	 */
-	@SuppressWarnings("static-method")
-	boolean shouldIgnoreStartupFailure(SQLException exception) {
+	private static boolean shouldSkipDatabaseConfigurationRead(Connection connection) throws SQLException {
 		return (UtilImpl.ENVIRONMENT_IDENTIFIER != null) &&
 				(UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS != null) &&
 				(! UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS.isEmpty()) &&
-				isMissingConfigurationTableFailure(exception);
+				(! configurationTableExists(connection));
 	}
 
-	private static boolean isMissingConfigurationTableFailure(SQLException exception) {
-		for (SQLException current = exception; current != null; current = current.getNextException()) {
-			String state = current.getSQLState();
-			String message = current.getMessage();
-			boolean syntaxOrObjectState = (state != null) && state.startsWith("42");
-			boolean missingConfigurationTable = (message != null) &&
-					message.toLowerCase(Locale.ROOT).contains(ADM_CONFIGURATION_TABLE_NAME);
-			if (missingConfigurationTable && (syntaxOrObjectState || (current instanceof SQLSyntaxErrorException))) {
-				return true;
+	private static boolean configurationTableExists(Connection connection) throws SQLException {
+		DatabaseMetaData metadata = connection.getMetaData();
+		String catalog = connection.getCatalog();
+		try (ResultSet tables = metadata.getTables(catalog, null, "%", TABLE_TYPES)) {
+			while (tables.next()) {
+				String tableName = tables.getString("TABLE_NAME");
+				if (ADM_CONFIGURATION_TABLE_NAME.equalsIgnoreCase(tableName)) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingleton.java
@@ -1,7 +1,6 @@
 package org.skyve.impl.util;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -10,8 +9,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.skyve.CORE;
 import org.skyve.EXT;
 import org.skyve.domain.messages.DomainException;
-import org.skyve.util.logging.SkyveLoggerFactory;
-import org.slf4j.Logger;
 
 /**
  * Caches and serves customer-level two-factor-authentication configuration.
@@ -25,8 +22,7 @@ import org.slf4j.Logger;
  */
 public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 	private static final String ADM_CONFIGURATION_TABLE_NAME = "ADM_Configuration";
-	private static final String[] TABLE_TYPES = new String[] {"TABLE"};
-	private static final Logger LOGGER = SkyveLoggerFactory.getLogger(TwoFactorAuthConfigurationSingleton.class);
+	private static final String TFA_CUSTOMERS_JSON_PATH = "account.tfaCustomers";
 	private static TwoFactorAuthConfigurationSingleton instance = new TwoFactorAuthConfigurationSingleton();
 
 	private final ConcurrentHashMap<String, TwoFactorAuthCustomerConfiguration> configuration = new ConcurrentHashMap<>();
@@ -110,12 +106,6 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 	@Override
 	public void startup() {
 		try (Connection c = getDataStoreConnection()) {
-			if (shouldSkipDatabaseConfigurationRead(c)) {
-				LOGGER.warn("Skipping TFA database configuration read during non-production bootstrap because {} does not exist.",
-								ADM_CONFIGURATION_TABLE_NAME);
-				return;
-			}
-
 			String query = "select twoFactorType, twofactorPushCodeTimeOutSeconds, twoFactorEmailSubject, twoFactorEmailBody, bizCustomer " +
 								"from " + ADM_CONFIGURATION_TABLE_NAME + " " +
 								"where twoFactorType is not null and twofactorPushCodeTimeOutSeconds is not null";
@@ -136,7 +126,7 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 			}
 		}
 		catch (SQLException e) {
-			throw new DomainException("Failure reading customer configuration from database.", e);
+			throw new DomainException(buildStartupFailureMessage(), e);
 		}
 	}
 
@@ -151,37 +141,23 @@ public class TwoFactorAuthConfigurationSingleton implements SystemObserver {
 		return EXT.getDataStoreConnection();
 	}
 
-	/**
-	 * Determines whether the startup database read should be skipped.
-	 *
-	 * <p>This is limited to non-production bootstrap-style environments where
-	 * customer-level two-factor authentication has been pre-configured in JSON and
-	 * the configuration table may not yet exist.
-	 *
-	 * @param connection The open datastore connection
-	 * @return {@code true} when startup should continue without reading database-backed
-	 *         TFA settings
-	 * @throws SQLException If table metadata cannot be read
-	 */
-	private static boolean shouldSkipDatabaseConfigurationRead(Connection connection) throws SQLException {
-		return (UtilImpl.ENVIRONMENT_IDENTIFIER != null) &&
-				(UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS != null) &&
-				(! UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS.isEmpty()) &&
-				(! configurationTableExists(connection));
-	}
-
-	private static boolean configurationTableExists(Connection connection) throws SQLException {
-		DatabaseMetaData metadata = connection.getMetaData();
-		String catalog = connection.getCatalog();
-		try (ResultSet tables = metadata.getTables(catalog, null, "%", TABLE_TYPES)) {
-			while (tables.next()) {
-				String tableName = tables.getString("TABLE_NAME");
-				if (ADM_CONFIGURATION_TABLE_NAME.equalsIgnoreCase(tableName)) {
-					return true;
-				}
-			}
-		}
-		return false;
+	private static String buildStartupFailureMessage() {
+		boolean tfaCustomersConfigured = (UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS != null) &&
+				(! UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS.isEmpty());
+		return "Failure reading two-factor authentication customer configuration from database table " +
+				ADM_CONFIGURATION_TABLE_NAME +
+				". Troubleshooting: confirm table " +
+				ADM_CONFIGURATION_TABLE_NAME +
+				" exists in the configured datastore/schema; confirm schema synchronisation or migrations completed successfully before startup; " +
+				"check whether JSON property " +
+				TFA_CUSTOMERS_JSON_PATH +
+				" is configured. " +
+				TFA_CUSTOMERS_JSON_PATH +
+				" configured: " +
+				tfaCustomersConfigured +
+				". On a brand-new database, either create/bootstrap the admin configuration table before enabling TFA customers in JSON, or temporarily remove/empty " +
+				TFA_CUSTOMERS_JSON_PATH +
+				" until the admin configuration exists.";
 	}
 	
 	/**

--- a/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
+++ b/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
@@ -2,9 +2,21 @@ package org.skyve.impl.util;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
 import java.util.HashSet;
@@ -14,7 +26,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.skyve.domain.messages.DomainException;
 
+@SuppressWarnings("static-method")
 class TwoFactorAuthConfigurationSingletonStartupTest {
+	private static final String TFA_CONFIGURATION_QUERY =
+			"select twoFactorType, twofactorPushCodeTimeOutSeconds, twoFactorEmailSubject, twoFactorEmailBody, bizCustomer " +
+					"from ADM_Configuration " +
+					"where twoFactorType is not null and twofactorPushCodeTimeOutSeconds is not null";
+
 	private String previousEnvironmentIdentifier = UtilImpl.ENVIRONMENT_IDENTIFIER;
 	private Set<String> previousTwoFactorAuthCustomers = UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS;
 
@@ -26,41 +44,75 @@ class TwoFactorAuthConfigurationSingletonStartupTest {
 	}
 
 	@Test
-	void startupSkipsDatabaseFailureForConfiguredCustomersInNonProductionBootstrap() throws SQLException {
+	void startupSkipsDatabaseReadWhenConfigurationTableIsMissingInNonProductionBootstrap() throws SQLException {
 		UtilImpl.ENVIRONMENT_IDENTIFIER = "development";
 		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
 
 		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
-		doThrow(new SQLSyntaxErrorException("ADM_Configuration does not exist"))
-				.when(singleton)
-				.getDataStoreConnection();
+		Connection connection = connectionWithConfigurationTable(false);
+		doReturn(connection).when(singleton).getDataStoreConnection();
 
 		assertDoesNotThrow(singleton::startup);
+		verify(connection, never()).prepareStatement(TFA_CONFIGURATION_QUERY);
 	}
 
 	@Test
-	void startupStillFailsForDatabaseFailureOutsideBootstrapScenario() throws SQLException {
+	void startupStillFailsForMissingConfigurationTableOutsideBootstrapScenario() throws SQLException {
 		UtilImpl.ENVIRONMENT_IDENTIFIER = null;
 		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
 
 		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
+		Connection connection = mock(Connection.class);
+		doReturn(connection).when(singleton).getDataStoreConnection();
 		doThrow(new SQLSyntaxErrorException("ADM_Configuration does not exist"))
-				.when(singleton)
-				.getDataStoreConnection();
+				.when(connection)
+				.prepareStatement(TFA_CONFIGURATION_QUERY);
 
 		assertThrows(DomainException.class, singleton::startup);
 	}
 
 	@Test
-	void startupStillFailsForUnrelatedSqlFailureInBootstrapScenario() throws SQLException {
+	void startupStillFailsForDatabaseReadFailureWhenConfigurationTableExistsInBootstrapScenario() throws SQLException {
 		UtilImpl.ENVIRONMENT_IDENTIFIER = "development";
 		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
 
 		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
+		Connection connection = connectionWithConfigurationTable(true);
+		doReturn(connection).when(singleton).getDataStoreConnection();
 		doThrow(new SQLException("Connection refused", "08001"))
-				.when(singleton)
-				.getDataStoreConnection();
+				.when(connection)
+				.prepareStatement(TFA_CONFIGURATION_QUERY);
 
 		assertThrows(DomainException.class, singleton::startup);
+	}
+
+	@Test
+	void startupStillFailsForMetadataFailureInBootstrapScenario() throws SQLException {
+		UtilImpl.ENVIRONMENT_IDENTIFIER = "development";
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
+
+		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
+		Connection connection = mock(Connection.class);
+		doReturn(connection).when(singleton).getDataStoreConnection();
+		when(connection.getMetaData()).thenThrow(new SQLException("Metadata unavailable"));
+
+		assertThrows(DomainException.class, singleton::startup);
+	}
+
+	private static Connection connectionWithConfigurationTable(boolean tableExists) throws SQLException {
+		Connection connection = mock(Connection.class);
+		DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+		ResultSet tables = mock(ResultSet.class);
+		when(connection.getMetaData()).thenReturn(metadata);
+		when(metadata.getTables(isNull(), isNull(), eq("%"), any(String[].class))).thenReturn(tables);
+		if (tableExists) {
+			when(tables.next()).thenReturn(true);
+			when(tables.getString("TABLE_NAME")).thenReturn("ADM_CONFIGURATION");
+			PreparedStatement statement = mock(PreparedStatement.class);
+			ResultSet results = mock(ResultSet.class);
+			when(connection.prepareStatement(TFA_CONFIGURATION_QUERY)).thenReturn(statement);
+			when(statement.executeQuery()).thenReturn(results);
+		}
+		return connection;
 	}
 }

--- a/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
+++ b/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
@@ -50,4 +50,17 @@ class TwoFactorAuthConfigurationSingletonStartupTest {
 
 		assertThrows(DomainException.class, singleton::startup);
 	}
+
+	@Test
+	void startupStillFailsForUnrelatedSqlFailureInBootstrapScenario() throws SQLException {
+		UtilImpl.ENVIRONMENT_IDENTIFIER = "development";
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
+
+		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
+		doThrow(new SQLException("Connection refused", "08001"))
+				.when(singleton)
+				.getDataStoreConnection();
+
+		assertThrows(DomainException.class, singleton::startup);
+	}
 }

--- a/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
+++ b/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
@@ -1,22 +1,13 @@
 package org.skyve.impl.util;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
 import java.util.HashSet;
@@ -44,21 +35,8 @@ class TwoFactorAuthConfigurationSingletonStartupTest {
 	}
 
 	@Test
-	void startupSkipsDatabaseReadWhenConfigurationTableIsMissingInNonProductionBootstrap() throws SQLException {
+	void startupFailureMessageIdentifiesConfigurationTableAndConfiguredJsonTfaCustomers() throws SQLException {
 		UtilImpl.ENVIRONMENT_IDENTIFIER = "development";
-		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
-
-		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
-		Connection connection = connectionWithConfigurationTable(false);
-		doReturn(connection).when(singleton).getDataStoreConnection();
-
-		assertDoesNotThrow(singleton::startup);
-		verify(connection, never()).prepareStatement(TFA_CONFIGURATION_QUERY);
-	}
-
-	@Test
-	void startupStillFailsForMissingConfigurationTableOutsideBootstrapScenario() throws SQLException {
-		UtilImpl.ENVIRONMENT_IDENTIFIER = null;
 		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
 
 		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
@@ -68,51 +46,29 @@ class TwoFactorAuthConfigurationSingletonStartupTest {
 				.when(connection)
 				.prepareStatement(TFA_CONFIGURATION_QUERY);
 
-		assertThrows(DomainException.class, singleton::startup);
+		DomainException exception = assertThrows(DomainException.class, singleton::startup);
+		String message = exception.getMessage();
+
+		assertTrue(message.contains("ADM_Configuration"));
+		assertTrue(message.contains("schema synchronisation"));
+		assertTrue(message.contains("account.tfaCustomers configured: true"));
+		assertTrue(message.contains("brand-new database"));
 	}
 
 	@Test
-	void startupStillFailsForDatabaseReadFailureWhenConfigurationTableExistsInBootstrapScenario() throws SQLException {
+	void startupFailureMessageReportsWhenJsonTfaCustomersAreNotConfigured() throws SQLException {
 		UtilImpl.ENVIRONMENT_IDENTIFIER = "development";
-		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>();
 
 		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
-		Connection connection = connectionWithConfigurationTable(true);
+		Connection connection = mock(Connection.class);
 		doReturn(connection).when(singleton).getDataStoreConnection();
-		doThrow(new SQLException("Connection refused", "08001"))
+		doThrow(new SQLSyntaxErrorException("ADM_Configuration does not exist"))
 				.when(connection)
 				.prepareStatement(TFA_CONFIGURATION_QUERY);
 
-		assertThrows(DomainException.class, singleton::startup);
-	}
+		DomainException exception = assertThrows(DomainException.class, singleton::startup);
 
-	@Test
-	void startupStillFailsForMetadataFailureInBootstrapScenario() throws SQLException {
-		UtilImpl.ENVIRONMENT_IDENTIFIER = "development";
-		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
-
-		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
-		Connection connection = mock(Connection.class);
-		doReturn(connection).when(singleton).getDataStoreConnection();
-		when(connection.getMetaData()).thenThrow(new SQLException("Metadata unavailable"));
-
-		assertThrows(DomainException.class, singleton::startup);
-	}
-
-	private static Connection connectionWithConfigurationTable(boolean tableExists) throws SQLException {
-		Connection connection = mock(Connection.class);
-		DatabaseMetaData metadata = mock(DatabaseMetaData.class);
-		ResultSet tables = mock(ResultSet.class);
-		when(connection.getMetaData()).thenReturn(metadata);
-		when(metadata.getTables(isNull(), isNull(), eq("%"), any(String[].class))).thenReturn(tables);
-		if (tableExists) {
-			when(tables.next()).thenReturn(true);
-			when(tables.getString("TABLE_NAME")).thenReturn("ADM_CONFIGURATION");
-			PreparedStatement statement = mock(PreparedStatement.class);
-			ResultSet results = mock(ResultSet.class);
-			when(connection.prepareStatement(TFA_CONFIGURATION_QUERY)).thenReturn(statement);
-			when(statement.executeQuery()).thenReturn(results);
-		}
-		return connection;
+		assertTrue(exception.getMessage().contains("account.tfaCustomers configured: false"));
 	}
 }

--- a/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
+++ b/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
@@ -51,8 +51,9 @@ class TwoFactorAuthConfigurationSingletonStartupTest {
 
 		assertTrue(message.contains("ADM_Configuration"));
 		assertTrue(message.contains("schema synchronisation"));
+		assertTrue(message.contains("every application startup"));
+		assertTrue(message.contains("even when account.tfaCustomers is empty"));
 		assertTrue(message.contains("account.tfaCustomers configured: true"));
-		assertTrue(message.contains("brand-new database"));
 	}
 
 	@Test

--- a/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
+++ b/skyve-ext/src/test/java/org/skyve/impl/util/TwoFactorAuthConfigurationSingletonStartupTest.java
@@ -1,0 +1,53 @@
+package org.skyve.impl.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.skyve.domain.messages.DomainException;
+
+class TwoFactorAuthConfigurationSingletonStartupTest {
+	private String previousEnvironmentIdentifier = UtilImpl.ENVIRONMENT_IDENTIFIER;
+	private Set<String> previousTwoFactorAuthCustomers = UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS;
+
+	@AfterEach
+	void restoreUtilSettings() {
+		UtilImpl.ENVIRONMENT_IDENTIFIER = previousEnvironmentIdentifier;
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = previousTwoFactorAuthCustomers;
+		TwoFactorAuthConfigurationSingleton.getInstance().shutdown();
+	}
+
+	@Test
+	void startupSkipsDatabaseFailureForConfiguredCustomersInNonProductionBootstrap() throws SQLException {
+		UtilImpl.ENVIRONMENT_IDENTIFIER = "development";
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
+
+		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
+		doThrow(new SQLSyntaxErrorException("ADM_Configuration does not exist"))
+				.when(singleton)
+				.getDataStoreConnection();
+
+		assertDoesNotThrow(singleton::startup);
+	}
+
+	@Test
+	void startupStillFailsForDatabaseFailureOutsideBootstrapScenario() throws SQLException {
+		UtilImpl.ENVIRONMENT_IDENTIFIER = null;
+		UtilImpl.TWO_FACTOR_AUTH_CUSTOMERS = new HashSet<>(Set.of("acme"));
+
+		TwoFactorAuthConfigurationSingleton singleton = spy(TwoFactorAuthConfigurationSingleton.getInstance());
+		doThrow(new SQLSyntaxErrorException("ADM_Configuration does not exist"))
+				.when(singleton)
+				.getDataStoreConnection();
+
+		assertThrows(DomainException.class, singleton::startup);
+	}
+}


### PR DESCRIPTION
- log instead of throwing an exception when the Configuration table doesn't exist
- add unit tests