### PR TITLE
Fix "serialize SessionImpl while connected" when an action backgrounds a task

### DIFF
--- a/skyve-web/src/main/java/org/skyve/impl/web/ViewWebContext.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/ViewWebContext.java
@@ -41,8 +41,9 @@ public abstract class ViewWebContext extends AbstractWebContext {
 		// inside the request's transaction, so the session is otherwise still connected, causing
 		// "Cannot serialize SessionImpl while connected" and a corrupted conversation — the same
 		// defect SkyveFacesPhaseListener.afterResponseRendered() guards against at render time.
-		// Pass false so the EntityManager stays open for the remainder of the request; the phase
-		// listener's finally block performs the final commit(true) which closes it.
+		// Pass false so the EntityManager stays open for the remainder of the request; whichever
+		// entry point is servicing the request (the JSF phase listener, a SmartClient servlet etc)
+		// performs the final commit(true) in its request cleanup, which closes it.
 		AbstractPersistence.get().commit(false);
 		StateUtil.cacheConversation(this);
 	}

--- a/skyve-web/src/main/java/org/skyve/impl/web/ViewWebContext.java
+++ b/skyve-web/src/main/java/org/skyve/impl/web/ViewWebContext.java
@@ -4,6 +4,7 @@ import org.skyve.EXT;
 import org.skyve.domain.Bean;
 import org.skyve.domain.messages.SessionEndedException;
 import org.skyve.impl.cache.StateUtil;
+import org.skyve.impl.persistence.AbstractPersistence;
 import org.skyve.web.BackgroundTask;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -34,6 +35,15 @@ public abstract class ViewWebContext extends AbstractWebContext {
 
 	@Override
 	public void cacheConversation() throws Exception {
+		// Commit (which ends the transaction and releases the JDBC connection) BEFORE serialising
+		// the conversation, so the Hibernate session is disconnected and serialises cleanly.
+		// A server-side action that calls cacheConversation() or background() mid-request runs
+		// inside the request's transaction, so the session is otherwise still connected, causing
+		// "Cannot serialize SessionImpl while connected" and a corrupted conversation — the same
+		// defect SkyveFacesPhaseListener.afterResponseRendered() guards against at render time.
+		// Pass false so the EntityManager stays open for the remainder of the request; the phase
+		// listener's finally block performs the final commit(true) which closes it.
+		AbstractPersistence.get().commit(false);
 		StateUtil.cacheConversation(this);
 	}
 	


### PR DESCRIPTION
Fixes #335. The follow-up to #309 - same root cause, second entry point.

### The change
`ViewWebContext.cacheConversation()` now calls `AbstractPersistence.get().commit(false)` immediately before `StateUtil.cacheConversation(this)`. A server-side action that calls `webContext.background(...)` (or `cacheConversation()` directly) serialises the conversation mid-action, while the request's transaction still holds its JDBC connection - so the Hibernate session was always connected at that point and `SessionImpl.writeObject` threw. Committing first releases the connection so the session serialises cleanly; passing `false` keeps the EntityManager open for the rest of the request, and the phase listener's existing `finally` `commit(true)` still closes it. This is the same reorder #309 applied at end-of-render, placed at the mid-action serialisation point - covering both `background()` and direct `cacheConversation()` calls.

### Semantic note
Work persisted before the `background()` call is committed at that point and can no longer be rolled back by a later failure in the same action - arguably the right contract for backgrounding, since the task runs on another thread with its own persistence and needs the committed state visible, but flagging it for review. Reads after the call still work (connection re-acquired and released per statement); a subsequent write in the same request would need a new transaction.