### PR TITLE
Update device.jsp to handle missing or invalid ua parameter

### DIFF
--- a/skyve-war/src/main/webapp/device.jsp
+++ b/skyve-war/src/main/webapp/device.jsp
@@ -8,7 +8,17 @@
 <%! static final Logger logger = LoggerFactory.getLogger("org.skyve.jsp.device"); %>
 
 <%
-	UserAgentType type = UserAgentType.valueOf(request.getParameter("ua"));
+	String userAgent = request.getParameter("ua");
+	UserAgentType type = UserAgentType.other;
+	if (userAgent == null) {
+		logger.warn("Missing ua parameter for /device.jsp, defaulting to other.");
+	} else {
+		try {
+			type = UserAgentType.valueOf(userAgent);
+		} catch (IllegalArgumentException e) {
+			logger.warn("Invalid ua parameter '{}' for /device.jsp, defaulting to other.", userAgent);
+		}
+	}
 	request.setAttribute(AbstractWebContext.USER_AGENT_TYPE_KEY, type);
 	request.setAttribute(AbstractWebContext.EMULATED_USER_AGENT_TYPE_KEY, Boolean.TRUE);
 	


### PR DESCRIPTION
Safely fallback to `other` when the ua patameter is missing or invalid.