### PR TITLE
Fix "serialize SessionImpl while connected" for list-grid edit views

### DIFF
--- a/skyve-web/src/main/java/org/skyve/impl/web/faces/SkyveFacesPhaseListener.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/faces/SkyveFacesPhaseListener.java
@@ -228,8 +228,17 @@ public class SkyveFacesPhaseListener implements PhaseListener {
 
 						// Cache the conversation
 						Severity maximumSeverity = event.getFacesContext().getMaximumSeverity();
-						if ((maximumSeverity == null) || 
+						if ((maximumSeverity == null) ||
 								(maximumSeverity.getOrdinal() < FacesMessage.SEVERITY_ERROR.getOrdinal())) {
+							// Commit (which ends the transaction and releases the JDBC connection) BEFORE
+							// serialising the conversation, so the Hibernate session is disconnected and
+							// serialises cleanly. A list grid that runs a query during the JSF RENDER phase
+							// otherwise leaves the session connected, causing "Cannot serialize SessionImpl
+							// while connected" and a corrupted conversation. Pass false so the EntityManager
+							// stays open for the cached conversation to be restored; the finally block below
+							// performs the final commit(true) which closes it. This is a reorder of the commit
+							// that already happens every request, not an additional commit.
+							AbstractPersistence.get().commit(false);
 							StateUtil.cacheConversation(webContext);
 						}
 						// Dehydrate the view


### PR DESCRIPTION
## Fix "Cannot serialize SessionImpl while connected" for edit views containing a query-backed list grid

### Summary
An edit view (`a=e`) whose view embeds a query/model-backed `<listGrid>` fails to cache its conversation with `Cannot serialize SessionImpl while connected`, corrupting the conversation and breaking the next interaction. This reorders the per-request commit so the Hibernate session is disconnected before the conversation is serialised.

### Environment
Observed on Skyve `10.0.0-SNAPSHOT`, Hibernate `5.6.15.Final` (RESOURCE_LOCAL / non-JTA datasource), JSF/PrimeFaces, Java 21.

### Symptom
```
ERROR org.skyve.impl.web.faces.SkyveFacesFilter - request failed for /external/edit.xhtml
  jakarta.servlet.ServletException: Cannot serialize SessionImpl [...] while connected
Caused by: java.lang.IllegalStateException: Cannot serialize SessionImpl [...] while connected
    at org.hibernate.internal.AbstractSharedSessionContract.writeObject(...)
    at org.hibernate.internal.util.SerializationHelper.serialize(...)
    at org.skyve.impl.cache.StateUtil.cacheConversation(StateUtil.java:61)
    at org.skyve.impl.web.faces.SkyveFacesPhaseListener.afterResponseRendered(...)
```
The page renders once, but the conversation is never cached, so the next conversation action (e.g. a server-side action or zoom) fails with `… "this.em" is null`.

### Reproduction
A singular/non-persistent document opened as an **edit view** whose view contains a `<listGrid query="…">` (or `model="…"`) — i.e. the grid executes a **DB query during render**, not an in-memory child collection. It does **not** reproduce on detail views with no list grid, or on grids bound to an already-loaded parent child-collection.

### Root cause
- `AbstractWebContext.conversation` (an `AbstractPersistence`) and `AbstractHibernatePersistence.em` (the Hibernate `Session`) are **non-transient**, so the session is serialised with the cached conversation by design — passivated and restored next request (`getCachedConversation` → `setForThread()`), which Hibernate only permits when the session is **disconnected**.
- In `SkyveFacesPhaseListener.afterResponseRendered`, `StateUtil.cacheConversation(webContext)` runs in the `try` block, and `persistence.commit(true)` (which commits **and** disconnects) runs in the `finally` — i.e. caching happens **before** the disconnect.
- For most views the connection is already released after the command-phase statements, so the session is serialisable at cache time. A `<listGrid>` query runs during **RENDER_RESPONSE**, immediately before `afterResponseRendered`, reconnecting the session — so `cacheConversation` serialises a *connected* session and `SessionImpl.writeObject` throws.

### The fix
Commit (which releases the connection) just before serialising, passing `false` so the `EntityManager` stays open for restoration:

```diff
 if ((maximumSeverity == null) ||
         (maximumSeverity.getOrdinal() < FacesMessage.SEVERITY_ERROR.getOrdinal())) {
+    // Commit (ends the transaction, releasing the JDBC connection) so the Hibernate session is
+    // disconnected and serialises cleanly; a list grid querying during render otherwise leaves
+    // it connected. false keeps the EntityManager open for the cached conversation to be
+    // restored; the finally block's commit(true) closes it. Reorder of an existing commit.
+    AbstractPersistence.get().commit(false);
     StateUtil.cacheConversation(webContext);
 }
```
`commit(false)` ends the transaction (releasing the connection → session serialisable) and keeps `em` open. The unchanged `finally` `commit(true)` then finds no active transaction (skips the commit) and just closes persistence. This only **reorders** the commit that already runs every request.

### Alternatives ruled out
- **Make `em`/`conversation` transient** — breaks restore: the deserialised persistence is reattached and reused (`setForThread()` → `begin()`), so a null `em` NPEs.
- **`Session.disconnect()`** — not available on `org.hibernate.Session` in 5.6.x; `commit` is the public disconnect path.
- **App-level workarounds** (evict / `session.clear()`, `continueConversation="false"`, replacing the bound bean) — none work, because the connected session is reachable via the persistence's non-transient `em`, independent of the bean graph.

### Testing
- **`skyve-web` test suite: 2838 tests, 0 failures** with the change (the module the fix lives in; `skyve-core`/`skyve-ext` are upstream dependencies and unaffected).
- **Verified at application level**: reproduced the failure on a tenant-portal app (two edit views embedding query-backed `<listGrid>`s — one per render logged `Cannot serialize SessionImpl while connected`), then confirmed end-to-end after the fix: zero serialize errors across both views, and the previously-broken submit-action-after-render flow succeeds. Detail views and other flows unaffected.
- **No unit test added — and why.** The fix is an ordering change inside the private static `afterResponseRendered`, which depends on three statics (`FacesUtil.getNamed`, `AbstractPersistence.get`, `StateUtil.cacheConversation`). Guarding the ordering needs static mocking, which isn't available in `skyve-web`: the module uses `mockito-core` (subclass mock maker), and the only static-mock test, `LoginServletTest`, is `@Disabled("Until byte buddy can be uplifted to allow mockito-inline lib to work")` — so `mockStatic` fails with `SubclassByteBuddyMockMaker does not support the creation of static mocks`. The existing `SkyveFacesPhaseListenerTest` therefore only covers the `RESTORE_VIEW`/`UPDATE_MODEL_VALUES` paths. The realistic coverage is an integration/SAIL test (à la `skyve-war`'s `PrimeFacesConsolidatedTest`) driving the full faces lifecycle against an edit view with a query/model-backed `<listGrid>`; happy to add one, or to enable `mockito-inline` for `skyve-web`, if either is in scope.

### Compatibility / risk
Low — the request already commits unconditionally in the same `finally`; this just moves the transaction-commit a few statements earlier (render is already complete; only `cacheConversation` and `view.dehydrate()` run in between). No API change.

### Questions for maintainers
1. Is committing before `cacheConversation` (vs in the `finally`) safe in all flows, or is there a case where the conversation must be cached in a pre-commit state, or where `dehydrate()`/post-render work needs an open transaction?
2. Would you prefer the disconnect inside `StateUtil.cacheConversation` (ensure serialisable just-in-time) or a dedicated `AbstractPersistence` method, rather than reordering here?
3. Should the framework avoid serialising a live session at all (e.g. transient `em` + re-establish on restore)?