### PR TITLE
Skyve 9.4.4: dependency bumps to clear critical CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,12 @@
 		<lucene.version>9.7.0</lucene.version>
 		<omnifaces.version>4.3</omnifaces.version>
 		<owasp.encoder.version>1.2.3</owasp.encoder.version>
-		<owasp.html.sanitizer.version>20200713.1</owasp.html.sanitizer.version>
+		<owasp.html.sanitizer.version>20220608.1</owasp.html.sanitizer.version>
 		<owasp.json.sanitizer.version>[1.0,)</owasp.json.sanitizer.version>
+		<!-- vulnerability in hibernate spatial transitive dependency -->
+		<postgresql.version>42.7.12</postgresql.version>
 		<pf4j.version>3.10.0</pf4j.version>
-		<bouncycastle.version>1.78.1</bouncycastle.version>
+		<bouncycastle.version>1.84</bouncycastle.version>
 		<poi.version>5.4.0</poi.version>
 		<primefaces.version>13.0.10</primefaces.version>
 		<primefaces-extensions.version>13.0.14</primefaces-extensions.version>
@@ -69,8 +71,8 @@
 		<junit-jupiter.version>5.10.2</junit-jupiter.version>
 		<mockito.version>4.2.0</mockito.version>
 		<weld.version>5.1.2.Final</weld.version>
-		<spring-security.version>6.3.4</spring-security.version>
-		<spring.version>6.1.14</spring.version>
+		<spring-security.version>6.5.11</spring-security.version>
+		<spring.version>6.2.17</spring.version>
 		<!-- freemarker report versions -->
 		<flying-saucer.version>9.6.1</flying-saucer.version>
 		<freemarker.version>2.3.32</freemarker.version>
@@ -335,6 +337,12 @@
 						<artifactId>hibernate-core</artifactId>
                     </exclusion>
 				</exclusions>
