### PR TITLE
Harden Audit comparison editor against un-coercible audited values

### DIFF
--- a/skyve-war/src/main/java/modules/admin/Audit/models/AuditComparisonModel.java
+++ b/skyve-war/src/main/java/modules/admin/Audit/models/AuditComparisonModel.java
@@ -240,11 +240,19 @@ public class AuditComparisonModel extends ComparisonModel<Audit, Audit> {
 					converter = enumeration.getConverter();
 				}
 
-				if (value instanceof String string) {
-					value = BindUtil.fromSerialised(converter, type, string);
+				try {
+					if (value instanceof String string) {
+						value = BindUtil.fromSerialised(converter, type, string);
+					}
+					else {
+						value = BindUtil.convert(type, value);
+					}
 				}
-				else {
-					value = BindUtil.convert(type, value);
+				catch (@SuppressWarnings("unused") Exception e) {
+					// The audited value can no longer be coerced to the attribute's type
+					// (e.g. a removed/renamed enum constant). Fall back to the raw audited string.
+					property.setTitle(name);
+					property.setWidget(new TextField());
 				}
 			}
 
@@ -287,11 +295,18 @@ public class AuditComparisonModel extends ComparisonModel<Audit, Audit> {
 						converter = enumeration.getConverter();
 					}
 
-					if (value instanceof String string) {
-						value = BindUtil.fromSerialised(converter, type, string);
+					try {
+						if (value instanceof String string) {
+							value = BindUtil.fromSerialised(converter, type, string);
+						}
+						else {
+							value = BindUtil.convert(type, value);
+						}
 					}
-					else {
-						value = BindUtil.convert(type, value);
+					catch (@SuppressWarnings("unused") Exception e) {
+						// The audited value can no longer be coerced to the attribute's type
+						// (e.g. a removed/renamed enum constant). Fall back to the raw audited string.
+						property.setWidget(new TextField());
 					}
 				}
 

--- a/skyve-war/src/main/java/modules/admin/Audit/models/AuditComparisonModel.java
+++ b/skyve-war/src/main/java/modules/admin/Audit/models/AuditComparisonModel.java
@@ -250,9 +250,12 @@ public class AuditComparisonModel extends ComparisonModel<Audit, Audit> {
 				}
 				catch (@SuppressWarnings("unused") Exception e) {
 					// The audited value can no longer be coerced to the attribute's type
-					// (e.g. a removed/renamed enum constant). Fall back to the raw audited string.
-					property.setTitle(name);
+					// (e.g. a removed/renamed enum constant). Keep the attribute's localised
+					// title but degrade to a text widget showing the raw audited string.
 					property.setWidget(new TextField());
+					if (value != null) {
+						value = value.toString();
+					}
 				}
 			}
 
@@ -305,8 +308,12 @@ public class AuditComparisonModel extends ComparisonModel<Audit, Audit> {
 					}
 					catch (@SuppressWarnings("unused") Exception e) {
 						// The audited value can no longer be coerced to the attribute's type
-						// (e.g. a removed/renamed enum constant). Fall back to the raw audited string.
+						// (e.g. a removed/renamed enum constant). Degrade to a text widget
+						// showing the raw audited string.
 						property.setWidget(new TextField());
+						if (value != null) {
+							value = value.toString();
+						}
 					}
 				}
 

--- a/skyve-war/src/test/java/modules/admin/Audit/models/AuditComparisonModelH2Test.java
+++ b/skyve-war/src/test/java/modules/admin/Audit/models/AuditComparisonModelH2Test.java
@@ -187,7 +187,9 @@ class AuditComparisonModelH2Test extends AbstractH2Test {
 
 		ComparisonProperty property = root.getProperties().get(0);
 		assertThat(property.getName(), is("wizardState"));
-		assertThat(property.getTitle(), is("wizardState"));
+		// The attribute still exists, so its localised title is retained; only the
+		// widget/value degrades because the value can no longer be coerced.
+		assertThat(property.getTitle(), is("Wizard State"));
 		assertThat(property.getWidget(), instanceOf(TextField.class));
 		assertThat(property.getNewValue(), is("obsoleteState"));
 	}

--- a/skyve-war/src/test/java/modules/admin/Audit/models/AuditComparisonModelH2Test.java
+++ b/skyve-war/src/test/java/modules/admin/Audit/models/AuditComparisonModelH2Test.java
@@ -175,6 +175,39 @@ class AuditComparisonModelH2Test extends AbstractH2Test {
 		assertThat(child.getProperties().get(0).getName(), is(Contact.namePropertyName));
 	}
 
+	@Test
+	@SuppressWarnings("static-method")
+	void uncoercibleEnumValueInSourceDegradesToTextField() throws Exception {
+		AuditComparisonModel model = new AuditComparisonModel();
+		Audit audit = metadataAudit(Operation.insert,
+				"{\"\":" + objectWithoutBizKey("user-id", "\"wizardState\":\"obsoleteState\"") + "}",
+				null);
+
+		ComparisonComposite root = model.getComparisonComposite(audit);
+
+		ComparisonProperty property = root.getProperties().get(0);
+		assertThat(property.getName(), is("wizardState"));
+		assertThat(property.getTitle(), is("wizardState"));
+		assertThat(property.getWidget(), instanceOf(TextField.class));
+		assertThat(property.getNewValue(), is("obsoleteState"));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void uncoercibleEnumValueInComparisonDegradesToTextField() throws Exception {
+		AuditComparisonModel model = new AuditComparisonModel();
+		Audit audit = metadataAudit(Operation.update,
+				"{\"\":" + objectWithoutBizKey("user-id", "\"wizardState\":\"createContact\"") + "}",
+				"{\"\":" + objectWithoutBizKey("user-id", "\"wizardState\":\"obsoleteState\"") + "}");
+
+		ComparisonComposite root = model.getComparisonComposite(audit);
+
+		ComparisonProperty property = root.getProperties().get(0);
+		assertThat(property.getName(), is("wizardState"));
+		assertThat(property.getWidget(), instanceOf(TextField.class));
+		assertThat(property.getOldValue(), is("obsoleteState"));
+	}
+
 	private static Audit audit(Operation operation, String sourceDetail, String comparisonDetail) {
 		Audit selected = Audit.newInstance();
 		Audit source = version(operation, sourceDetail);


### PR DESCRIPTION
## Cause

A stale enumeration value in an audit record crashed the entire Audit comparison view with:

```
MetaDataException: Could not populate the comparison editor
```

When building the comparison, each audited value (stored as a String) is coerced back to its attribute's type. For a static `Enumeration` whose constant has since been removed or renamed, `Enum.valueOf(...)` throws `IllegalArgumentException`, which propagated out of `getComparisonComposite` — so a single obsolete value made the whole editor unviewable.

This is a general latent bug: any enum constant ever removed or renamed makes every historical audit holding that value impossible to open.

## Fix

Wrap the value coercion in `addProperties(...)` and `updateNode(...)` so an un-coercible value degrades gracefully — the attribute's localised title is kept, the widget falls back to a `TextField`, and the raw audited string is shown. This mirrors the file's existing fallback for attributes that no longer exist.

## Notes

- Catching `Exception` is deliberate: any value that won't coerce should degrade to text, not just today's `IllegalArgumentException`.
- Dynamic enums are unaffected (they use `String` and never hit `Enum.valueOf`).
- No API, schema, or data-migration changes.

## Tests

Added two `AuditComparisonModelH2Test` cases (single-version and compare paths) using a stale `wizardState` value, asserting the obsolete value renders as plain text while the title and widget degrade correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)