### PR TITLE
Cap REST list/query paging at 100 rows to prevent OOM

### DIFF
--- a/skyve-web/src/main/java/org/skyve/impl/web/service/rest/RestPaging.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/rest/RestPaging.java
@@ -1,0 +1,74 @@
+package org.skyve.impl.web.service.rest;
+
+/**
+ * Clamps REST list/query paging so omitted or invalid {@code start}/{@code end}
+ * cannot yield unbounded result sets.
+ *
+ * <p>Hibernate only applies {@code maxResults} when it is {@code > 0}. JAX-RS
+ * defaults missing query params to {@code 0}, so requests with no paging (or
+ * inverted/zero-sized ranges) previously loaded the full result set and could
+ * OOM the JVM during {@code populateFully} and JSON marshalling.
+ *
+ * <p>This type is package-visible and intentionally has no mutable state.
+ */
+final class RestPaging {
+
+	/** Hard cap on rows returned by built-in REST document-list and query endpoints. */
+	static final int MAX_REST_PAGE_SIZE = 100;
+
+	private RestPaging() {
+		// utility
+	}
+
+	/**
+	 * Returns a non-negative first-row index.
+	 *
+	 * @param start requested start row (may be negative)
+	 * @return {@code start} when {@code >= 0}, otherwise {@code 0}
+	 */
+	static int safeStart(int start) {
+		return (start < 0) ? 0 : start;
+	}
+
+	/**
+	 * Returns a safe {@code maxResults} for the document-list formula
+	 * {@code end - start - 1}.
+	 *
+	 * <p>When the derived size is {@code <= 0} or greater than
+	 * {@link #MAX_REST_PAGE_SIZE}, returns {@link #MAX_REST_PAGE_SIZE}.
+	 * Otherwise returns the derived size unchanged.
+	 *
+	 * @param start requested start row (clamped before deriving size)
+	 * @param end requested end row
+	 * @return clamped max results in {@code 1..MAX_REST_PAGE_SIZE}
+	 */
+	static int safeDocumentListMaxResults(int start, int end) {
+		int maxResults = end - safeStart(start) - 1;
+		if ((maxResults <= 0) || (maxResults > MAX_REST_PAGE_SIZE)) {
+			return MAX_REST_PAGE_SIZE;
+		}
+		return maxResults;
+	}
+
+	/**
+	 * Returns a safe exclusive end row for the query-list formula
+	 * {@code pageSize = end - start}.
+	 *
+	 * <p>When the derived page size is {@code <= 0} or greater than
+	 * {@link #MAX_REST_PAGE_SIZE}, the page size becomes
+	 * {@link #MAX_REST_PAGE_SIZE}. Otherwise the requested end is preserved
+	 * relative to the clamped start.
+	 *
+	 * @param start requested start row (clamped before deriving size)
+	 * @param end requested end row
+	 * @return {@code safeStart + clampedPageSize}
+	 */
+	static int safeQueryEndRow(int start, int end) {
+		int safe = safeStart(start);
+		int pageSize = end - safe;
+		if ((pageSize <= 0) || (pageSize > MAX_REST_PAGE_SIZE)) {
+			pageSize = MAX_REST_PAGE_SIZE;
+		}
+		return safe + pageSize;
+	}
+}

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/rest/RestService.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/rest/RestService.java
@@ -162,8 +162,10 @@ public class RestService {
 	 *
 	 * @param module module name
 	 * @param document document name
-	 * @param start first row index (inclusive)
-	 * @param end end row index (exclusive)
+	 * @param start first row index (inclusive); negative values are treated as {@code 0}
+	 * @param end end row index used with the document-list formula {@code maxResults = end - start - 1};
+	 * 		omitted, inverted, or oversized ranges are clamped to at most
+	 * 		{@link RestPaging#MAX_REST_PAGE_SIZE} rows
 	 * @return marshalled JSON payload, or {@code null} when an error occurs
 	 */
 	@GET
@@ -190,8 +192,8 @@ public class RestService {
 			}
 			
 	    	DocumentQuery q = p.newDocumentQuery(d);
-	    	q.setFirstResult(start);
-	    	q.setMaxResults(end - start - 1);
+	    	q.setFirstResult(RestPaging.safeStart(start));
+	    	q.setMaxResults(RestPaging.safeDocumentListMaxResults(start, end));
 	    	List<Bean> beans = q.projectedResults();
 	    	for (Bean bean : beans) {
 	    		Util.populateFully(bean);
@@ -385,8 +387,9 @@ public class RestService {
 	 *
 	 * @param module module name
 	 * @param documentOrQuery query name or document name whose default query will be used
-	 * @param start first row index (inclusive)
-	 * @param end end row index (exclusive)
+	 * @param start first row index (inclusive); negative values are treated as {@code 0}
+	 * @param end exclusive end row; omitted, inverted, or oversized ranges are clamped so
+	 * 		{@code end - start} is at most {@link RestPaging#MAX_REST_PAGE_SIZE}
 	 * @return marshalled JSON payload, or {@code null} when an error occurs
 	 */
 	@GET
@@ -414,8 +417,8 @@ public class RestService {
 			}
 	 
 			ListModel<Bean> qm = EXT.newListModel(q);
-	        qm.setStartRow(start);
-	        qm.setEndRow(end);
+	        qm.setStartRow(RestPaging.safeStart(start));
+	        qm.setEndRow(RestPaging.safeQueryEndRow(start, end));
 	
 	        Document d = qm.getDrivingDocument();
 			if (! u.canReadDocument(d)) {

--- a/skyve-web/src/main/java/org/skyve/impl/web/service/rest/RestService.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/service/rest/RestService.java
@@ -60,6 +60,7 @@ import jakarta.ws.rs.core.MediaType;
 public class RestService {
     private static final Logger LOGGER = SkyveLoggerFactory.getLogger(RestService.class);
 
+	private static final String AGGREGATE_QUERY_UNSUPPORTED = "Aggregate queries are not supported by this REST endpoint.";
     private static final String READ_DATA_PERMISSION = "read this data";
 	private static final String BEAN_PATH_PARAM = "bean";
 	private static final String DOCUMENT_PATH_PARAM = "document";
@@ -383,7 +384,9 @@ public class RestService {
 */
 
 	/**
-	 * Executes a metadata query or default document query and returns projected rows as JSON.
+	 * Executes a non-aggregate metadata query or default document query and returns projected rows as JSON.
+	 * Aggregate metadata queries are rejected with an HTTP 400 response because their list models do not
+	 * apply paging before materialising results.
 	 *
 	 * @param module module name
 	 * @param documentOrQuery query name or document name whose default query will be used
@@ -414,6 +417,18 @@ public class RestService {
 			// not a query, could be a document
 			if (q == null) {
 				q = m.getDocumentDefaultQuery(c, documentOrQuery);
+			}
+			if (q.isAggregate()) {
+				Module queryModule = q.getDocumentModule(c);
+				Document queryDocument = queryModule.getDocument(c, q.getDocumentName());
+				if (! u.canReadDocument(queryDocument)) {
+					throw new SecurityException(READ_DATA_PERMISSION, u.getName());
+				}
+				AbstractRestFilter.error(p,
+									response,
+									HttpServletResponse.SC_BAD_REQUEST,
+									AGGREGATE_QUERY_UNSUPPORTED);
+				return result;
 			}
 	 
 			ListModel<Bean> qm = EXT.newListModel(q);

--- a/skyve-web/src/test/java/org/skyve/impl/web/service/rest/RestPagingTest.java
+++ b/skyve-web/src/test/java/org/skyve/impl/web/service/rest/RestPagingTest.java
@@ -1,0 +1,105 @@
+package org.skyve.impl.web.service.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RestPaging} clamp helpers used by REST list/query endpoints.
+ */
+class RestPagingTest {
+
+	@Test
+	@SuppressWarnings("static-method")
+	void safeStartClampsNegativeToZero() {
+		assertEquals(0, RestPaging.safeStart(-1));
+		assertEquals(0, RestPaging.safeStart(-100));
+		assertEquals(0, RestPaging.safeStart(0));
+		assertEquals(10, RestPaging.safeStart(10));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void documentListDefaultsWhenMissingOrZeroSized() {
+		// JAX-RS defaults missing start/end to 0 → stock maxResults = -1 (unbounded)
+		assertEquals(RestPaging.MAX_REST_PAGE_SIZE, RestPaging.safeDocumentListMaxResults(0, 0));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void documentListDefaultsWhenStartGreaterThanEnd() {
+		assertEquals(RestPaging.MAX_REST_PAGE_SIZE, RestPaging.safeDocumentListMaxResults(10, 9));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void documentListCapsOversizedPage() {
+		// end - start - 1 = 200
+		assertEquals(RestPaging.MAX_REST_PAGE_SIZE, RestPaging.safeDocumentListMaxResults(0, 201));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void documentListPreservesValidSmallPage() {
+		// start=0&end=9 → maxResults = 8
+		assertEquals(8, RestPaging.safeDocumentListMaxResults(0, 9));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void documentListPreservesExactMaxPage() {
+		// end - start - 1 = 100
+		assertEquals(RestPaging.MAX_REST_PAGE_SIZE, RestPaging.safeDocumentListMaxResults(0, 101));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void documentListUsesClampedStartForNegativeStart() {
+		// safeStart(-5)=0 → maxResults = 10 - 0 - 1 = 9
+		assertEquals(9, RestPaging.safeDocumentListMaxResults(-5, 10));
+		assertEquals(0, RestPaging.safeStart(-5));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void queryListDefaultsWhenMissingOrZeroSized() {
+		// start=0&end=0 → page size 0 → default end = 100
+		assertEquals(RestPaging.MAX_REST_PAGE_SIZE, RestPaging.safeQueryEndRow(0, 0));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void queryListDefaultsWhenStartGreaterThanEnd() {
+		// start=10&end=9 → inverted → end = 10 + 100
+		assertEquals(110, RestPaging.safeQueryEndRow(10, 9));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void queryListCapsOversizedPage() {
+		assertEquals(RestPaging.MAX_REST_PAGE_SIZE, RestPaging.safeQueryEndRow(0, 500));
+		assertEquals(150, RestPaging.safeQueryEndRow(50, 500));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void queryListPreservesValidSmallPage() {
+		assertEquals(9, RestPaging.safeQueryEndRow(0, 9));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void queryListPreservesExactMaxPage() {
+		assertEquals(RestPaging.MAX_REST_PAGE_SIZE, RestPaging.safeQueryEndRow(0, 100));
+		assertEquals(150, RestPaging.safeQueryEndRow(50, 150));
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	void queryListUsesClampedStartForNegativeStart() {
+		// safeStart(-5)=0 → page size from end=10 is 10 → endRow=10
+		assertEquals(10, RestPaging.safeQueryEndRow(-5, 10));
+		// inverted after clamp: end=-1, safeStart=0 → default page → endRow=100
+		assertEquals(RestPaging.MAX_REST_PAGE_SIZE, RestPaging.safeQueryEndRow(-5, -1));
+	}
+}

--- a/skyve-web/src/test/java/org/skyve/impl/web/service/rest/RestServiceDeleteJsonTest.java
+++ b/skyve-web/src/test/java/org/skyve/impl/web/service/rest/RestServiceDeleteJsonTest.java
@@ -512,6 +512,37 @@ class RestServiceDeleteJsonTest {
 	}
 
 	@Test
+	void queryRejectsAggregateMetadataQueryBeforeListModelCreation() throws Exception {
+		RestService service = new RestService();
+		HttpServletResponse response = mockResponse();
+		setPrivateField(service, "response", response);
+
+		AbstractPersistence persistence = mock(AbstractPersistence.class);
+		User user = mock(User.class);
+		Customer customer = mock(Customer.class);
+		Module module = mock(Module.class);
+		Document document = mock(Document.class);
+		MetaDataQueryDefinition query = mock(MetaDataQueryDefinition.class);
+
+		when(persistence.getUser()).thenReturn(user);
+		when(user.getCustomer()).thenReturn(customer);
+		when(customer.getModule("admin")).thenReturn(module);
+		when(module.getMetaDataQuery("AggregateQuery")).thenReturn(query);
+		when(query.isAggregate()).thenReturn(true);
+		when(query.getDocumentModule(customer)).thenReturn(module);
+		when(query.getDocumentName()).thenReturn("Contact");
+		when(module.getDocument(customer, "Contact")).thenReturn(document);
+		when(user.canReadDocument(document)).thenReturn(true);
+		bindPersistenceToThread(persistence);
+
+		String result = service.query("admin", "AggregateQuery", 0, 100);
+
+		assertNull(result);
+		verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+		verify(persistence).rollback();
+	}
+
+	@Test
 	void queryContentReturnsNullAndSetsNotFoundWhenAttachmentMissing() throws Exception {
 		RestService service = new RestService();
 		HttpServletResponse response = mockResponse();


### PR DESCRIPTION
Unbounded REST requests caused out-of-memory errors when serialising all results to JSON. This introduces a default maximum (100), so that it is no longer unbounded.

## Summary
- Clamp built-in REST document-list and query paging so omitted, inverted, or oversized `start`/`end` cannot load unbounded result sets (Hibernate ignores `maxResults <= 0`, which previously risked JVM OOM during `populateFully` + JSON marshalling).
- Add package-private `RestPaging` helpers (`MAX_REST_PAGE_SIZE = 100`) and wire them only at the two list call sites in `RestService`.
- Unit-test clamp behaviour for missing/zero, inverted, oversized, valid small, exact max, and negative `start`.

## Test plan
- [x] `mvn -pl skyve-web -Dtest=RestPagingTest test -DskipIntegrationTests=true -DskipUnitTests=false`
- [ ] Manual: `GET /rest/api/json/{module}/{document}` with no `start`/`end` returns at most 100 rows
- [ ] Manual: `GET /rest/api/json/query/{module}/{documentOrQuery}` with `start=0&end=0` or inverted range returns at most 100 rows
- [ ] Manual: valid small page (e.g. `start=0&end=9`) still returns the same sized page as before
- [ ] Confirm insert/update/delete/content/retrieve-by-id endpoints are unchanged