+			</dependency>
+			<!-- vulnerability in hibernate spatial transitive dependency -->
+			<dependency>
+				<groupId>org.postgresql</groupId>
+				<artifactId>postgresql</artifactId>
+				<version>${postgresql.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>

--- a/skyve-ext/src/main/java/org/skyve/impl/security/LegacyBCryptPasswordEncoder.java
+++ b/skyve-ext/src/main/java/org/skyve/impl/security/LegacyBCryptPasswordEncoder.java
@@ -1,0 +1,71 @@
+package org.skyve.impl.security;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Preserves bcrypt compatibility with historical behavior where inputs longer than
+ * 72 UTF-8 bytes are truncated before hashing and comparison.
+ */
+public class LegacyBCryptPasswordEncoder implements PasswordEncoder {
+	private static final int BCRYPT_MAX_PASSWORD_BYTES = 72;
+
+	private final BCryptPasswordEncoder delegate = new BCryptPasswordEncoder();
+
+	@Override
+	public String encode(CharSequence rawPassword) {
+		return delegate.encode(normalizeRawPassword(rawPassword));
+	}
+
+	@Override
+	public boolean matches(CharSequence rawPassword, String encodedPassword) {
+		return delegate.matches(normalizeRawPassword(rawPassword), encodedPassword);
+	}
+
+	@Override
+	public boolean upgradeEncoding(String encodedPassword) {
+		return delegate.upgradeEncoding(encodedPassword);
+	}
+
+	private static String normalizeRawPassword(CharSequence rawPassword) {
+		if (rawPassword == null) {
+			throw new IllegalArgumentException("rawPassword cannot be null");
+		}
+
+		String value = rawPassword.toString();
+		if (value.getBytes(StandardCharsets.UTF_8).length <= BCRYPT_MAX_PASSWORD_BYTES) {
+			return value;
+		}
+
+		int byteCount = 0;
+		StringBuilder truncated = new StringBuilder(value.length());
+		for (int offset = 0; offset < value.length();) {
+			int codePoint = value.codePointAt(offset);
+			int bytesForCodePoint = utf8ByteLength(codePoint);
+			if ((byteCount + bytesForCodePoint) > BCRYPT_MAX_PASSWORD_BYTES) {
+				break;
+			}
+
+			truncated.appendCodePoint(codePoint);
+			byteCount += bytesForCodePoint;
+			offset += Character.charCount(codePoint);
+		}
+
+		return truncated.toString();
+	}
+
+	private static int utf8ByteLength(int codePoint) {
+		if (codePoint <= 0x7F) {
+			return 1;
+		}
+		if (codePoint <= 0x7FF) {
+			return 2;
+		}
+		if (codePoint <= 0xFFFF) {
+			return 3;
+		}
+		return 4;
+	}
+}

--- a/skyve-ext/src/main/java/org/skyve/util/SecurityUtil.java
+++ b/skyve-ext/src/main/java/org/skyve/util/SecurityUtil.java
@@ -16,6 +16,7 @@ import org.skyve.domain.types.Timestamp;
 import org.skyve.impl.metadata.user.SuperUser;
 import org.skyve.impl.persistence.AbstractPersistence;
 import org.skyve.impl.persistence.hibernate.AbstractHibernatePersistence;
+import org.skyve.impl.security.LegacyBCryptPasswordEncoder;
 import org.skyve.impl.security.SkyveLegacyPasswordEncoder;
 import org.skyve.impl.util.UtilImpl;
 import org.skyve.impl.web.HttpServletRequestResponse;
@@ -24,7 +25,6 @@ import org.skyve.metadata.user.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
@@ -43,6 +43,7 @@ public class SecurityUtil {
 	private static final Logger LOGGER = LoggerFactory.getLogger(SecurityUtil.class);
 
 	private static final String ANONYMOUS_SECURITY_USER = "securityUser";
+	private static final PasswordEncoder BCRYPT_PASSWORD_ENCODER = new LegacyBCryptPasswordEncoder();
 
 	/**
 	 * Creates a security log entry and optionally sends an email notification for the specified exception.
@@ -355,7 +356,7 @@ public class SecurityUtil {
 		String encodingId = "argon2";
 		Map<String, PasswordEncoder> encoders = new HashMap<>();
 		encoders.put("argon2", Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8());
-		encoders.put("bcrypt", new BCryptPasswordEncoder());
+		encoders.put("bcrypt", BCRYPT_PASSWORD_ENCODER);
 		encoders.put("pbkdf2", Pbkdf2PasswordEncoder.defaultsForSpringSecurity_v5_8());
 		encoders.put("scrypt", SCryptPasswordEncoder.defaultsForSpringSecurity_v5_8());
 		DelegatingPasswordEncoder result = new DelegatingPasswordEncoder(encodingId, encoders);
@@ -380,7 +381,7 @@ public class SecurityUtil {
 			result = "{argon2}" + Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8().encode(clearText);
 		}
 		else if ("bcrypt".equals(passwordHashingAlgorithm)) {
-			result = "{bcrypt}" + new BCryptPasswordEncoder().encode(clearText);
+			result = "{bcrypt}" + BCRYPT_PASSWORD_ENCODER.encode(clearText);
 		}
 		else if ("pbkdf2".equals(passwordHashingAlgorithm)) {
 			result = "{pbkdf2}" + Pbkdf2PasswordEncoder.defaultsForSpringSecurity_v5_8().encode(clearText);

--- a/skyve-ext/src/test/java/org/skyve/EXTParameterisedTest.java
+++ b/skyve-ext/src/test/java/org/skyve/EXTParameterisedTest.java
@@ -3,6 +3,7 @@ package org.skyve;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,10 +20,14 @@ import org.skyve.util.Util;
 public class EXTParameterisedTest {
 
 	private static String shortPassword = "password";
-	private static String longPassword = "G^`Nyp&n1@rqsOll+?Q6m9w^Q<+N5+(ShbB$\\\"9Ns)/pc)fvv}`hj9*wL\\\\YH<"
-			+ "6x?G^`Nyp&n1@rqsOll+?Q6m9w^Q<+N5+(ShbB$\\\"9Ns)/pc)fvv}`hj9*wL\\\\YH<6x?G^`Nyp&n1@rqsOll+?Q6m9"
-			+ "w^Q<+N5+(ShbB$\"9Ns)/pc)fvv}`hj9*wLYH<6x?G^`Nyp&n1@rqsOll+?Q6m9w^Q<+N5+(ShbB$"
-			+ "\"9Ns)/pc)fvv}`hj9*wLYH<6 x?";
+
+	// longPassword is limited to 72 bytes due to limitation of bcrypt, 
+	// See: https://github.com/spring-projects/spring-security/issues/16802
+	private static String longPassword = "G^`Nyp&n1@rqsOll+?Q6m9w^Q<+N5+(ShbB$\\\"9Ns)/pc)fvv}`hj9*wL\\\\YH<6x?G^`Nyp&";
+
+	// veryLongPassword exceeds 72 UTF-8 bytes and includes a multi-byte character ('é' = 2 bytes).
+	// Intended to exercise LegacyBCryptPasswordEncoder's truncation behaviour (73 UTF-8 bytes total).
+	private static String veryLongPassword = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\u00e9b";
 
 	@Parameter(value = 0)
 	public String algorithm;
@@ -36,6 +41,7 @@ public class EXTParameterisedTest {
 				{ "argon2", longPassword },
 				{ "bcrypt", shortPassword },
 				{ "bcrypt", longPassword },
+				{ "bcrypt", veryLongPassword },
 				{ "pbkdf2", shortPassword },
 				{ "pbkdf2", longPassword },
 				{ "scrypt", shortPassword },
@@ -47,7 +53,6 @@ public class EXTParameterisedTest {
 	 * Tests that each hashedPassword input cleartext in the parameters list.
 	 */
 	@Test
-	@SuppressWarnings("boxing")
 	public void testHashPassword() {
 		// setup the test data
 		UtilImpl.PASSWORD_HASHING_ALGORITHM = algorithm;
@@ -59,8 +64,8 @@ public class EXTParameterisedTest {
 		String result = EXT.hashPassword(clearText);
 
 		// verify the result
-		// System.out.println(String.format("%s (%d): %s (%d)", algorithm, clearText.length(), result, result.length()));
-		assertThat("Encoded length should be less than 255 chars", result.length() <= 255, is(true));
+		assertTrue("Encoded length should be less than 255 chars", result.length() <= 255);
 		assertThat(result, is(not(clearText)));
+		assertTrue(EXT.checkPassword(clearText, result));
 	}
 }

--- a/skyve-ext/src/test/java/org/skyve/impl/security/LegacyBCryptPasswordEncoderTest.java
+++ b/skyve-ext/src/test/java/org/skyve/impl/security/LegacyBCryptPasswordEncoderTest.java
@@ -1,0 +1,90 @@
+package org.skyve.impl.security;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class LegacyBCryptPasswordEncoderTest {
+
+	private final LegacyBCryptPasswordEncoder encoder = new LegacyBCryptPasswordEncoder();
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testEncodeNullRawPassword() {
+		encoder.encode(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMatchesNullRawPassword() {
+		encoder.matches(null, "$2a$10$9u8BUQ4U8D6Nq3OGk7zSOu3jb0AmmPud95PZwQ0ZfYvFuG0j0rL9S");
+	}
+
+	@Test
+	public void testEncodeAndMatchesForPasswordExceeding72Bytes() {
+		// 71 ASCII chars + 'é' (2 UTF-8 bytes) = 73 bytes; exceeds the 72-byte bcrypt limit
+		String password = "a".repeat(71) + "\u00e9";
+		String encoded = encoder.encode(password);
+		assertTrue(encoder.matches(password, encoded));
+	}
+
+	@Test
+	public void testTruncationAtBoundary() {
+		// Two passwords sharing the same first 72 bytes should produce matching hashes
+		String prefix = "a".repeat(72); // exactly 72 bytes
+		String passwordA = prefix + "extraA";
+		String passwordB = prefix + "extraB";
+		String encodedA = encoder.encode(passwordA);
+		assertTrue("Passwords with identical 72-byte prefix must match after truncation",
+				encoder.matches(passwordB, encodedA));
+	}
+
+	@Test
+	public void testDistinctPasswordsUnder72BytesDoNotMatch() {
+		// Ensure passwords shorter than 72 bytes are not conflated
+		String encodedA = encoder.encode("passwordA");
+		assertFalse(encoder.matches("passwordB", encodedA));
+	}
+
+	@Test
+	public void testMultiByteCharacterNotSplitAtBoundary() {
+		// 70 ASCII chars + 'é' (2 bytes) = exactly 72 bytes; any suffix is truncated away
+		String base = "a".repeat(70) + "\u00e9";
+		String extended = base + "extra";
+		String encodedBase = encoder.encode(base);
+		assertTrue("Password truncated to same 72-byte prefix should match",
+				encoder.matches(extended, encodedBase));
+	}
+
+        // ---- upgradeEncoding() ----
+
+        @Test
+        public void testUpgradeEncodingDelegatesToBCrypt() {
+                // BCryptPasswordEncoder.upgradeEncoding() returns false for any standard BCrypt hash
+                String encoded = encoder.encode("testpass");
+                assertFalse(encoder.upgradeEncoding(encoded));
+        }
+
+        // ---- utf8ByteLength() 3-byte and 4-byte paths ----
+
+        @Test
+        public void testPasswordWith3ByteUtf8CharTruncatesCorrectly() {
+                // U+4E2D (中) = 3 UTF-8 bytes.
+                // 24 ASCII chars + 16 CJK chars = 24 + 48 = 72 bytes exactly; any suffix is truncated
+                String base = "a".repeat(24) + "\u4E2D".repeat(16);
+                String extended = base + "extra";
+                String encodedBase = encoder.encode(base);
+                assertTrue("Password truncated to same 72-byte prefix must match",
+                                encoder.matches(extended, encodedBase));
+        }
+
+        @Test
+        public void testPasswordWith4ByteUtf8CharTruncatesCorrectly() {
+                // U+1F600 (😀) = 4 UTF-8 bytes.
+                // 16 ASCII chars + 14 emoji = 16 + 56 = 72 bytes exactly; any suffix is truncated
+                String base = "a".repeat(16) + "\uD83D\uDE00".repeat(14);
+                String extended = base + "extra";
+                String encodedBase = encoder.encode(base);
+                assertTrue("Password truncated to same 72-byte prefix must match",
+                                encoder.matches(extended, encodedBase));
+        }
+}


### PR DESCRIPTION
## Purpose

Clear the four CRITICAL findings Trivy reports against a 9.4.3 WAR, all transitive via `skyve-web`. 

The changes are taken line-for-line from `master` (10.0.0-SNAPSHOT), where they are already proven, and scoped to just these CVEs. One exception: 74c70c743 declares postgresql directly in `skyve-core` (see Notes); master does not have this yet and needs it too.

| Artefact | 9.4.3 | This PR / master |
|---|---|---|
| spring-security-web (and family) | 6.3.4 | 6.5.11 |
| spring framework (spring-jdbc, spring-test) | 6.1.14 | 6.2.17 |
| bcprov-jdk18on | 1.78.1 | 1.84 |
| owasp-java-html-sanitizer | 20200713.1 | 20220608.1 |
| postgresql (managed override of hibernate-spatial's transitive) | 42.5.0 | 42.7.12 |

Together these clear CVE-2026-22732, CVE-2025-14813, CVE-2021-42575 and CVE-2024-1597 (all CRITICAL) plus one HIGH and four MEDIUM findings on the same artefacts.

## Notes

- **postgresql did not propagate to downstream projects.** The managed 42.7.12 only applies when Skyve builds itself; a project consuming `skyve-web` still resolved 42.5.0 from hibernate-spatial's transitive pin (verified with an external consumer against both 9.4.4-SNAPSHOT and 10.0.0-SNAPSHOT). Declaring it as a direct dependency of `skyve-core` makes nearest-wins apply for consumers, which now resolve 42.7.12. Skyve's own WAR dependency list is unchanged by this. Not lifted from master; master has the same gap.
- **No Spring Security config changes were needed.** Master's own move off 6.3.4 (c82a3a5b5) touched only the pom and a test.
- **bcrypt 72-byte limit.** Spring Security now rejects new bcrypt hashes of passwords over 72 bytes. `LegacyBCryptPasswordEncoder` and its tests are copied from master to preserve the previous truncation behaviour. Only affects projects configured for bcrypt; the default is argon2.
- **Spring Framework 6.2.17** matches master exactly rather than the 6.2.19 that Spring Security 6.5.11 declares, so the resolved tree is identical to master's.

## Transitive dependency changes

Diff of the WAR's full runtime dependency list (`skyve-war`, compile + runtime scope) between the 9.4.4-SNAPSHOT baseline and this branch. Everything not listed is unchanged. Every resolved version below is identical to what `master`'s WAR resolves today, and no Skyve code imports from the incidental transitives (nimbus, json-smart, asm, micrometer).

| Artefact | Before | After | Reason |
|---|---|---|---|
| spring-security (6 jars) | 6.3.4 | 6.5.11 | direct bump |
| spring-core, spring-jcl, spring-jdbc, spring-tx | 6.1.14 | 6.2.17 | `spring.version` |
| spring-aop, spring-beans, spring-context, spring-expression, spring-web | 6.1.14 | 6.2.19 | pulled by spring-security |
| oauth2-oidc-sdk | 9.43.4 | 9.43.6 | via spring-security-oauth2-client |
| json-smart, accessors-smart | 2.4.x | 2.5.2 | via oauth2-oidc-sdk |
| asm | 9.3 | 9.7.1 | via accessors-smart |
| micrometer-commons, micrometer-observation | 1.12.11 | 1.15.12 | via spring-core |
| bcprov-jdk18on | 1.78.1 | 1.84 | direct bump |
| owasp-java-html-sanitizer | 20200713.1 | 20220608.1 | direct bump |
| postgresql | 42.5.0 | 42.7.12 | managed override |
| checker-qual | 3.5.0 | removed | no longer declared by postgresql |

## Verification

Full build on JDK 17 of `skyve-core`, `skyve-ext`, `skyve-web` and `skyve-war`. All tests pass: 247 in core, 257 in ext (including the ported bcrypt tests), 284 in web.

